### PR TITLE
fix(traefik): move tls.stores to dynamic config for Traefik v3

### DIFF
--- a/bootstrap/roles/traefik/files/traefik/dynamic/tls.yml
+++ b/bootstrap/roles/traefik/files/traefik/dynamic/tls.yml
@@ -1,0 +1,7 @@
+---
+tls:
+  stores:
+    default:
+      defaultCertificate:
+        certFile: /etc/traefik/certs/lab.crt
+        keyFile: /etc/traefik/certs/lab.key

--- a/bootstrap/roles/traefik/files/traefik/traefik.yml
+++ b/bootstrap/roles/traefik/files/traefik/traefik.yml
@@ -16,12 +16,5 @@ providers:
     directory: /etc/traefik/dynamic
     watch: true
 
-tls:
-  stores:
-    default:
-      defaultCertificate:
-        certFile: /etc/traefik/certs/lab.crt
-        keyFile: /etc/traefik/certs/lab.key
-
 api:
   dashboard: false


### PR DESCRIPTION
## Problem

In Traefik v3, the `tls:` section of the static configuration (`traefik.yml`) only supports `options` (cipher suites, TLS versions). The `tls.stores` stanza is dynamic configuration and must live in the `dynamic/` directory.

The previous placement in `traefik.yml` caused Traefik to silently ignore the lab certificate and fall back to its auto-generated self-signed cert, making the `openssl` key generation in the playbook a no-op.

## Fix

Move `tls.stores.default.defaultCertificate` from `traefik.yml` into a new `dynamic/tls.yml` file, which Traefik v3 loads via the file provider.

## Test plan

- [ ] Re-provision the monitoring VM and confirm `systemctl status traefik.service` shows no TLS errors in the journal
- [ ] Verify the browser presents the lab cert (`CN=monitoring, O=Lab`) on any `https://<mon-ip>/` route

🤖 Generated with [Claude Code](https://claude.com/claude-code)