### PR TITLE
docs: add NICs column to compute requirements table

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ OS disk sizes below are the defaults used by the non-Azure Terraform providers. 
 
 ### Network
 
-The lab uses four isolated subnets inside `192.0.2.0/24` plus one DHCP/public interface on the monitoring VM. Only the monitoring VM requires a publicly routable IP.
+The lab uses four isolated subnets inside `192.0.2.0/24` plus one DHCP/public interface on the monitoring VM. Only the monitoring VM (`mon-benchmark-01`) requires a publicly routable IP — it acts as the SSH jump host and Traefik reverse proxy entry point for the entire lab. All other VMs are reachable only via the management subnet.
 
 | Subnet | CIDR | Purpose |
 |:-------|:-----|:--------|
@@ -74,7 +74,7 @@ The lab uses four isolated subnets inside `192.0.2.0/24` plus one DHCP/public in
 
 | Port | Protocol | Source | Purpose |
 |-----:|:---------|:-------|:--------|
-| 22 | TCP | operator CIDR | SSH access |
+| 22 | TCP | operator CIDR | SSH access / jump host into the lab |
 | 443 | TCP | operator CIDR | HTTPS (Traefik — all web UIs) |
 
 All inter-VM communication stays on the internal subnets and requires no additional inbound rules.

--- a/README.md
+++ b/README.md
@@ -33,16 +33,16 @@ The lab deploys 7 virtual machines. Each VM needs at least 2 NICs (management + 
 
 Default VM sizes map to Azure SKUs. For other providers (KVM, Proxmox, VMware) you set these values directly in the provider's `.tfvars`.
 
-| VM | Role | Azure size | vCPU | RAM |
-|:---|:-----|:-----------|-----:|----:|
-| `db-benchmark-01` | PostgreSQL | `Standard_B2ms` | 2 | 8 GB |
-| `core-benchmark-01` | OpenNMS Core (8 GB JVM heap) | `Standard_B4ms` | 4 | 16 GB |
-| `kafka-benchmark-01` | Apache Kafka + Kafka UI | `Standard_B2ms` | 2 | 8 GB |
-| `minion-benchmark-01` | OpenNMS Minion | `Standard_B2ms` | 2 | 8 GB |
-| `netsim-benchmark-01` | SNMP Simulator (l8opensim) | `Standard_B2ms` | 2 | 8 GB |
-| `mon-benchmark-01` | Monitoring stack (Prometheus, Grafana, Jaeger, …) | `Standard_B2ms` | 2 | 8 GB |
-| `es-benchmark-01` | Elasticsearch | `Standard_B2ms` | 2 | 8 GB |
-| **Total** | | | **16** | **64 GB** |
+| VM | Role | Azure size | vCPU | RAM | NICs |
+|:---|:-----|:-----------|-----:|----:|-----:|
+| `db-benchmark-01` | PostgreSQL | `Standard_B2ms` | 2 | 8 GB | 2 |
+| `core-benchmark-01` | OpenNMS Core (8 GB JVM heap) | `Standard_B4ms` | 4 | 16 GB | 3 |
+| `kafka-benchmark-01` | Apache Kafka + Kafka UI | `Standard_B2ms` | 2 | 8 GB | 2 |
+| `minion-benchmark-01` | OpenNMS Minion | `Standard_B2ms` | 2 | 8 GB | 3 |
+| `netsim-benchmark-01` | SNMP Simulator (l8opensim) | `Standard_B2ms` | 2 | 8 GB | 2 |
+| `mon-benchmark-01` | Monitoring stack (Prometheus, Grafana, Jaeger, …) | `Standard_B2ms` | 2 | 8 GB | 2 |
+| `es-benchmark-01` | Elasticsearch | `Standard_B2ms` | 2 | 8 GB | 2 |
+| **Total** | | | **16** | **64 GB** | |
 
 ### Storage
 


### PR DESCRIPTION
## Summary

- Adds a **NICs** column to the compute table in the Requirements section
- db, kafka, netsim, mon, es: 2 NICs (management + one functional subnet)
- core, minion: 3 NICs (management + two functional subnets)

🤖 Generated with [Claude Code](https://claude.com/claude-code)