### PR TITLE
fix(jaeger): use QUERY_BASE_PATH env var instead of CLI flag

### DIFF
--- a/bootstrap/roles/jaeger/templates/jaeger.service.j2
+++ b/bootstrap/roles/jaeger/templates/jaeger.service.j2
@@ -15,8 +15,8 @@ ExecStart=/usr/bin/docker run \
   --cpus={{ jaeger_cpus }} \
   --memory={{ jaeger_memory }} \
   -e TZ={{ jaeger_tz }} \
-  {{ jaeger_image }} \
-  --query.base-path={{ jaeger_query_base_path }}
+  -e QUERY_BASE_PATH={{ jaeger_query_base_path }} \
+  {{ jaeger_image }}
 ExecStop=/usr/bin/docker stop jaeger
 
 [Install]


### PR DESCRIPTION
## Summary

`--query.base-path=/jaeger` passed as a container argument does not take effect in the Jaeger v2 image (`jaegertracing/jaeger:latest`). The Jaeger Docker image expects the base path to be set via the `QUERY_BASE_PATH` environment variable (passed with `-e` before the image name in `docker run`).

Without this, the Jaeger UI renders asset URLs as `/static/...` instead of `/jaeger/static/...`, causing a blank page because Traefik has no route for `/static/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)