### PR TITLE
fix(jaeger): provide explicit config file with base_path for v2

### DIFF
--- a/bootstrap/roles/jaeger/defaults/main.yml
+++ b/bootstrap/roles/jaeger/defaults/main.yml
@@ -6,3 +6,4 @@ jaeger_cpus: "1.0"
 jaeger_memory: 256m
 jaeger_tz: UTC
 jaeger_query_base_path: /jaeger
+jaeger_config_dir: /etc/jaeger

--- a/bootstrap/roles/jaeger/tasks/main.yml
+++ b/bootstrap/roles/jaeger/tasks/main.yml
@@ -1,4 +1,20 @@
 ---
+- name: Create Jaeger config directory
+  ansible.builtin.file:
+    path: "{{ jaeger_config_dir }}"
+    state: directory
+    mode: "0755"
+  tags: ["monitoring", "jaeger"]
+
+- name: Deploy Jaeger config
+  ansible.builtin.template:
+    src: jaeger-config.yaml.j2
+    dest: "{{ jaeger_config_dir }}/config.yaml"
+    mode: "0644"
+  notify:
+    - Restart jaeger
+  tags: ["monitoring", "jaeger"]
+
 - name: Deploy Jaeger systemd unit
   ansible.builtin.template:
     src: jaeger.service.j2

--- a/bootstrap/roles/jaeger/templates/jaeger-config.yaml.j2
+++ b/bootstrap/roles/jaeger/templates/jaeger-config.yaml.j2
@@ -1,0 +1,89 @@
+---
+# Managed by Ansible — do not edit manually
+service:
+  extensions: [jaeger_storage, jaeger_query, jaeger_mcp, remote_sampling, healthcheckv2, expvar, zpages]
+  pipelines:
+    traces:
+      receivers: [otlp, jaeger, zipkin]
+      processors: [batch]
+      exporters: [jaeger_storage_exporter]
+  telemetry:
+    resource:
+      service.name: jaeger
+    metrics:
+      level: detailed
+      readers:
+        - pull:
+            exporter:
+              prometheus:
+                host: "0.0.0.0"
+                port: 8888
+    logs:
+      level: info
+
+extensions:
+  jaeger_query:
+    base_path: {{ jaeger_query_base_path }}
+    storage:
+      traces: some_storage
+
+  jaeger_mcp:
+    http:
+      endpoint: "0.0.0.0:16687"
+
+  jaeger_storage:
+    backends:
+      some_storage:
+        memory:
+          max_traces: 100000
+
+  remote_sampling:
+    file:
+      path:
+      default_sampling_probability: 1
+      reload_interval: 1s
+    http:
+      endpoint: "0.0.0.0:5778"
+    grpc:
+      endpoint: "0.0.0.0:5779"
+
+  healthcheckv2:
+    use_v2: true
+    http:
+      endpoint: "0.0.0.0:13133"
+    grpc:
+
+  expvar:
+    endpoint: "0.0.0.0:27777"
+
+  zpages:
+    endpoint: "0.0.0.0:27778"
+
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: "0.0.0.0:4317"
+      http:
+        endpoint: "0.0.0.0:4318"
+
+  jaeger:
+    protocols:
+      grpc:
+        endpoint: "0.0.0.0:14250"
+      thrift_http:
+        endpoint: "0.0.0.0:14268"
+      thrift_binary:
+        endpoint: "0.0.0.0:6832"
+      thrift_compact:
+        endpoint: "0.0.0.0:6831"
+
+  zipkin:
+    endpoint: "0.0.0.0:9411"
+
+processors:
+  batch:
+
+exporters:
+  jaeger_storage_exporter:
+    trace_storage: some_storage

--- a/bootstrap/roles/jaeger/templates/jaeger.service.j2
+++ b/bootstrap/roles/jaeger/templates/jaeger.service.j2
@@ -15,8 +15,9 @@ ExecStart=/usr/bin/docker run \
   --cpus={{ jaeger_cpus }} \
   --memory={{ jaeger_memory }} \
   -e TZ={{ jaeger_tz }} \
+  -v {{ jaeger_config_dir }}/config.yaml:/etc/jaeger/config.yaml:ro \
   {{ jaeger_image }} \
-  --set=extensions.jaeger_query.base_path={{ jaeger_query_base_path }}
+  --config=file:/etc/jaeger/config.yaml
 ExecStop=/usr/bin/docker stop jaeger
 
 [Install]


### PR DESCRIPTION
## Summary

- `--set` is silently ignored when no `--config` flag is provided — the default all-in-one path in the binary bypasses Viper flag processing
- Fix: deploy the embedded default `all-in-one.yaml` as an Ansible template with `base_path: /jaeger` added under `extensions.jaeger_query`, mount it into the container, and pass `--config=file:/etc/jaeger/config.yaml`
- Bind addresses hardcoded to `0.0.0.0` (the default config uses `${env:JAEGER_LISTEN_HOST:-localhost}` which would break container port mappings)

## Test plan

- [ ] `ansible-playbook site.yml --tags jaeger` — config file deployed, container restarted
- [ ] `curl -k -L https://bench-lab/jaeger` returns 200 with `<base href="/jaeger/">`
- [ ] Jaeger UI loads without white page / missing assets

🤖 Generated with [Claude Code](https://claude.com/claude-code)