### PR TITLE
feat: add Dependabot for Terraform and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  - package-ecosystem: "terraform"
+    directory: "/terraform/azure"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "terraform"
+    directory: "/terraform/kvm"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "terraform"
+    directory: "/terraform/proxmox"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary

- Adds `.github/dependabot.yml` with weekly update checks for all three Terraform provider directories (`azure`, `kvm`, `proxmox`) and GitHub Actions workflows
- Dependabot requires a separate entry per directory for Terraform, so each provider has its own block

## Test plan

- [ ] Confirm Dependabot is enabled in the repo's Security settings
- [ ] Verify Dependabot PRs appear on the next weekly schedule (or trigger manually via GitHub UI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)