### PR TITLE
fix(docker_ce): validate GPG key download and scrub empty keys on failure

### DIFF
--- a/bootstrap/roles/docker_ce/tasks/main.yml
+++ b/bootstrap/roles/docker_ce/tasks/main.yml
@@ -21,12 +21,33 @@
     state: absent
   tags: ["docker"]
 
-- name: Download repository GPG key
-  ansible.builtin.get_url:
-    url: "{{ repo_uri_pubkey }}"
-    dest: "{{ repo_signed_by }}"
-    mode: "0644"
+# get_url can silently leave a 0-byte file behind (e.g. CDN returns 200 with
+# empty body). apt then rejects the repo as "not signed" and subsequent runs
+# fail at apt_update before docker_ce runs, so scrub any bad key on failure.
+- name: Download and validate repository GPG key
   tags: ["docker"]
+  block:
+    - name: Download repository GPG key
+      ansible.builtin.get_url:
+        url: "{{ repo_uri_pubkey }}"
+        dest: "{{ repo_signed_by }}"
+        mode: "0644"
+
+    - name: Validate downloaded GPG key is a PGP public key block
+      ansible.builtin.command:
+        cmd: "grep -q '^-----BEGIN PGP PUBLIC KEY BLOCK-----' {{ repo_signed_by }}"
+      changed_when: false
+  rescue:
+    - name: Remove invalid GPG key so the next run can retry cleanly
+      ansible.builtin.file:
+        path: "{{ repo_signed_by }}"
+        state: absent
+
+    - name: Fail with diagnostic message
+      ansible.builtin.fail:
+        msg: >-
+          Downloaded GPG key at {{ repo_signed_by }} was missing or not a valid
+          PGP public key block. Removed; retry the play.
 
 - name: Add repository with signed-by option
   ansible.builtin.template:


### PR DESCRIPTION
## Summary

- Wrap the Docker GPG key download in a `block`/`rescue` that validates the resulting file contains a PGP public key block.
- On validation failure, delete the bad key and fail with a clear diagnostic so the next run starts from a clean slate instead of inheriting a booby-trapped apt source.

## Why

Reproduced on a fresh KVM lab deploy: all four `docker_engine` hosts (mon, kafka, netsim, es) ended up with `/etc/apt/keyrings/docker.asc` at **0 bytes** after an earlier partial run. Because `docker.sources` references the key via `Signed-By:`, apt rejected the repo as unsigned and every subsequent `./deploy.sh --provider kvm` aborted at the very first `apt_update` task — long before `docker_ce` could refetch the key:

```
W: GPG error: https://download.docker.com/linux/ubuntu noble InRelease:
   GPG: add_keyblock_resource 33587281  GPG: keydb_search 33554445
E: The repository 'https://download.docker.com/linux/ubuntu noble InRelease' is not signed.
```

`ansible.builtin.get_url` doesn't error on a 200-with-empty-body response, so a transient CDN/proxy hiccup can leave that empty file behind. The new validation catches it immediately and prevents the trap.

## Test plan

- [ ] Re-run `./deploy.sh --provider kvm` on a clean lab — expect Docker repo bootstrap to complete normally.
- [ ] Simulate a bad download (e.g. `sudo truncate -s 0 /etc/apt/keyrings/docker.asc` before the play runs) and confirm the rescue branch removes the file and fails with the diagnostic message, rather than letting apt hit the unsigned-repo error.