### PR TITLE
chore(l8opensim): bump image to v0.2.0

### DIFF
--- a/bootstrap/roles/l8opensim/defaults/main.yml
+++ b/bootstrap/roles/l8opensim/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-l8opensim_image: "ghcr.io/labmonkeys-space/l8opensim:v0.1.1"
+l8opensim_image: "ghcr.io/labmonkeys-space/l8opensim:v0.2.0"
 l8opensim_auto_start_ip: "10.42.0.1"
 l8opensim_auto_count: 100
 l8opensim_auto_netmask: "16"


### PR DESCRIPTION
## Summary

- Bumps `l8opensim_image` default from `v0.1.1` to `v0.2.0`

## Test plan

- [x] Re-run bootstrap on the netsim VM and verify the new container starts correctly
- [x] Confirm SNMP simulation targets remain reachable on `10.42.0.0/16`

🤖 Generated with [Claude Code](https://claude.com/claude-code)