### PR TITLE
fix(prometheus): add --add-host entries so container resolves lab hostnames

### DIFF
--- a/bootstrap/roles/prometheus/templates/prometheus.service.j2
+++ b/bootstrap/roles/prometheus/templates/prometheus.service.j2
@@ -18,6 +18,9 @@ ExecStart=/usr/bin/docker run \
   --memory={{ prometheus_memory }} \
   -u 65534 \
   -e TZ={{ prometheus_tz }} \
+{% for host in groups['all'] %}
+  --add-host={{ host }}:{{ hostvars[host]['ansible_host'] }} \
+{% endfor %}
   -v data-prometheus:/prometheus/data \
   -v {{ prometheus_config_dir }}/prometheus.yml:/etc/prometheus/prometheus.yml:ro \
   {{ prometheus_image }} \


### PR DESCRIPTION
## Problem

The Prometheus container runs on the Docker bridge network. The `prometheus.yml` template generates targets using inventory hostnames (e.g. `db-benchmark-01:9100`), but the container has no way to resolve those names — no `/etc/hosts` for lab VMs, no lab DNS. All scrape targets were unreachable, causing "No data" in the Node Exporter Full dashboard.

## Fix

Inject `--add-host=<hostname>:<ip>` flags into `docker run`, derived from `hostvars[host]['ansible_host']` for every host in the inventory. This populates the container's `/etc/hosts` at startup and keeps hostname-based `instance` labels in scraped metrics (better dashboard UX than switching to bare IPs).

Rendered example:
```
--add-host=db-benchmark-01:192.0.2.196 \
--add-host=core-benchmark-01:192.0.2.197 \
...
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)