### PR TITLE
fix(traefik): route /_next/* to app-starter for Next.js static assets

### DIFF
--- a/bootstrap/roles/traefik/files/traefik/dynamic/routes.yml
+++ b/bootstrap/roles/traefik/files/traefik/dynamic/routes.yml
@@ -2,7 +2,7 @@
 http:
   routers:
     app-starter:
-      rule: "Path(`/`)"
+      rule: "Path(`/`) || PathPrefix(`/_next`)"
       entryPoints:
         - websecure
       service: app-starter


### PR DESCRIPTION
## Summary

- app-starter is a Next.js app that loads its JS/CSS bundles from `/_next/static/...`
- The previous `Path(\`/\`)` Traefik rule only matched the exact root, so all asset requests returned 404 and styling was broken
- Extended the rule to `Path(\`/\`) || PathPrefix(\`/_next\`)` to cover both the root and all Next.js static assets

## Test plan

- [ ] Drop updated `routes.yml` on the monitoring VM (Traefik picks it up automatically via `watch: true`)
- [ ] Reload `https://<monitoring>/` — styling should render correctly with no 404s in the browser console

🤖 Generated with [Claude Code](https://claude.com/claude-code)