### PR TITLE
feat(terraform): add VMware vSphere provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,9 @@ terraform/kvm/kvm.tfvars
 # Proxmox tfvars contains an API token — gitignored, use proxmox.tfvars.example as template
 terraform/proxmox/proxmox.tfvars
 
+# VMware tfvars contains a vCenter password — gitignored, use vmware.tfvars.example as template
+terraform/vmware/vmware.tfvars
+
 # CLI config files
 .terraformrc
 terraform.rc

--- a/deploy.sh
+++ b/deploy.sh
@@ -16,10 +16,10 @@ set -euo pipefail
 
 usage() {
   cat <<EOF
-Usage: $0 --provider <azure|kvm|proxmox> [OPTIONS]
+Usage: $0 --provider <azure|kvm|proxmox|vmware> [OPTIONS]
 
 Options:
-  --provider  <azure|kvm|proxmox>   Target infrastructure provider (required)
+  --provider  <azure|kvm|proxmox|vmware>   Target infrastructure provider (required)
   --destroy                         Tear down all lab resources
   --tf-args   "<args>"              Extra arguments passed verbatim to terraform
   -v|-vv|-vvv|-vvvv                 Ansible verbosity
@@ -29,8 +29,10 @@ Examples:
   $0 --provider azure
   $0 --provider kvm
   $0 --provider proxmox
+  $0 --provider vmware
   $0 --provider azure --destroy
   $0 --provider proxmox --tf-args "-var proxmox_insecure=true"
+  $0 --provider vmware --tf-args "-var vsphere_insecure=true"
   $0 --provider kvm -vvv
 EOF
 }
@@ -62,8 +64,8 @@ done
 
 [[ -z "$PROVIDER" ]] && { echo "Error: --provider is required" >&2; error_usage; }
 case "$PROVIDER" in
-  azure|kvm|proxmox) ;;
-  *) echo "Error: provider must be 'azure', 'kvm', or 'proxmox'" >&2; error_usage ;;
+  azure|kvm|proxmox|vmware) ;;
+  *) echo "Error: provider must be 'azure', 'kvm', 'proxmox', or 'vmware'" >&2; error_usage ;;
 esac
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -171,16 +173,19 @@ tf_apply "${PROVIDER_VARS[@]+"${PROVIDER_VARS[@]}"}"
 # KVM and Proxmox: the monitoring VM's external (jump host) IP is DHCP-assigned
 # after boot and cannot be known at plan time.  Discover it via SSH through the
 # hypervisor, then re-apply to regenerate the Ansible inventory with ProxyJump.
-if [[ "$PROVIDER" == "kvm" || "$PROVIDER" == "proxmox" ]]; then
+if [[ "$PROVIDER" == "kvm" || "$PROVIDER" == "proxmox" || "$PROVIDER" == "vmware" ]]; then
   IP_MONITORING=$(tf_output ip_monitoring)
   ADMIN_USER=$(tf_output admin_user)
 
   if [[ "$PROVIDER" == "kvm" ]]; then
     HYPERVISOR=$(tf_output libvirt_host)
-  else
+  elif [[ "$PROVIDER" == "proxmox" ]]; then
     # Proxmox: derive SSH host from the API endpoint URL.
     PROXMOX_ENDPOINT=$(tf_output proxmox_endpoint)
     HYPERVISOR=$(echo "$PROXMOX_ENDPOINT" | sed 's|https\?://||; s|[:/].*||')
+  else
+    # VMware: SSH directly to the ESXi host (or vCenter) to probe the monitoring VM.
+    HYPERVISOR=$(tf_output vsphere_server)
   fi
 
   if [[ -n "$HYPERVISOR" && -n "$IP_MONITORING" ]]; then

