### PR TITLE
docs: consolidate Terraform provider deployment docs into root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,11 @@ terraform apply -var-file=../lab.tfvars -var-file=proxmox.tfvars
 
 **5. Set the jump host and re-apply**
 
-After the first apply, the monitoring VM receives a DHCP address on `vmbr4`. Find it in the Proxmox UI or via `qm guest exec`, then set `jump_host` in `proxmox.tfvars` and re-apply to regenerate the Ansible inventory with `ProxyJump` enabled:
+After the first apply, the monitoring VM receives a DHCP address on `vmbr4`. Find it in the Proxmox UI or by querying the guest agent, then set `jump_host` in `proxmox.tfvars` and re-apply to regenerate the Ansible inventory with `ProxyJump` enabled:
+
+```bash
+qm guest cmd 200 network-get-interfaces
+```
 
 ```hcl
 jump_host = "10.0.0.42"   # external IP of the monitoring VM


### PR DESCRIPTION
## Summary

- Removes the defunct `azcli/` bash deployment section (directory no longer exists in the repo)
- Adds a unified **Lab Deployment** section with subsections for all three Terraform providers: Azure, KVM/libvirt, and Proxmox VE
- Azure and Proxmox content written from scratch (no prior READMEs existed); KVM condenses `terraform/kvm/README.md` into a quickstart with a cross-reference to the full doc
- Tailscale access tip relocated from the old azcli section into the Azure subsection where it belongs

## Test plan

- [ ] Verify Azure subsection matches `terraform/azure/azure.tfvars` and `variables.tf`
- [ ] Verify Proxmox subsection matches `terraform/proxmox/proxmox.tfvars.example` and `variables.tf`
- [ ] Verify KVM quickstart matches `terraform/kvm/README.md` and `kvm.tfvars.example`
- [ ] Confirm no references to removed `azcli/` directory remain
- [ ] Render the Markdown locally and check tables, admonitions, and code blocks display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)