### PR TITLE
fix: set remote_tmp to suppress Ansible root tmp warning

### DIFF
--- a/bootstrap/ansible.cfg
+++ b/bootstrap/ansible.cfg
@@ -4,6 +4,7 @@ pipelining         = True
 forks              = 20
 remote_user        = labuser
 interpreter_python = auto_silent
+remote_tmp         = /tmp/.ansible-tmp
 deprecation_warnings = False
 allow_broken_conditionals = True
 

--- a/experiments/c1km1_4c16g_kfk_pm_snmp/ansible.cfg
+++ b/experiments/c1km1_4c16g_kfk_pm_snmp/ansible.cfg
@@ -4,6 +4,7 @@ pipelining         = True
 forks              = 20
 remote_user        = labuser
 interpreter_python = auto_silent
+remote_tmp         = /tmp/.ansible-tmp
 deprecation_warnings = False
 
 [ssh_connection]

--- a/experiments/c1km1_4c16g_kfk_snmptraps/ansible.cfg
+++ b/experiments/c1km1_4c16g_kfk_snmptraps/ansible.cfg
@@ -4,6 +4,7 @@ pipelining         = True
 forks              = 20
 remote_user        = labuser
 interpreter_python = auto_silent
+remote_tmp         = /tmp/.ansible-tmp
 deprecation_warnings = False
 
 [ssh_connection]

--- a/experiments/c1km1_4c16g_kfk_syslog/ansible.cfg
+++ b/experiments/c1km1_4c16g_kfk_syslog/ansible.cfg
@@ -4,6 +4,7 @@ pipelining         = True
 forks              = 20
 remote_user        = labuser
 interpreter_python = auto_silent
+remote_tmp         = /tmp/.ansible-tmp
 deprecation_warnings = False
 
 [ssh_connection]

--- a/experiments/c1km1_4c16g_rrd_pm_snmp/ansible.cfg
+++ b/experiments/c1km1_4c16g_rrd_pm_snmp/ansible.cfg
@@ -4,6 +4,7 @@ pipelining         = True
 forks              = 20
 remote_user        = labuser
 interpreter_python = auto_silent
+remote_tmp         = /tmp/.ansible-tmp
 deprecation_warnings = False
 
 [ssh_connection]


### PR DESCRIPTION
## Summary

- Add `remote_tmp = /tmp/.ansible-tmp` to `ansible.cfg` in `bootstrap/` and all four experiment directories
- Suppresses the warning `Module remote_tmp /root/.ansible/tmp did not exist and was created with a mode of 0700`

Ansible creates `/root/.ansible/tmp` on-the-fly when connecting as root and warns that mode 0700 may cause issues for other users. Setting `remote_tmp` to a path under `/tmp` (which is world-writable) avoids the on-the-fly creation and the warning.

## Test plan

- [ ] Run `bootstrap/preparation-playbook.yml` — warning should not appear
- [ ] Run any experiment playbook — warning should not appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)