### PR TITLE
fix(jaeger): set --query.base-path so UI assets resolve correctly behind Traefik

### DIFF
--- a/bootstrap/roles/jaeger/defaults/main.yml
+++ b/bootstrap/roles/jaeger/defaults/main.yml
@@ -5,3 +5,4 @@ jaeger_port_ui: "16686"
 jaeger_cpus: "1.0"
 jaeger_memory: 256m
 jaeger_tz: UTC
+jaeger_query_base_path: /jaeger

--- a/bootstrap/roles/jaeger/templates/jaeger.service.j2
+++ b/bootstrap/roles/jaeger/templates/jaeger.service.j2
@@ -15,7 +15,8 @@ ExecStart=/usr/bin/docker run \
   --cpus={{ jaeger_cpus }} \
   --memory={{ jaeger_memory }} \
   -e TZ={{ jaeger_tz }} \
-  {{ jaeger_image }}
+  {{ jaeger_image }} \
+  --query.base-path={{ jaeger_query_base_path }}
 ExecStop=/usr/bin/docker stop jaeger
 
 [Install]


### PR DESCRIPTION
## Summary

Jaeger UI was blank at `/jaeger` because the container rendered asset URLs as `/static/...` (absolute paths). The browser then requested `https://<host>/static/...` which has no Traefik route.

**Root cause:** Traefik's `jaeger-strip` middleware strips `/jaeger` before forwarding to the container, so Jaeger thinks it's at `/` and generates root-relative asset paths.

**Fix:** Pass `--query.base-path=/jaeger` to the Jaeger container so it prefixes all asset and API URLs with `/jaeger`. Traefik routes `/jaeger/static/...` correctly through `jaeger-strip` → container gets `/static/...`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)