### PR TITLE
fix(grafana): correct src path for dashboard copy task

### DIFF
--- a/bootstrap/roles/grafana/tasks/main.yml
+++ b/bootstrap/roles/grafana/tasks/main.yml
@@ -8,7 +8,7 @@
 
 - name: Deploy benchmark dashboards
   ansible.builtin.copy:
-    src: grafana/provisioning/dashboards/
+    src: provisioning/dashboards/
     dest: "{{ grafana_provisioning_dashboards_dir }}/"
     mode: "0644"
   notify: Restart grafana


### PR DESCRIPTION
## Summary

- The `copy` task used `src: grafana/provisioning/dashboards/`, causing Ansible to search for `files/grafana/provisioning/dashboards/`
- The files actually live at `roles/grafana/files/provisioning/dashboards/`
- Fix: change `src` to `provisioning/dashboards/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)