### PR TITLE
refactor(l8opensim): replace docker_container with systemd docker unit

### DIFF
--- a/bootstrap/requirements.yml
+++ b/bootstrap/requirements.yml
@@ -1,7 +1,6 @@
 ---
 collections:
   - name: ansible.posix
-  - name: community.docker
   - name: community.general
   - name: prometheus.prometheus
   # NOTE: versions prior to 0.21.0 use `when: (_common_dependencies)` with a string value,

--- a/bootstrap/roles/l8opensim/defaults/main.yml
+++ b/bootstrap/roles/l8opensim/defaults/main.yml
@@ -4,6 +4,5 @@ l8opensim_auto_start_ip: "10.42.0.1"
 l8opensim_auto_count: 100
 l8opensim_auto_netmask: "16"
 l8opensim_web_port: 8080
-l8opensim_restart_policy: "unless-stopped"
 l8opensim_sim_network: "10.42.0.0/16"
 l8opensim_net_interface: "enp2s0"

--- a/bootstrap/roles/l8opensim/tasks/main.yml
+++ b/bootstrap/roles/l8opensim/tasks/main.yml
@@ -35,26 +35,23 @@
     state: started
   tags: ["l8opensim"]
 
-- name: Pull l8opensim image
-  community.docker.docker_image:
-    name: "{{ l8opensim_image }}"
-    source: pull
-    force_source: true
+- name: Deploy l8opensim systemd unit
+  ansible.builtin.template:
+    src: l8opensim.service.j2
+    dest: /etc/systemd/system/l8opensim.service
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Reload systemd daemon
   tags: ["l8opensim"]
 
-- name: Run l8opensim container
-  community.docker.docker_container:
-    name: l8opensim
-    image: "{{ l8opensim_image }}"
+- name: Flush handlers before enabling l8opensim service
+  ansible.builtin.meta: flush_handlers
+  tags: ["l8opensim"]
+
+- name: Enable and start l8opensim service
+  ansible.builtin.systemd:
+    name: l8opensim.service
+    enabled: true
     state: started
-    restart_policy: "{{ l8opensim_restart_policy }}"
-    privileged: true
-    network_mode: host
-    devices:
-      - /dev/net/tun:/dev/net/tun
-    command: >-
-      -auto-start-ip {{ l8opensim_auto_start_ip }}
-      -auto-count {{ l8opensim_auto_count }}
-      -auto-netmask {{ l8opensim_auto_netmask }}
-      -port {{ l8opensim_web_port }}
   tags: ["l8opensim"]

--- a/bootstrap/roles/l8opensim/templates/l8opensim.service.j2
+++ b/bootstrap/roles/l8opensim/templates/l8opensim.service.j2
@@ -1,0 +1,24 @@
+[Unit]
+Description=L8 OpenSim SNMP simulator
+After=docker.service
+Requires=docker.service
+
+[Service]
+Restart=always
+RestartSec=5
+ExecStartPre=-/usr/bin/docker stop l8opensim
+ExecStartPre=-/usr/bin/docker rm l8opensim
+ExecStart=/usr/bin/docker run \
+  --name l8opensim \
+  --privileged \
+  --network host \
+  --device /dev/net/tun:/dev/net/tun \
+  {{ l8opensim_image }} \
+  -auto-start-ip {{ l8opensim_auto_start_ip }} \
+  -auto-count {{ l8opensim_auto_count }} \
+  -auto-netmask {{ l8opensim_auto_netmask }} \
+  -port {{ l8opensim_web_port }}
+ExecStop=/usr/bin/docker stop l8opensim
+
+[Install]
+WantedBy=multi-user.target

--- a/bootstrap/roles/l8opensim/templates/opensim-forward.service.j2
+++ b/bootstrap/roles/l8opensim/templates/opensim-forward.service.j2
@@ -1,7 +1,8 @@
 [Unit]
 Description=Allow forwarding to l8opensim simulated devices ({{ l8opensim_sim_network }})
-After=docker.service
+After=docker.service l8opensim.service
 Requires=docker.service
+BindsTo=l8opensim.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
## Summary

- Drop `community.docker.docker_container` / `docker_image` tasks in favour of a dedicated `l8opensim.service` that runs the container directly via `docker run`, consistent with the kafka-ui refactor (#71)
- Remove `l8opensim_restart_policy` default — restart is now owned by systemd (`Restart=always`)
- All container flags (`--privileged`, `--network host`, `--device /dev/net/tun`) and CLI args are preserved in the unit template

## Changes

| File | Action |
|---|---|
| `defaults/main.yml` | Removed `l8opensim_restart_policy` |
| `templates/l8opensim.service.j2` | Added — systemd unit using `docker run` |
| `tasks/main.yml` | Replaced `docker_image` + `docker_container` tasks with template deploy + flush + enable |

## Test plan

- [ ] Run `ansible-playbook -i inventory preparation-playbook.yml --tags l8opensim` against the lab and confirm `l8opensim.service` starts
- [ ] Verify `systemctl status l8opensim.service` shows the container running
- [ ] Confirm SNMP simulation subnet (`10.42.0.0/16`) is reachable from Minion after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)