--- a/terraform/vmware/README.md
+++ b/terraform/vmware/README.md
@@ -1,0 +1,91 @@
+# VMware vSphere Terraform Provider
+
+Deploys the OpenNMS benchmark lab on a VMware vSphere environment managed by vCenter. For general setup and deployment instructions see the [main README](../../README.md).
+
+## Prerequisites
+
+Complete these steps **before** running `terraform apply`.
+
+### 1. Create port groups
+
+Create five port groups on a vSwitch or dvSwitch in your vSphere environment. Internal port groups (db, kafka, sim) carry only lab traffic and do not require uplinks. The management and external port groups need uplinks for operator SSH access.
+
+| Variable | Purpose | Subnet |
+|---|---|---|
+| `pg_mgmt` | Management — static IPs, operator SSH | `192.0.2.192/26` |
+| `pg_db` | Database traffic between Core and PostgreSQL | `192.0.2.0/26` |
+| `pg_kafka` | Kafka coordination (Core, Kafka, Minion) | `192.0.2.64/26` |
+| `pg_sim` | SNMP simulation network (Minion ↔ NetSim) | `192.0.2.128/26` |
+| `pg_ext` | External DHCP — monitoring VM gets a routable IP here | _(DHCP)_ |
+
+### 2. Build a template VM
+
+The provider clones all VMs from a single Ubuntu 24.04 LTS template. Build it once:
+
+1. Import the Ubuntu 24.04 cloud image OVA (or attach the cloud `.vmdk`):
+   ```bash
+   govc import.ova noble-server-cloudimg-amd64.ova
+   ```
+2. Boot the VM and install required packages:
+   ```bash
+   apt install -y open-vm-tools cloud-init
+   ```
+3. Generalize (clear cloud-init state):
+   ```bash
+   cloud-init clean --logs
+   sudo shutdown -h now
+   ```
+4. In the vSphere UI, right-click the VM → **Convert to Template**.
+
+The template name must match the `template_name` variable in `vmware.tfvars`.
+
+## Deployment
+
+```bash
+cp vmware.tfvars.example vmware.tfvars
+# Edit vmware.tfvars with your vCenter credentials and topology values
+
+# From the repo root:
+./deploy.sh --provider vmware
+
+# With self-signed vCenter certificate:
+./deploy.sh --provider vmware --tf-args "-var vsphere_insecure=true"
+```
+
+## Network interface naming
+
+VMware VMXNET3 adapters on Ubuntu 24.04 enumerate by PCI slot:
+
+| Interface | NIC order | Used by |
+|---|---|---|
+| `ens160` | 1st (PCI 0:7.0) | Management (`pg_mgmt`) on all VMs |
+| `ens192` | 2nd (PCI 0:8.0) | Role-specific subnet on all VMs |
+| `ens224` | 3rd (PCI 0:9.0) | Core (kafka), Minion (sim) |
+| `ens256` | 4th (PCI 0:10.0) | _(reserved)_ |
+
+Verify on a running VM: `ssh ubuntu@<ip> ip link`
+
+## Cloud-init delivery
+
+Unlike KVM (cdrom ISO) or Proxmox (snippets file), VMware delivers cloud-init payloads via **VMware guestinfo** properties set in `extra_config`. `open-vm-tools` reads these properties at boot and hands them to cloud-init, which configures users, SSH keys, `/etc/hosts`, and Netplan network configuration.
+
+This means no ISO attachment or file upload is needed — cloud-init is fully declarative in the Terraform resource.
+
+## Jump host
+
+The monitoring VM (`mon-benchmark-01`) has two NICs:
+
+- `ens160` — static IP `192.0.2.200` on `pg_mgmt`
+- `ens192` — DHCP address on `pg_ext` (the lab jump host)
+
+`deploy.sh` automatically discovers the external IP after the first apply by SSHing through the vSphere host to the monitoring VM, then re-runs apply with `-var jump_host=<ip>` to regenerate the Ansible inventory with ProxyJump configured.
+
+If you need to set it manually:
+
+```bash
+# Find the external IP
+ssh ubuntu@192.0.2.200 ip -4 addr show ens192
+
+# Re-apply with the discovered IP
+terraform apply -var-file=../lab.tfvars -var-file=vmware.tfvars -var jump_host=<ip>
+```

--- a/terraform/vmware/main.tf
+++ b/terraform/vmware/main.tf
@@ -1,0 +1,91 @@
+locals {
+  hosts = {
+    "db-benchmark-01"     = var.ip_database
+    "core-benchmark-01"   = var.ip_core
+    "kafka-benchmark-01"  = var.ip_kafka
+    "minion-benchmark-01" = var.ip_minion
+    "netsim-benchmark-01" = var.ip_netsim
+    "mon-benchmark-01"    = var.ip_monitoring
+    "es-benchmark-01"     = var.ip_elasticsearch
+  }
+}
+
+module "compute" {
+  source = "./modules/compute"
+
+  datacenter    = var.datacenter
+  cluster       = var.cluster
+  datastore     = var.datastore
+  template_name = var.template_name
+  admin_user    = var.admin_user
+  ssh_public_key = trimspace(file(pathexpand("${var.ssh_key_path}.pub")))
+  net_sim_cidr  = var.net_sim_cidr
+  net_sim_gateway = var.net_sim_gateway
+  hosts         = local.hosts
+  ip_database   = var.ip_database
+  ip_core       = var.ip_core
+  ip_kafka      = var.ip_kafka
+  ip_minion     = var.ip_minion
+  ip_netsim     = var.ip_netsim
+  ip_monitoring = var.ip_monitoring
+  ip_database_db  = var.ip_database_db
+  ip_core_db      = var.ip_core_db
+  ip_core_kafka   = var.ip_core_kafka
+  ip_kafka_kafka  = var.ip_kafka_kafka
+  ip_minion_kafka = var.ip_minion_kafka
+  ip_minion_sim   = var.ip_minion_sim
+  ip_netsim_sim   = var.ip_netsim_sim
+  ip_elasticsearch = var.ip_elasticsearch
+  ip_es_core      = var.ip_es_core
+  gateway_mgmt  = cidrhost(var.subnet_mgmt, 1)
+  pg_mgmt       = var.pg_mgmt
+  pg_db         = var.pg_db
+  pg_kafka      = var.pg_kafka
+  pg_sim        = var.pg_sim
+  pg_ext        = var.pg_ext
+  disk_sizes_gb = var.disk_sizes_gb
+}
+
+module "diagram" {
+  source = "../modules/diagram"
+
+  subnet_mgmt  = var.subnet_mgmt
+  subnet_db    = var.subnet_db
+  subnet_kafka = var.subnet_kafka
+  subnet_sim   = var.subnet_sim
+
+  ip_monitoring    = var.ip_monitoring
+  ip_database      = var.ip_database
+  ip_core          = var.ip_core
+  ip_kafka         = var.ip_kafka
+  ip_minion        = var.ip_minion
+  ip_netsim        = var.ip_netsim
+  ip_elasticsearch = var.ip_elasticsearch
+
+  ip_database_db  = var.ip_database_db
+  ip_core_db      = var.ip_core_db
+  ip_es_core      = var.ip_es_core
+  ip_kafka_kafka  = var.ip_kafka_kafka
+  ip_core_kafka   = var.ip_core_kafka
+  ip_minion_kafka = var.ip_minion_kafka
+  ip_minion_sim   = var.ip_minion_sim
+  ip_netsim_sim   = var.ip_netsim_sim
+
+  vm_names = var.vm_names
+}
+
+module "inventory" {
+  source = "../modules/inventory"
+
+  ip_database          = var.ip_database
+  ip_core              = var.ip_core
+  ip_kafka             = var.ip_kafka
+  ip_minion            = var.ip_minion
+  ip_netsim            = var.ip_netsim
+  ip_monitoring        = var.ip_monitoring
+  ip_elasticsearch     = var.ip_elasticsearch
+  admin_user           = var.admin_user
+  ssh_key_path         = var.ssh_key_path
+  jump_host            = var.jump_host
+  netsim_sim_interface = "ens192"
+}

