### PR TITLE
ci(terraform): add Validate (VMware) job and fix fmt

### DIFF
--- a/.github/workflows/terraform-lint.yml
+++ b/.github/workflows/terraform-lint.yml
@@ -79,6 +79,26 @@ jobs:
         run: terraform validate
         working-directory: terraform/proxmox
 
+  validate-vmware:
+    name: Validate (VMware)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: hashicorp/setup-terraform@v4
+        with:
+          terraform_version: "~1.5"
+
+      - name: terraform init
+        # hashicorp/vsphere is a HashiCorp-maintained provider and installs without a running host
+        run: terraform init -backend=false
+        working-directory: terraform/vmware
+
+      - name: terraform validate
+        # validate checks syntax and type correctness only — no provider API calls
+        run: terraform validate
+        working-directory: terraform/vmware
+
   tflint:
     name: TFLint
     runs-on: ubuntu-latest
@@ -118,3 +138,13 @@ jobs:
       - name: TFLint (Proxmox)
         run: tflint --recursive --minimum-failure-severity=error
         working-directory: terraform/proxmox
+
+      - name: Init TFLint (VMware)
+        run: tflint --init
+        working-directory: terraform/vmware
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: TFLint (VMware)
+        run: tflint --recursive --minimum-failure-severity=error
+        working-directory: terraform/vmware

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ git submodule update
 
 ## 🚀 Lab Deployment
 
-The lab is deployed using Terraform. Three providers are supported: **Azure**, **KVM/libvirt**, and **Proxmox VE**.
+The lab is deployed using Terraform. Four providers are supported: **Azure**, **KVM/libvirt**, **Proxmox VE**, and **VMware vSphere**.
 
 All providers share a common `terraform/lab.tfvars` for network layout, IP addresses, and VM names. Each provider adds its own `<provider>.tfvars` for host-specific settings.
 
