### PR TITLE
fix(jaeger): configure base_path via --set flag for Jaeger v2

### DIFF
--- a/bootstrap/roles/jaeger/templates/jaeger.service.j2
+++ b/bootstrap/roles/jaeger/templates/jaeger.service.j2
@@ -15,8 +15,8 @@ ExecStart=/usr/bin/docker run \
   --cpus={{ jaeger_cpus }} \
   --memory={{ jaeger_memory }} \
   -e TZ={{ jaeger_tz }} \
-  -e QUERY_BASE_PATH={{ jaeger_query_base_path }} \
-  {{ jaeger_image }}
+  {{ jaeger_image }} \
+  --set=extensions.jaeger_query.base_path={{ jaeger_query_base_path }}
 ExecStop=/usr/bin/docker stop jaeger
 
 [Install]

--- a/bootstrap/roles/traefik/files/traefik/dynamic/routes.yml
+++ b/bootstrap/roles/traefik/files/traefik/dynamic/routes.yml
@@ -24,8 +24,6 @@ http:
       entryPoints:
         - websecure
       service: jaeger
-      middlewares:
-        - jaeger-strip
       tls: {}
     opennms:
       rule: "PathPrefix(`/opennms`)"
@@ -68,10 +66,6 @@ http:
       service: opensim
       tls: {}
   middlewares:
-    jaeger-strip:
-      stripPrefix:
-        prefixes:
-          - /jaeger
     kibana-strip:
       stripPrefix:
         prefixes:


### PR DESCRIPTION
## Summary

- `QUERY_BASE_PATH` is a Jaeger v1 env var — Jaeger v2.17.0 silently ignores it (logs confirm: `"Using UI configuration" "path": ""`)
- Jaeger v2 uses an OTel Collector config pipeline; `base_path` must be set under `extensions.jaeger_query` in its YAML config or overridden via `--set`
- Since the container runs with the default all-in-one config (no `--config` flag), pass `--set=extensions.jaeger_query.base_path=/jaeger` as a command argument after the image name
- Jaeger v2 handles the path prefix internally (serves routes under `/jaeger/`, injects correct `<base href="/jaeger/">`), so remove `jaeger-strip` from Traefik — the full path must pass through unchanged

## Root cause trace

```
# Container logs showed:
No '--config' flags detected, using default All-in-One configuration with memory storage.
Using UI configuration {"path": ""}   ← base_path was empty despite QUERY_BASE_PATH being set
```

## Test plan

- [ ] Redeploy via bootstrap playbook with `--tags traefik,jaeger`
- [ ] `curl -k -L https://bench-lab/jaeger` returns HTTP 200 with Jaeger UI (not white page)
- [ ] Static assets load correctly (no 404s in browser DevTools)

🤖 Generated with [Claude Code](https://claude.com/claude-code)