### PR TITLE
fix: bump opennms_version to 35.0.5

### DIFF
--- a/opennms-lab-vars.yml
+++ b/opennms-lab-vars.yml
@@ -1,6 +1,6 @@
 ---
 opennms_distribution: Horizon
-opennms_version: "35.0.4"
+opennms_version: "35.0.5"
 opennms_pkg_version: "{{ opennms_version }}*"
 
 opennms_datasource_db_host: 192.0.2.196


### PR DESCRIPTION
## Summary

- Bumps `opennms_version` from `35.0.4` to `35.0.5` in `opennms-lab-vars.yml`
- The OpenNMS apt repo no longer carries `35.0.4-1` for dependency packages (`opennms-common`, `libopennms-java`, `libopennmsdeps-java`); `35.0.5` is now the current release
- Without this fix, apt cannot satisfy the exact-version dependency chain required by `opennms-server=35.0.4-1`, causing the playbook to fail with "held broken packages"

## Test plan

- [ ] Re-run `ansible-playbook` against `core-benchmark-01` and verify OpenNMS core installs cleanly at `35.0.5`

🤖 Generated with [Claude Code](https://claude.com/claude-code)