@@ -264,6 +264,80 @@ ssh_key_path         = "~/.ssh/id_rsa"
 ```
 
 The script runs `terraform init` and `terraform apply`, then automatically discovers the monitoring VM's external DHCP address on `vmbr4` (via SSH through the Proxmox host) and re-applies to regenerate the Ansible inventory with the correct `jump_host`. It then bootstraps the VMs and deploys the full OpenNMS stack.
+
+---
+
+### VMware vSphere
+
+**Requirements:** vCenter Server, account with VM create/clone permissions, Terraform ≥ 1.5, [`govc`](https://github.com/vmware/govmomi/tree/main/govc) (optional, for OVA import)
+
+See [`terraform/vmware/README.md`](terraform/vmware/README.md) for full documentation including cloud-init delivery via guestinfo and network interface naming.
+
+**1. Create port groups** on a vSwitch or dvSwitch in the vSphere UI:
+
+| Variable | Purpose | Subnet |
+|:---------|:--------|:-------|
+| `pg_mgmt` | Management — static IPs, operator SSH | `192.0.2.192/26` |
+| `pg_db` | Database traffic between Core and PostgreSQL | `192.0.2.0/26` |
+| `pg_kafka` | Kafka coordination (Core, Kafka, Minion) | `192.0.2.64/26` |
+| `pg_sim` | SNMP simulation network (Minion ↔ NetSim) | `192.0.2.128/26` |
+| `pg_ext` | External DHCP — monitoring VM gets a routable IP here | _(DHCP)_ |
+
+Internal port groups (`pg_db`, `pg_kafka`, `pg_sim`) carry only lab traffic and do not require uplinks. `pg_mgmt` and `pg_ext` need uplinks for operator SSH access.
+
+**2. Build a template VM** (one-time setup)
+
+```bash
+# Import Ubuntu 24.04 cloud image OVA
+govc import.ova noble-server-cloudimg-amd64.ova
+
+# Boot the VM and install required packages
+apt install -y open-vm-tools cloud-init
+
+# Generalize — clear cloud-init state before converting to template
+cloud-init clean --logs
+sudo shutdown -h now
+```
+
+In the vSphere UI, right-click the VM → **Convert to Template**. The template name must match `template_name` in `vmware.tfvars`.
+
+**3. Configure**
+
+```bash
+cp terraform/vmware/vmware.tfvars.example terraform/vmware/vmware.tfvars
+```
+
+Edit `vmware.tfvars` with your values:
+
+```hcl
+vsphere_server   = "vcenter.example.com"
+vsphere_user     = "administrator@vsphere.local"
+vsphere_password = ""                            # or set TF_VAR_vsphere_password
+vsphere_insecure = false                         # set true for self-signed certificates
+datacenter       = "dc1"
+cluster          = "cluster1"
+datastore        = "datastore1"
+template_name    = "ubuntu-2404-cloud-init"
+ssh_key_path     = "~/.ssh/id_rsa"
+pg_mgmt          = "PG-LAB-MGMT"
+pg_db            = "PG-LAB-DB"
+pg_kafka         = "PG-LAB-KAFKA"
+pg_sim           = "PG-LAB-SIM"
+pg_ext           = "PG-LAB-EXT"
+```
+
+`vmware.tfvars` is gitignored — your credentials are never committed.
+
+**4. Deploy**
+
+```bash
+./deploy.sh --provider vmware
+
+# With a self-signed vCenter certificate:
+./deploy.sh --provider vmware --tf-args "-var vsphere_insecure=true"
+```
+
+The script runs `terraform init` and `terraform apply`, then automatically discovers the monitoring VM's external DHCP address on `pg_ext` and re-applies to regenerate the Ansible inventory with the correct `jump_host`. It then bootstraps the VMs and deploys the full OpenNMS stack.
 
 ---
 

--- a/terraform/vmware/.tflint.hcl
+++ b/terraform/vmware/.tflint.hcl
@@ -1,0 +1,1 @@
+# No tflint plugin for the hashicorp/vsphere provider — core rules only

--- a/terraform/vmware/main.tf
+++ b/terraform/vmware/main.tf
@@ -13,37 +13,37 @@ locals {
 module "compute" {
   source = "./modules/compute"
 
-  datacenter    = var.datacenter
-  cluster       = var.cluster
-  datastore     = var.datastore
-  template_name = var.template_name
-  admin_user    = var.admin_user
-  ssh_public_key = trimspace(file(pathexpand("${var.ssh_key_path}.pub")))
-  net_sim_cidr  = var.net_sim_cidr
-  net_sim_gateway = var.net_sim_gateway
-  hosts         = local.hosts
-  ip_database   = var.ip_database
-  ip_core       = var.ip_core
-  ip_kafka      = var.ip_kafka
-  ip_minion     = var.ip_minion
-  ip_netsim     = var.ip_netsim
-  ip_monitoring = var.ip_monitoring
-  ip_database_db  = var.ip_database_db
-  ip_core_db      = var.ip_core_db
-  ip_core_kafka   = var.ip_core_kafka
-  ip_kafka_kafka  = var.ip_kafka_kafka
-  ip_minion_kafka = var.ip_minion_kafka
-  ip_minion_sim   = var.ip_minion_sim
-  ip_netsim_sim   = var.ip_netsim_sim
+  datacenter       = var.datacenter
+  cluster          = var.cluster
+  datastore        = var.datastore
+  template_name    = var.template_name
+  admin_user       = var.admin_user
+  ssh_public_key   = trimspace(file(pathexpand("${var.ssh_key_path}.pub")))
+  net_sim_cidr     = var.net_sim_cidr
+  net_sim_gateway  = var.net_sim_gateway
+  hosts            = local.hosts
+  ip_database      = var.ip_database
+  ip_core          = var.ip_core
+  ip_kafka         = var.ip_kafka
+  ip_minion        = var.ip_minion
+  ip_netsim        = var.ip_netsim
+  ip_monitoring    = var.ip_monitoring
+  ip_database_db   = var.ip_database_db
+  ip_core_db       = var.ip_core_db
+  ip_core_kafka    = var.ip_core_kafka
+  ip_kafka_kafka   = var.ip_kafka_kafka
+  ip_minion_kafka  = var.ip_minion_kafka
+  ip_minion_sim    = var.ip_minion_sim
+  ip_netsim_sim    = var.ip_netsim_sim
   ip_elasticsearch = var.ip_elasticsearch
-  ip_es_core      = var.ip_es_core
-  gateway_mgmt  = cidrhost(var.subnet_mgmt, 1)
-  pg_mgmt       = var.pg_mgmt
-  pg_db         = var.pg_db
-  pg_kafka      = var.pg_kafka
-  pg_sim        = var.pg_sim
-  pg_ext        = var.pg_ext
-  disk_sizes_gb = var.disk_sizes_gb
+  ip_es_core       = var.ip_es_core
+  gateway_mgmt     = cidrhost(var.subnet_mgmt, 1)
+  pg_mgmt          = var.pg_mgmt
+  pg_db            = var.pg_db
+  pg_kafka         = var.pg_kafka
+  pg_sim           = var.pg_sim
+  pg_ext           = var.pg_ext
+  disk_sizes_gb    = var.disk_sizes_gb
 }
 
 module "diagram" {

--- a/terraform/vmware/modules/compute/main.tf
+++ b/terraform/vmware/modules/compute/main.tf
@@ -21,7 +21,7 @@ terraform {
 # cloud-init installed.
 
 module "cloud_init_elasticsearch" {
-  source         = "../../../../modules/cloud-init"
+  source         = "../../../modules/cloud-init"
   vm_name        = "es-benchmark-01"
   admin_user     = var.admin_user
   ssh_public_key = var.ssh_public_key
@@ -33,7 +33,7 @@ module "cloud_init_elasticsearch" {
 }
 
 module "cloud_init_database" {
-  source         = "../../../../modules/cloud-init"
+  source         = "../../../modules/cloud-init"
   vm_name        = "db-benchmark-01"
   admin_user     = var.admin_user
   ssh_public_key = var.ssh_public_key
@@ -45,7 +45,7 @@ module "cloud_init_database" {
 }
 
 module "cloud_init_core" {
-  source         = "../../../../modules/cloud-init"
+  source         = "../../../modules/cloud-init"
   vm_name        = "core-benchmark-01"
   admin_user     = var.admin_user
   ssh_public_key = var.ssh_public_key
@@ -58,7 +58,7 @@ module "cloud_init_core" {
 }
 
 module "cloud_init_kafka" {
-  source         = "../../../../modules/cloud-init"
+  source         = "../../../modules/cloud-init"
   vm_name        = "kafka-benchmark-01"
   admin_user     = var.admin_user
   ssh_public_key = var.ssh_public_key
@@ -70,7 +70,7 @@ module "cloud_init_kafka" {
 }
 
 module "cloud_init_minion" {
-  source         = "../../../../modules/cloud-init"
+  source         = "../../../modules/cloud-init"
   vm_name        = "minion-benchmark-01"
   admin_user     = var.admin_user
   ssh_public_key = var.ssh_public_key
@@ -83,7 +83,7 @@ module "cloud_init_minion" {
 }
 
 module "cloud_init_netsim" {
-  source         = "../../../../modules/cloud-init"
+  source         = "../../../modules/cloud-init"
   vm_name        = "netsim-benchmark-01"
   admin_user     = var.admin_user
   ssh_public_key = var.ssh_public_key
@@ -95,7 +95,7 @@ module "cloud_init_netsim" {
 }
 
 module "cloud_init_monitoring" {
-  source         = "../../../../modules/cloud-init"
+  source         = "../../../modules/cloud-init"
   vm_name        = "mon-benchmark-01"
   admin_user     = var.admin_user
   ssh_public_key = var.ssh_public_key


### PR DESCRIPTION
## Summary

- **Fix `terraform fmt`**: `terraform/vmware/main.tf` had misaligned attribute assignments; corrected with `terraform fmt -recursive`
- **Add `terraform/vmware/.tflint.hcl`**: core rules only (no TFLint plugin exists for `hashicorp/vsphere`), consistent with KVM and Proxmox
- **Add `validate-vmware` job**: mirrors the existing Azure, KVM, and Proxmox validate jobs — `terraform init -backend=false` + `terraform validate` in `terraform/vmware/`
- **Add TFLint steps for VMware**: `Init TFLint (VMware)` and `TFLint (VMware)` appended to the existing `tflint` job

## Test plan

- [ ] `fmt` job passes (`terraform fmt -check -recursive terraform/` exits 0)
- [ ] `validate-vmware` job passes (`terraform init` + `terraform validate` succeed)
- [ ] `tflint` job passes including the new VMware steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)