--- a/terraform/vmware/modules/compute/main.tf
+++ b/terraform/vmware/modules/compute/main.tf
@@ -88,7 +88,6 @@ module "cloud_init_netsim" {
   admin_user     = var.admin_user
   ssh_public_key = var.ssh_public_key
   hosts          = var.hosts
-  local_routes   = [var.net_sim_cidr]
   interfaces = [
     { name = "ens160", address = var.ip_netsim, prefix = 26, gateway = var.gateway_mgmt },
     { name = "ens192", address = var.ip_netsim_sim, prefix = 26, gateway = null },

--- a/terraform/vmware/modules/compute/main.tf
+++ b/terraform/vmware/modules/compute/main.tf
@@ -1,0 +1,451 @@
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    vsphere = {
+      source  = "hashicorp/vsphere"
+      version = "~> 2.10"
+    }
+  }
+}
+
+# Cloud-init configuration — rendered via the shared module (same templates as KVM and Proxmox).
+# Interface names inside VMware VMs with VMXNET3 adapters (Ubuntu 24.04):
+#   ens160 = first NIC  (PCI 0:7.0)
+#   ens192 = second NIC (PCI 0:8.0)
+#   ens224 = third NIC  (PCI 0:9.0)
+#   ens256 = fourth NIC (PCI 0:10.0)
+# Verify on your setup: ssh ubuntu@<ip> ip link
+#
+# Cloud-init is delivered via VMware guestinfo properties read by open-vm-tools at
+# boot — no ISO or snippets file needed. The template VM must have open-vm-tools and
+# cloud-init installed.
+
+module "cloud_init_elasticsearch" {
+  source         = "../../../../modules/cloud-init"
+  vm_name        = "es-benchmark-01"
+  admin_user     = var.admin_user
+  ssh_public_key = var.ssh_public_key
+  hosts          = var.hosts
+  interfaces = [
+    { name = "ens160", address = var.ip_elasticsearch, prefix = 26, gateway = var.gateway_mgmt },
+    { name = "ens192", address = var.ip_es_core, prefix = 26, gateway = null },
+  ]
+}
+
+module "cloud_init_database" {
+  source         = "../../../../modules/cloud-init"
+  vm_name        = "db-benchmark-01"
+  admin_user     = var.admin_user
+  ssh_public_key = var.ssh_public_key
+  hosts          = var.hosts
+  interfaces = [
+    { name = "ens160", address = var.ip_database, prefix = 26, gateway = var.gateway_mgmt },
+    { name = "ens192", address = var.ip_database_db, prefix = 26, gateway = null },
+  ]
+}
+
+module "cloud_init_core" {
+  source         = "../../../../modules/cloud-init"
+  vm_name        = "core-benchmark-01"
+  admin_user     = var.admin_user
+  ssh_public_key = var.ssh_public_key
+  hosts          = var.hosts
+  interfaces = [
+    { name = "ens160", address = var.ip_core, prefix = 26, gateway = var.gateway_mgmt },
+    { name = "ens192", address = var.ip_core_db, prefix = 26, gateway = null },
+    { name = "ens224", address = var.ip_core_kafka, prefix = 26, gateway = null },
+  ]
+}
+
+module "cloud_init_kafka" {
+  source         = "../../../../modules/cloud-init"
+  vm_name        = "kafka-benchmark-01"
+  admin_user     = var.admin_user
+  ssh_public_key = var.ssh_public_key
+  hosts          = var.hosts
+  interfaces = [
+    { name = "ens160", address = var.ip_kafka, prefix = 26, gateway = var.gateway_mgmt },
+    { name = "ens192", address = var.ip_kafka_kafka, prefix = 26, gateway = null },
+  ]
+}
+
+module "cloud_init_minion" {
+  source         = "../../../../modules/cloud-init"
+  vm_name        = "minion-benchmark-01"
+  admin_user     = var.admin_user
+  ssh_public_key = var.ssh_public_key
+  hosts          = var.hosts
+  interfaces = [
+    { name = "ens160", address = var.ip_minion, prefix = 26, gateway = var.gateway_mgmt },
+    { name = "ens192", address = var.ip_minion_kafka, prefix = 26, gateway = null },
+    { name = "ens224", address = var.ip_minion_sim, prefix = 26, gateway = null, routes = [{ to = var.net_sim_cidr, via = var.net_sim_gateway }] },
+  ]
+}
+
+module "cloud_init_netsim" {
+  source         = "../../../../modules/cloud-init"
+  vm_name        = "netsim-benchmark-01"
+  admin_user     = var.admin_user
+  ssh_public_key = var.ssh_public_key
+  hosts          = var.hosts
+  local_routes   = [var.net_sim_cidr]
+  interfaces = [
+    { name = "ens160", address = var.ip_netsim, prefix = 26, gateway = var.gateway_mgmt },
+    { name = "ens192", address = var.ip_netsim_sim, prefix = 26, gateway = null },
+  ]
+}
+
+module "cloud_init_monitoring" {
+  source         = "../../../../modules/cloud-init"
+  vm_name        = "mon-benchmark-01"
+  admin_user     = var.admin_user
+  ssh_public_key = var.ssh_public_key
+  hosts          = var.hosts
+  interfaces = [
+    { name = "ens160", address = var.ip_monitoring, prefix = 26, gateway = null },
+    { name = "ens192", address = null, prefix = null, gateway = null },
+  ]
+}
+
+# vSphere data sources — resolved at plan time from the provider.
+
+data "vsphere_datacenter" "dc" {
+  name = var.datacenter
+}
+
+data "vsphere_datastore" "ds" {
+  name          = var.datastore
+  datacenter_id = data.vsphere_datacenter.dc.id
+}
+
+data "vsphere_compute_cluster" "cluster" {
+  name          = var.cluster
+  datacenter_id = data.vsphere_datacenter.dc.id
+}
+
+data "vsphere_virtual_machine" "template" {
+  name          = var.template_name
+  datacenter_id = data.vsphere_datacenter.dc.id
+}
+
+data "vsphere_network" "mgmt" {
+  name          = var.pg_mgmt
+  datacenter_id = data.vsphere_datacenter.dc.id
+}
+
+data "vsphere_network" "db" {
+  name          = var.pg_db
+  datacenter_id = data.vsphere_datacenter.dc.id
+}
+
+data "vsphere_network" "kafka" {
+  name          = var.pg_kafka
+  datacenter_id = data.vsphere_datacenter.dc.id
+}
+
+data "vsphere_network" "sim" {
+  name          = var.pg_sim
+  datacenter_id = data.vsphere_datacenter.dc.id
+}
+
+data "vsphere_network" "ext" {
+  name          = var.pg_ext
+  datacenter_id = data.vsphere_datacenter.dc.id
+}
+
+# VMs — full clones of the Ubuntu 24.04 cloud-init template.
+# Cloud-init payload is delivered via VMware guestinfo properties.
+# open-vm-tools reads guestinfo.userdata and guestinfo.metadata at boot and
+# hands them to cloud-init, which configures users, SSH keys, /etc/hosts,
+# and network interfaces (via Netplan).
+#
+# Creation order: database → core → kafka → minion → netsim → monitoring → elasticsearch
+
+resource "vsphere_virtual_machine" "database" {
+  name             = "db-benchmark-01"
+  resource_pool_id = data.vsphere_compute_cluster.cluster.resource_pool_id
+  datastore_id     = data.vsphere_datastore.ds.id
+  num_cpus         = 2
+  memory           = 4096
+  guest_id         = data.vsphere_virtual_machine.template.guest_id
+  firmware         = data.vsphere_virtual_machine.template.firmware
+  annotation       = "opennms-benchmark"
+
+  clone {
+    template_uuid = data.vsphere_virtual_machine.template.id
+  }
+
+  disk {
+    label            = "disk0"
+    size             = var.disk_sizes_gb["database"]
+    thin_provisioned = true
+  }
+
+  network_interface {
+    network_id   = data.vsphere_network.mgmt.id
+    adapter_type = "vmxnet3"
+  }
+
+  network_interface {
+    network_id   = data.vsphere_network.db.id
+    adapter_type = "vmxnet3"
+  }
+
+  extra_config = {
+    "guestinfo.userdata"          = module.cloud_init_database.user_data_base64
+    "guestinfo.userdata.encoding" = "base64"
+    "guestinfo.metadata"          = base64encode(module.cloud_init_database.network_config)
+    "guestinfo.metadata.encoding" = "base64"
+  }
+}
+
+resource "vsphere_virtual_machine" "core" {
+  name             = "core-benchmark-01"
+  resource_pool_id = data.vsphere_compute_cluster.cluster.resource_pool_id
+  datastore_id     = data.vsphere_datastore.ds.id
+  num_cpus         = 4
+  memory           = 16384
+  guest_id         = data.vsphere_virtual_machine.template.guest_id
+  firmware         = data.vsphere_virtual_machine.template.firmware
+  annotation       = "opennms-benchmark"
+
+  clone {
+    template_uuid = data.vsphere_virtual_machine.template.id
+  }
+
+  disk {
+    label            = "disk0"
+    size             = var.disk_sizes_gb["core"]
+    thin_provisioned = true
+  }
+
+  network_interface {
+    network_id   = data.vsphere_network.mgmt.id
+    adapter_type = "vmxnet3"
+  }
+
+  network_interface {
+    network_id   = data.vsphere_network.db.id
+    adapter_type = "vmxnet3"
+  }
+
+  network_interface {
+    network_id   = data.vsphere_network.kafka.id
+    adapter_type = "vmxnet3"
+  }
+
+  extra_config = {
+    "guestinfo.userdata"          = module.cloud_init_core.user_data_base64
+    "guestinfo.userdata.encoding" = "base64"
+    "guestinfo.metadata"          = base64encode(module.cloud_init_core.network_config)
+    "guestinfo.metadata.encoding" = "base64"
+  }
+
+  depends_on = [vsphere_virtual_machine.database]
+}
+
+resource "vsphere_virtual_machine" "kafka" {
+  name             = "kafka-benchmark-01"
+  resource_pool_id = data.vsphere_compute_cluster.cluster.resource_pool_id
+  datastore_id     = data.vsphere_datastore.ds.id
+  num_cpus         = 2
+  memory           = 4096
+  guest_id         = data.vsphere_virtual_machine.template.guest_id
+  firmware         = data.vsphere_virtual_machine.template.firmware
+  annotation       = "opennms-benchmark"
+
+  clone {
+    template_uuid = data.vsphere_virtual_machine.template.id
+  }
+
+  disk {
+    label            = "disk0"
+    size             = var.disk_sizes_gb["kafka"]
+    thin_provisioned = true
+  }
+
+  network_interface {
+    network_id   = data.vsphere_network.mgmt.id
+    adapter_type = "vmxnet3"
+  }
+
+  network_interface {
+    network_id   = data.vsphere_network.kafka.id
+    adapter_type = "vmxnet3"
+  }
+
+  extra_config = {
+    "guestinfo.userdata"          = module.cloud_init_kafka.user_data_base64
+    "guestinfo.userdata.encoding" = "base64"
+    "guestinfo.metadata"          = base64encode(module.cloud_init_kafka.network_config)
+    "guestinfo.metadata.encoding" = "base64"
+  }
+
+  depends_on = [vsphere_virtual_machine.core]
+}
+
+resource "vsphere_virtual_machine" "minion" {
+  name             = "minion-benchmark-01"
+  resource_pool_id = data.vsphere_compute_cluster.cluster.resource_pool_id
+  datastore_id     = data.vsphere_datastore.ds.id
+  num_cpus         = 2
+  memory           = 4096
+  guest_id         = data.vsphere_virtual_machine.template.guest_id
+  firmware         = data.vsphere_virtual_machine.template.firmware
+  annotation       = "opennms-benchmark"
+
+  clone {
+    template_uuid = data.vsphere_virtual_machine.template.id
+  }
+
+  disk {
+    label            = "disk0"
+    size             = var.disk_sizes_gb["minion"]
+    thin_provisioned = true
+  }
+
+  network_interface {
+    network_id   = data.vsphere_network.mgmt.id
+    adapter_type = "vmxnet3"
+  }
+
+  network_interface {
+    network_id   = data.vsphere_network.kafka.id
+    adapter_type = "vmxnet3"
+  }
+
+  network_interface {
+    network_id   = data.vsphere_network.sim.id
+    adapter_type = "vmxnet3"
+  }
+
+  extra_config = {
+    "guestinfo.userdata"          = module.cloud_init_minion.user_data_base64
+    "guestinfo.userdata.encoding" = "base64"
+    "guestinfo.metadata"          = base64encode(module.cloud_init_minion.network_config)
+    "guestinfo.metadata.encoding" = "base64"
+  }
+
+  depends_on = [vsphere_virtual_machine.kafka]
+}
+
+resource "vsphere_virtual_machine" "netsim" {
+  name             = "netsim-benchmark-01"
+  resource_pool_id = data.vsphere_compute_cluster.cluster.resource_pool_id
+  datastore_id     = data.vsphere_datastore.ds.id
+  num_cpus         = 2
+  memory           = 4096
+  guest_id         = data.vsphere_virtual_machine.template.guest_id
+  firmware         = data.vsphere_virtual_machine.template.firmware
+  annotation       = "opennms-benchmark"
+
+  clone {
+    template_uuid = data.vsphere_virtual_machine.template.id
+  }
+
+  disk {
+    label            = "disk0"
+    size             = var.disk_sizes_gb["netsim"]
+    thin_provisioned = true
+  }
+
+  network_interface {
+    network_id   = data.vsphere_network.mgmt.id
+    adapter_type = "vmxnet3"
+  }
+
+  network_interface {
+    network_id   = data.vsphere_network.sim.id
+    adapter_type = "vmxnet3"
+  }
+
+  extra_config = {
+    "guestinfo.userdata"          = module.cloud_init_netsim.user_data_base64
+    "guestinfo.userdata.encoding" = "base64"
+    "guestinfo.metadata"          = base64encode(module.cloud_init_netsim.network_config)
+    "guestinfo.metadata.encoding" = "base64"
+  }
+
+  depends_on = [vsphere_virtual_machine.minion]
+}
+
+resource "vsphere_virtual_machine" "monitoring" {
+  name             = "mon-benchmark-01"
+  resource_pool_id = data.vsphere_compute_cluster.cluster.resource_pool_id
+  datastore_id     = data.vsphere_datastore.ds.id
+  num_cpus         = 2
+  memory           = 4096
+  guest_id         = data.vsphere_virtual_machine.template.guest_id
+  firmware         = data.vsphere_virtual_machine.template.firmware
+  annotation       = "opennms-benchmark"
+
+  clone {
+    template_uuid = data.vsphere_virtual_machine.template.id
+  }
+
+  disk {
+    label            = "disk0"
+    size             = var.disk_sizes_gb["monitoring"]
+    thin_provisioned = true
+  }
+
+  network_interface {
+    network_id   = data.vsphere_network.mgmt.id
+    adapter_type = "vmxnet3"
+  }
+
+  # External NIC — DHCP-assigned routable address, used as the SSH jump host.
+  network_interface {
+    network_id   = data.vsphere_network.ext.id
+    adapter_type = "vmxnet3"
+  }
+
+  extra_config = {
+    "guestinfo.userdata"          = module.cloud_init_monitoring.user_data_base64
+    "guestinfo.userdata.encoding" = "base64"
+    "guestinfo.metadata"          = base64encode(module.cloud_init_monitoring.network_config)
+    "guestinfo.metadata.encoding" = "base64"
+  }
+
+  depends_on = [vsphere_virtual_machine.netsim]
+}
+
+resource "vsphere_virtual_machine" "elasticsearch" {
+  name             = "es-benchmark-01"
+  resource_pool_id = data.vsphere_compute_cluster.cluster.resource_pool_id
+  datastore_id     = data.vsphere_datastore.ds.id
+  num_cpus         = 4
+  memory           = 8192
+  guest_id         = data.vsphere_virtual_machine.template.guest_id
+  firmware         = data.vsphere_virtual_machine.template.firmware
+  annotation       = "opennms-benchmark"
+
+  clone {
+    template_uuid = data.vsphere_virtual_machine.template.id
+  }
+
+  disk {
+    label            = "disk0"
+    size             = var.disk_sizes_gb["elasticsearch"]
+    thin_provisioned = true
+  }
+
+  network_interface {
+    network_id   = data.vsphere_network.mgmt.id
+    adapter_type = "vmxnet3"
+  }
+
+  network_interface {
+    network_id   = data.vsphere_network.db.id
+    adapter_type = "vmxnet3"
+  }
+
+  extra_config = {
+    "guestinfo.userdata"          = module.cloud_init_elasticsearch.user_data_base64
+    "guestinfo.userdata.encoding" = "base64"
+    "guestinfo.metadata"          = base64encode(module.cloud_init_elasticsearch.network_config)
+    "guestinfo.metadata.encoding" = "base64"
+  }
+
+  depends_on = [vsphere_virtual_machine.monitoring]
+}

