### PR TITLE
fix(opensim-requisition): write XML to tempfile to avoid ARG_MAX

### DIFF
--- a/opensim-requisition.sh
+++ b/opensim-requisition.sh
@@ -128,8 +128,13 @@ fi
 opennms_base="https://${OPENNMS_HOST}:${OPENNMS_PORT}/opennms"
 curl_opts=(-sk -u "${OPENNMS_USER}:${OPENNMS_PASS}" -H "Content-Type: application/xml" -H "Accept: application/xml")
 
+tmp=$(mktemp /tmp/opensim-requisition.XXXXXX.xml)
+chmod 600 "$tmp"
+trap 'rm -f "$tmp"' EXIT
+printf '%s' "$requisition" > "$tmp"
+
 echo -n "Uploading requisition  ... "
-curl "${curl_opts[@]}" -X POST -d "$requisition" \
+curl "${curl_opts[@]}" -X POST -d "@${tmp}" \
   "${opennms_base}/rest/requisitions"
 echo "done"
 


### PR DESCRIPTION
## Summary

- `--import` with large device sets (e.g. 14 000 nodes) fails with `Argument list too long` because the full requisition XML is passed as a shell argument via `-d "$requisition"`
- Fix: write the XML to a `mktemp` file and pass it to `curl` with `-d @file`
- Temp file is cleaned up on exit via `trap`

## Test plan

- [ ] Run `./opensim-requisition.sh --import` against a lab with ≥10 000 simulated devices and confirm upload completes without `Argument list too long`
- [ ] Run `./opensim-requisition.sh --import --dry-run` and confirm XML is printed correctly (no file left behind)
- [ ] Run `./opensim-requisition.sh` (no flags) and confirm XML is printed to stdout unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)