### PR TITLE
feat(terraform/azure): add HTTPS inbound rule to monitoring NSG

### DIFF
--- a/terraform/azure/modules/network/main.tf
+++ b/terraform/azure/modules/network/main.tf
@@ -75,6 +75,18 @@ resource "azurerm_network_security_group" "monitoring" {
     source_address_prefix      = var.operator_cidr != "" ? var.operator_cidr : "*"
     destination_address_prefix = "*"
   }
+
+  security_rule {
+    name                       = "allow-https"
+    priority                   = 110
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "443"
+    source_address_prefix      = var.operator_cidr != "" ? var.operator_cidr : "*"
+    destination_address_prefix = "*"
+  }
 }
 
 # NICs — database


### PR DESCRIPTION
## Summary

- Adds `allow-https` security rule (port 443/tcp, priority 110) to the monitoring VM's NSG
- Source address scoped to `operator_cidr`, same as the existing `allow-ssh` rule (falls back to `*` when unset)

## Test plan

- [ ] `terraform plan` shows the new security rule added to `nsg-nic-*-mon-vnet-mgmt`
- [ ] HTTPS (Traefik proxy) is reachable on the monitoring VM after apply

🤖 Generated with [Claude Code](https://claude.com/claude-code)