--- a/terraform/vmware/modules/compute/variables.tf
+++ b/terraform/vmware/modules/compute/variables.tf
@@ -1,0 +1,47 @@
+variable "datacenter" { type = string }
+variable "cluster" { type = string }
+variable "datastore" { type = string }
+variable "template_name" { type = string }
+variable "admin_user" { type = string }
+variable "ssh_public_key" {
+  type      = string
+  sensitive = true
+}
+variable "net_sim_cidr" { type = string }
+variable "net_sim_gateway" { type = string }
+variable "hosts" { type = map(string) }
+variable "ip_database" { type = string }
+variable "ip_core" { type = string }
+variable "ip_kafka" { type = string }
+variable "ip_minion" { type = string }
+variable "ip_netsim" { type = string }
+variable "ip_monitoring" { type = string }
+variable "ip_database_db" { type = string }
+variable "ip_core_db" { type = string }
+variable "ip_core_kafka" { type = string }
+variable "ip_kafka_kafka" { type = string }
+variable "ip_minion_kafka" { type = string }
+variable "ip_minion_sim" { type = string }
+variable "ip_netsim_sim" { type = string }
+variable "ip_elasticsearch" { type = string }
+variable "ip_es_core" { type = string }
+variable "gateway_mgmt" { type = string }
+variable "pg_mgmt" { type = string }
+variable "pg_db" { type = string }
+variable "pg_kafka" { type = string }
+variable "pg_sim" { type = string }
+variable "pg_ext" { type = string }
+
+variable "disk_sizes_gb" {
+  type        = map(number)
+  description = "Disk size in GB per VM"
+  default = {
+    database      = 20
+    core          = 30
+    kafka         = 20
+    minion        = 20
+    netsim        = 20
+    monitoring    = 30
+    elasticsearch = 50
+  }
+}

