### PR TITLE
fix(l8opensim): deploy l8opensim.service before starting opensim-forward

### DIFF
--- a/bootstrap/roles/l8opensim/tasks/main.yml
+++ b/bootstrap/roles/l8opensim/tasks/main.yml
@@ -14,27 +14,6 @@
   notify: Reload systemd daemon
   tags: ["l8opensim"]
 
-- name: Install opensim-forward systemd service
-  ansible.builtin.template:
-    src: opensim-forward.service.j2
-    dest: /etc/systemd/system/opensim-forward.service
-    owner: root
-    group: root
-    mode: "0644"
-  notify: Reload systemd daemon
-  tags: ["l8opensim"]
-
-- name: Flush handlers to reload systemd before starting opensim-forward
-  ansible.builtin.meta: flush_handlers
-  tags: ["l8opensim"]
-
-- name: Enable and start opensim-forward service
-  ansible.builtin.systemd:
-    name: opensim-forward.service
-    enabled: true
-    state: started
-  tags: ["l8opensim"]
-
 - name: Deploy l8opensim systemd unit
   ansible.builtin.template:
     src: l8opensim.service.j2
@@ -45,13 +24,30 @@
   notify: Reload systemd daemon
   tags: ["l8opensim"]
 
-- name: Flush handlers before enabling l8opensim service
+- name: Install opensim-forward systemd service
+  ansible.builtin.template:
+    src: opensim-forward.service.j2
+    dest: /etc/systemd/system/opensim-forward.service
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Reload systemd daemon
+  tags: ["l8opensim"]
+
+- name: Flush handlers before enabling services
   ansible.builtin.meta: flush_handlers
   tags: ["l8opensim"]
 
 - name: Enable and start l8opensim service
   ansible.builtin.systemd:
     name: l8opensim.service
+    enabled: true
+    state: started
+  tags: ["l8opensim"]
+
+- name: Enable and start opensim-forward service
+  ansible.builtin.systemd:
+    name: opensim-forward.service
     enabled: true
     state: started
   tags: ["l8opensim"]


### PR DESCRIPTION
## Summary

`opensim-forward.service` has `BindsTo=l8opensim.service` and `After=l8opensim.service`. The previous task order deployed `opensim-forward.service` and tried to start it before `l8opensim.service` was even deployed, causing:

```
Unit l8opensim.service not found
```

Fix: deploy both unit files first, single `flush_handlers` to reload systemd, then start `l8opensim.service` before `opensim-forward.service`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)