### PR TITLE
fix(kibana): set SERVER_BASEPATH so redirects work through Traefik

### DIFF
--- a/bootstrap/roles/kibana/templates/kibana.service.j2
+++ b/bootstrap/roles/kibana/templates/kibana.service.j2
@@ -16,6 +16,8 @@ ExecStart=/usr/bin/docker run \
   -e TZ={{ kibana_tz }} \
   -e ELASTICSEARCH_HOSTS={{ kibana_elasticsearch_hosts }} \
   -e XPACK_SECURITY_ENABLED={{ kibana_xpack_security_enabled }} \
+  -e SERVER_BASEPATH=/kibana \
+  -e SERVER_REWRITEBASEPATH=true \
   {{ kibana_image }}
 ExecStop=/usr/bin/docker stop kibana
 

--- a/bootstrap/roles/traefik/files/traefik/dynamic/routes.yml
+++ b/bootstrap/roles/traefik/files/traefik/dynamic/routes.yml
@@ -50,8 +50,6 @@ http:
       entryPoints:
         - websecure
       service: kibana
-      middlewares:
-        - kibana-strip
       tls: {}
     opensim:
       rule: "PathPrefix(`/opensim`)"
@@ -72,10 +70,6 @@ http:
       stripPrefix:
         prefixes:
           - /jaeger
-    kibana-strip:
-      stripPrefix:
-        prefixes:
-          - /kibana
     opensim-strip:
       stripPrefix:
         prefixes:


### PR DESCRIPTION
## Summary

- Kibana's internal redirects (`/` → `/spaces/enter` → `/app/home`) use absolute paths
- With only `kibana-strip` in Traefik, the `/kibana` prefix was stripped before reaching Kibana, so Kibana's `302` responses sent the browser to paths Traefik had no route for → **404**
- Fix: set `SERVER_BASEPATH=/kibana` and `SERVER_REWRITEBASEPATH=true` on the Kibana container so it includes the prefix in all its own redirects and strips it internally
- Remove the now-redundant `kibana-strip` middleware from Traefik

## Test plan

- [ ] Redeploy Kibana and Traefik via bootstrap playbook
- [ ] Navigate to `https://<mon>/kibana` — should land on Kibana home without 404
- [ ] Verify all Kibana-internal navigation links still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)