--- a/terraform/vmware/outputs.tf
+++ b/terraform/vmware/outputs.tf
@@ -1,0 +1,14 @@
+output "vsphere_server" {
+  value       = var.vsphere_server
+  description = "vCenter Server hostname — used by deploy.sh to derive the SSH jump host for IP discovery"
+}
+
+output "ip_monitoring" {
+  value       = var.ip_monitoring
+  description = "Management IP of the monitoring VM"
+}
+
+output "admin_user" {
+  value       = var.admin_user
+  description = "Admin user on the VMs"
+}

--- a/terraform/vmware/providers.tf
+++ b/terraform/vmware/providers.tf
@@ -1,0 +1,20 @@
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    vsphere = {
+      source  = "hashicorp/vsphere"
+      version = "~> 2.10"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = "~> 2.0"
+    }
+  }
+}
+
+provider "vsphere" {
+  vsphere_server       = var.vsphere_server
+  user                 = var.vsphere_user
+  password             = var.vsphere_password
+  allow_unverified_ssl = var.vsphere_insecure
+}

--- a/terraform/vmware/variables.tf
+++ b/terraform/vmware/variables.tf
@@ -1,0 +1,123 @@
+# Shared (from lab.tfvars) — declared for cross-provider tfvars compatibility; not used by this module
+variable "lab_cidr" { type = string }
+variable "subnet_db" { type = string }
+variable "subnet_kafka" { type = string }
+variable "subnet_sim" { type = string }
+variable "subnet_mgmt" { type = string }
+variable "ip_database" { type = string }
+variable "ip_core" { type = string }
+variable "ip_kafka" { type = string }
+variable "ip_minion" { type = string }
+variable "ip_netsim" { type = string }
+variable "ip_monitoring" { type = string }
+variable "ip_database_db" { type = string }
+variable "ip_core_db" { type = string }
+variable "ip_core_kafka" { type = string }
+variable "ip_kafka_kafka" { type = string }
+variable "ip_minion_kafka" { type = string }
+variable "ip_minion_sim" { type = string }
+variable "ip_netsim_sim" { type = string }
+variable "net_sim_cidr" { type = string }
+variable "net_sim_gateway" { type = string }
+variable "admin_user" { type = string }
+variable "vm_names" {
+  type    = map(string)
+  default = null # accepted from lab.tfvars; not used by this module
+}
+variable "ip_elasticsearch" { type = string }
+variable "ip_es_core" { type = string }
+
+# VMware-specific (from vmware.tfvars)
+variable "vsphere_server" {
+  type        = string
+  description = "vCenter Server hostname or IP address"
+}
+
+variable "vsphere_user" {
+  type        = string
+  description = "vCenter user principal (e.g. administrator@vsphere.local)"
+}
+
+variable "vsphere_password" {
+  type        = string
+  sensitive   = true
+  description = "vCenter user password"
+}
+
+variable "vsphere_insecure" {
+  type        = bool
+  default     = false
+  description = "Skip TLS certificate verification (set true for self-signed certs)"
+}
+
+variable "datacenter" {
+  type        = string
+  description = "vSphere datacenter name"
+}
+
+variable "cluster" {
+  type        = string
+  description = "vSphere cluster or host name"
+}
+
+variable "datastore" {
+  type        = string
+  description = "vSphere datastore for VM disks"
+}
+
+variable "template_name" {
+  type        = string
+  description = "Name of the Ubuntu 24.04 cloud-init template VM to clone from"
+}
+
+variable "ssh_key_path" {
+  type        = string
+  description = "Path to SSH private key (without .pub extension)"
+}
+
+# Port group names — pre-existing on a vSwitch or dvSwitch.
+# Each corresponds to one lab subnet.
+variable "pg_mgmt" {
+  type        = string
+  description = "Port group for management network (192.0.2.192/26)"
+}
+
+variable "pg_db" {
+  type        = string
+  description = "Port group for database subnet (192.0.2.0/26)"
+}
+
+variable "pg_kafka" {
+  type        = string
+  description = "Port group for Kafka subnet (192.0.2.64/26)"
+}
+
+variable "pg_sim" {
+  type        = string
+  description = "Port group for SNMP simulation subnet (192.0.2.128/26)"
+}
+
+variable "pg_ext" {
+  type        = string
+  description = "Port group with external DHCP access — monitoring VM only; its DHCP address serves as the lab jump host"
+}
+
+variable "disk_sizes_gb" {
+  type        = map(number)
+  description = "Disk size in GB per VM"
+  default = {
+    database      = 20
+    core          = 30
+    kafka         = 20
+    minion        = 20
+    netsim        = 20
+    monitoring    = 30
+    elasticsearch = 50
+  }
+}
+
+variable "jump_host" {
+  type        = string
+  default     = ""
+  description = "External IP of the monitoring VM for SSH jump host. Set after first apply."
+}

