### PR TITLE
fix(grafana): override grafana_datasources to empty in extra-vars

### DIFF
--- a/opennms-lab-vars.yml
+++ b/opennms-lab-vars.yml
@@ -15,6 +15,11 @@ onns_hzn_base_url: http://192.0.2.197:8980
 opennms_es_host: "192.0.2.202"
 opennms_es_port: 9200
 
+# Datasources are provisioned by bootstrap/roles/grafana via files.
+# Empty list overrides the submodule's group_vars (which the collection
+# would otherwise use to call its datasource module — rejecting plugin types).
+grafana_datasources: []
+
 es_jvm_options: {}
 es_configuration:
   action.destructive_requires_name: true


### PR DESCRIPTION
## Summary

Previous fix set `grafana_datasources: []` in root `group_vars/grafana/vars.yml`, but the submodule's `ansible-opennms/group_vars/grafana/vars.yml` takes higher precedence when the playbook runs from `ansible-opennms/`. The collection's datasource module still picked up the full list with plugin types.

Fix: add `grafana_datasources: []` to `opennms-lab-vars.yml` (passed as `--extra-vars`). Extra-vars have the highest precedence in Ansible and override all group_vars regardless of source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)