### PR TITLE
feat(l8opensim): bump to v0.3.0 with IPFIX flow export and loose rp_filter

### DIFF
--- a/bootstrap/preparation-playbook.yml
+++ b/bootstrap/preparation-playbook.yml
@@ -48,8 +48,20 @@
   hosts: net_sim
   become: true
   roles:
+    - role: rp_filter
+      vars:
+        rp_filter_interfaces:
+          - all
+          - default
+          - "{{ l8opensim_net_interface }}"
     - net_snmp
     - l8opensim
+
+- name: Minion
+  hosts: minion
+  become: true
+  roles:
+    - rp_filter
 
 - name: Kafka-UI
   hosts: kafka_ui

--- a/bootstrap/roles/l8opensim/defaults/main.yml
+++ b/bootstrap/roles/l8opensim/defaults/main.yml
@@ -1,8 +1,10 @@
 ---
-l8opensim_image: "ghcr.io/labmonkeys-space/l8opensim:v0.2.0"
+l8opensim_image: "ghcr.io/labmonkeys-space/l8opensim:v0.3.0"
 l8opensim_auto_start_ip: "10.42.0.1"
-l8opensim_auto_count: 100
+l8opensim_auto_count: 1
 l8opensim_auto_netmask: "16"
 l8opensim_web_port: 8080
 l8opensim_sim_network: "10.42.0.0/16"
 l8opensim_net_interface: "enp2s0"
+l8opensim_flow_collector: "192.0.2.133:9999"
+l8opensim_flow_protocol: "ipfix"

--- a/bootstrap/roles/l8opensim/tasks/main.yml
+++ b/bootstrap/roles/l8opensim/tasks/main.yml
@@ -1,4 +1,12 @@
 ---
+- name: Install iptables on the simulator host
+  ansible.builtin.apt:
+    name: iptables
+    state: present
+    update_cache: true
+    cache_valid_time: 3600
+  tags: ["l8opensim"]
+
 - name: Disable and remove legacy monitoring-net-ipv4 loopback route service
   ansible.builtin.systemd:
     name: monitoring-net-ipv4.service

--- a/bootstrap/roles/l8opensim/templates/l8opensim.service.j2
+++ b/bootstrap/roles/l8opensim/templates/l8opensim.service.j2
@@ -17,7 +17,9 @@ ExecStart=/usr/bin/docker run \
   -auto-start-ip {{ l8opensim_auto_start_ip }} \
   -auto-count {{ l8opensim_auto_count }} \
   -auto-netmask {{ l8opensim_auto_netmask }} \
-  -port {{ l8opensim_web_port }}
+  -port {{ l8opensim_web_port }} \
+  -flow-collector {{ l8opensim_flow_collector }} \
+  -flow-protocol {{ l8opensim_flow_protocol }}
 ExecStop=/usr/bin/docker stop l8opensim
 
 [Install]

--- a/bootstrap/roles/rp_filter/defaults/main.yml
+++ b/bootstrap/roles/rp_filter/defaults/main.yml
@@ -1,0 +1,7 @@
+---
+# Loose-mode reverse-path filtering (RFC3704). Required for hosts that
+# send or receive traffic via asymmetric routes (e.g. the l8opensim flow
+# exporter and any Minion receiving those flows).
+rp_filter_interfaces:
+  - all
+  - default

--- a/bootstrap/roles/rp_filter/tasks/main.yml
+++ b/bootstrap/roles/rp_filter/tasks/main.yml
@@ -1,0 +1,17 @@
+---
+- name: Gather network facts for rp_filter
+  ansible.builtin.setup:
+    gather_subset:
+      - network
+  when: ansible_default_ipv4 is not defined
+  tags: ["rp-filter"]
+
+- name: Set IPv4 rp_filter to loose mode (2)
+  ansible.posix.sysctl:
+    name: "net.ipv4.conf.{{ item }}.rp_filter"
+    value: "2"
+    state: present
+    reload: true
+    sysctl_file: /etc/sysctl.d/99-rp-filter.conf
+  loop: "{{ (rp_filter_interfaces + [ansible_default_ipv4.interface]) | unique }}"
+  tags: ["rp-filter"]

--- a/opennms-lab-vars.yml
+++ b/opennms-lab-vars.yml
@@ -91,8 +91,8 @@ kafka_server_properties:
   "log.retention.check.interval.ms": 300000
   "log.dirs": /var/log/kafka/combined-logs
 
-#opennms_properties_timeseries:
-#  org.opennms.timeseries.strategy: osgi
+# opennms_properties_timeseries:
+#   org.opennms.timeseries.strategy: osgi
 
 opennms_jvm_conf:
   JAVA_HEAP_SIZE: 8192


### PR DESCRIPTION
## Summary
- Bump `l8opensim` image to `ghcr.io/labmonkeys-space/l8opensim:v0.3.0`, reduce `-auto-count` from 100 to 1, and add IPFIX flow export to `192.0.2.133:9999` via new `-flow-collector` / `-flow-protocol` flags.
- Install `iptables` on the simulator host so the existing `opensim-forward` service has the binary it needs.
- New reusable `rp_filter` role sets `net.ipv4.conf.{all,default,<default-iface>}.rp_filter=2` (RFC3704 loose mode) persistently, applied to both `net_sim` and `minion` so asymmetric flow traffic between the simulator and Minion isn't dropped.

## Notes
- Flow collector target `192.0.2.133:9999` isn't in `ansible-inventory.yml` (minion is `.199`, netsim is `.201`). Override `l8opensim_flow_collector` in inventory/group_vars if it should point elsewhere.
- On the `net_sim` play, `rp_filter_interfaces` explicitly includes `{{ l8opensim_net_interface }}` (`enp2s0`). On the Minion, the role auto-detects the default IPv4 interface.

## Test plan
- [ ] `ansible-playbook -i ansible-inventory.yml bootstrap/preparation-playbook.yml --tags l8opensim,rp-filter --check` passes syntax/dry-run.
- [ ] After a real run on `netsim-benchmark-01`: `systemctl status l8opensim` shows the container running with `-auto-count 1 -flow-collector 192.0.2.133:9999 -flow-protocol ipfix`; `iptables -L DOCKER-USER` shows the forward rules.
- [ ] `sysctl net.ipv4.conf.all.rp_filter` returns `2` on both `netsim-benchmark-01` and `minion-benchmark-01`; `sysctl net.ipv4.conf.enp2s0.rp_filter` returns `2` on the simulator.
- [ ] Flow records reach the configured collector (verify with `tcpdump -ni any port 9999` on the collector).

🤖 Generated with [Claude Code](https://claude.com/claude-code)