--- a/terraform/vmware/vmware.tfvars.example
+++ b/terraform/vmware/vmware.tfvars.example
@@ -1,0 +1,62 @@
+# VMware vSphere variables
+# Usage:
+#   cp vmware.tfvars.example vmware.tfvars
+#   # Edit vmware.tfvars with your real values (it is gitignored)
+#   terraform init
+#   terraform apply -var-file=../lab.tfvars -var-file=vmware.tfvars
+
+# vCenter connection
+vsphere_server   = "vcenter.example.com"  # Replace with your vCenter hostname or IP
+vsphere_user     = "administrator@vsphere.local"
+vsphere_password = ""                     # Set via TF_VAR_vsphere_password env var
+vsphere_insecure = false                  # Set true only if vCenter has a self-signed certificate
+
+# vSphere topology
+datacenter = "dc1"       # Datacenter name as shown in the vSphere UI
+cluster    = "cluster1"  # Cluster or standalone host name
+datastore  = "datastore1"
+
+# Template VM — create once before running terraform apply:
+#   1. Deploy an Ubuntu 24.04 LTS cloud image OVA (or import the cloud .vmdk):
+#        govc import.ova noble-server-cloudimg-amd64.ova
+#   2. Ensure open-vm-tools and cloud-init are installed:
+#        apt install -y open-vm-tools cloud-init
+#   3. Sysprep / generalize:
+#        cloud-init clean --logs
+#        shutdown -h now
+#   4. Convert VM to template in vSphere (right-click → Convert to Template)
+#
+# The name must match exactly as shown in the vSphere VM inventory.
+template_name = "ubuntu-2404-cloud-init"
+
+# SSH key for VM access
+ssh_key_path = "~/.ssh/id_rsa"
+
+# Port groups — create these on a vSwitch or dvSwitch before running terraform apply.
+# Each port group corresponds to one lab subnet. Internal port groups (pg_db, pg_kafka,
+# pg_sim) carry only lab traffic and do not need uplinks. pg_mgmt and pg_ext need
+# uplinks for operator SSH access and DHCP.
+#
+# VM interface names inside Ubuntu 24.04 VMs with VMXNET3 (PCI slot order):
+#   ens160 = first NIC, ens192 = second, ens224 = third, ens256 = fourth.
+# Verify on your setup with: ssh ubuntu@<vm-ip> ip link
+pg_mgmt  = "PG-LAB-MGMT"   # Management subnet 192.0.2.192/26 — static IPs, operator SSH
+pg_db    = "PG-LAB-DB"     # Database subnet 192.0.2.0/26
+pg_kafka = "PG-LAB-KAFKA"  # Kafka subnet 192.0.2.64/26
+pg_sim   = "PG-LAB-SIM"    # SNMP simulation subnet 192.0.2.128/26
+pg_ext   = "PG-LAB-EXT"    # External DHCP port group — monitoring VM gets a routable IP on this NIC
+
+# Disk sizes — IMPORTANT: if overriding, provide ALL seven keys. Terraform replaces the
+# entire map; a partial override drops the remaining keys and causes a plan error.
+# disk_sizes_gb = {
+#   database      = 20
+#   core          = 30
+#   kafka         = 20
+#   minion        = 20
+#   netsim        = 20
+#   monitoring    = 30
+#   elasticsearch = 50
+# }
+
+# jump_host = ""  # Set after first apply: external IP of the monitoring VM (from pg_ext DHCP).
+#                 # Re-run apply to regenerate the Ansible inventory with ProxyJump enabled.


