### PR TITLE
fix(l8opensim): wrap ExecStart in bash to allow shell operators

### DIFF
--- a/bootstrap/roles/l8opensim/templates/opensim-forward.service.j2
+++ b/bootstrap/roles/l8opensim/templates/opensim-forward.service.j2
@@ -6,10 +6,10 @@ Requires=docker.service
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecStart=/usr/sbin/iptables -C DOCKER-USER -o {{ l8opensim_net_interface }} -s {{ l8opensim_sim_network }} -j ACCEPT 2>/dev/null || /usr/sbin/iptables -I DOCKER-USER 1 -o {{ l8opensim_net_interface }} -s {{ l8opensim_sim_network }} -j ACCEPT
-ExecStart=/usr/sbin/iptables -C DOCKER-USER -i {{ l8opensim_net_interface }} -d {{ l8opensim_sim_network }} -j ACCEPT 2>/dev/null || /usr/sbin/iptables -I DOCKER-USER 1 -i {{ l8opensim_net_interface }} -d {{ l8opensim_sim_network }} -j ACCEPT
-ExecStop=/usr/sbin/iptables -D DOCKER-USER -o {{ l8opensim_net_interface }} -s {{ l8opensim_sim_network }} -j ACCEPT || true
-ExecStop=/usr/sbin/iptables -D DOCKER-USER -i {{ l8opensim_net_interface }} -d {{ l8opensim_sim_network }} -j ACCEPT || true
+ExecStart=/bin/bash -c '/usr/sbin/iptables -C DOCKER-USER -o {{ l8opensim_net_interface }} -s {{ l8opensim_sim_network }} -j ACCEPT 2>/dev/null || /usr/sbin/iptables -I DOCKER-USER 1 -o {{ l8opensim_net_interface }} -s {{ l8opensim_sim_network }} -j ACCEPT'
+ExecStart=/bin/bash -c '/usr/sbin/iptables -C DOCKER-USER -i {{ l8opensim_net_interface }} -d {{ l8opensim_sim_network }} -j ACCEPT 2>/dev/null || /usr/sbin/iptables -I DOCKER-USER 1 -i {{ l8opensim_net_interface }} -d {{ l8opensim_sim_network }} -j ACCEPT'
+ExecStop=-/usr/sbin/iptables -D DOCKER-USER -o {{ l8opensim_net_interface }} -s {{ l8opensim_sim_network }} -j ACCEPT
+ExecStop=-/usr/sbin/iptables -D DOCKER-USER -i {{ l8opensim_net_interface }} -d {{ l8opensim_sim_network }} -j ACCEPT
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Summary

- `ExecStart` in `opensim-forward.service` used `||` and `2>/dev/null` directly, but systemd executes `ExecStart` without a shell — those tokens were passed as literal arguments to iptables, causing exit status 2 (`Bad argument '2>/dev/null'`)
- Wrap each `ExecStart` in `/bin/bash -c '...'` so the shell interprets operators correctly
- Replace `ExecStop ... || true` with systemd-native `-` prefix for idiomatic failure suppression on cleanup

## Test plan

- [ ] Re-run `ansible-playbook -i ../ansible-inventory.yml preparation-playbook.yml --tags l8opensim` against `netsim-benchmark-01`
- [ ] Confirm `opensim-forward.service` reaches `active (exited)` state
- [ ] Verify iptables rules are present: `sudo iptables -L DOCKER-USER -n`

🤖 Generated with [Claude Code](https://claude.com/claude-code)