### PR DESCRIPTION
## Summary

- Adds `terraform/vmware/` provider deploying the same 7-VM lab topology as KVM and Proxmox, targeting a vCenter-managed vSphere environment
- Cloud-init delivered via VMware guestinfo `extra_config` properties (read by `open-vm-tools` at boot — no ISO or snippets file required)
- Extends `deploy.sh` with `vmware` as a supported provider, including jump-host IP discovery via `vsphere_server`

## Design notes

**Provider**: `hashicorp/vsphere ~> 2.10`

**Cloud-init delivery**: Unlike KVM (cdrom ISO) and Proxmox (snippets file), VMware reads cloud-init payloads from VM guestinfo properties set in `extra_config`. The template VM must have `open-vm-tools` and `cloud-init` pre-installed.

**Interface names**: VMXNET3 adapters on Ubuntu 24.04 enumerate by PCI slot — `ens160` (1st NIC), `ens192` (2nd), `ens224` (3rd), `ens256` (4th). These replace the Proxmox `ens18`/`ens19`/`ens20`/`ens21` names.

**Networks**: Port groups are resolved as `data` sources from pre-existing vSphere constructs (vSwitch or dvSwitch). No network resources are created by Terraform.

**Jump host**: Monitoring VM gets a DHCP address on `pg_ext`. `deploy.sh` SSHes through `vsphere_server` to discover the external IP, then re-applies with `-var jump_host=<ip>` — same pattern as Proxmox.

## Prerequisites

Before `terraform apply`, on the vSphere host:
- Create four port groups: `PG-LAB-MGMT`, `PG-LAB-DB`, `PG-LAB-KAFKA`, `PG-LAB-SIM`, `PG-LAB-EXT` (names configurable via tfvars)
- Build a template VM from Ubuntu 24.04 cloud image with `open-vm-tools` + `cloud-init`, converted to vSphere template

## Test plan

- [ ] `terraform init` succeeds in `terraform/vmware/`
- [ ] `terraform validate` passes
- [ ] `terraform plan -var-file=../lab.tfvars -var-file=vmware.tfvars` produces expected 7-VM plan
- [ ] VMs boot and cloud-init completes (check `/var/log/cloud-init-output.log`)
- [ ] Interface names match `ens160`/`ens192`/`ens224`/`ens256` on target VMs
- [ ] `./deploy.sh --provider vmware` runs all three stages end-to-end
- [ ] `./deploy.sh --provider vmware --destroy` tears down cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)