### PR TITLE
feat(l8opensim): bump to v0.4.1 with SNMP trap and syslog collectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ The network IP space is chosen from the private 192.0.2/24 range which is not pu
 |:-------------|:----------------|:----------------|:-------------------------|
 | 10.42.0.0/16 | `192.0.2.201`   | `192.0.2.129`   | Network with SNMP Agents |
 
+The netsim VM's l8opensim simulator emits three baseline event streams to the Minion's sim-facing NIC (`192.0.2.133`): IPFIX flows to `9999/udp`, SNMP traps to `10162/udp`, and UDP syslog (RFC 5424) to `10514/udp`.
+
 ## 🕹️ Usage
 
 ### Clone the repository with submodules

--- a/bootstrap/roles/l8opensim/defaults/main.yml
+++ b/bootstrap/roles/l8opensim/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-l8opensim_image: "ghcr.io/labmonkeys-space/l8opensim:v0.3.0"
+l8opensim_image: "ghcr.io/labmonkeys-space/l8opensim:v0.4.1"
 l8opensim_auto_start_ip: "10.42.0.1"
 l8opensim_auto_count: 1
 l8opensim_auto_netmask: "16"
@@ -8,3 +8,5 @@ l8opensim_sim_network: "10.42.0.0/16"
 l8opensim_net_interface: "enp2s0"
 l8opensim_flow_collector: "192.0.2.133:9999"
 l8opensim_flow_protocol: "ipfix"
+l8opensim_trap_collector: "192.0.2.133:10162"
+l8opensim_syslog_collector: "192.0.2.133:10514"

--- a/bootstrap/roles/l8opensim/templates/l8opensim.service.j2
+++ b/bootstrap/roles/l8opensim/templates/l8opensim.service.j2
@@ -19,7 +19,9 @@ ExecStart=/usr/bin/docker run \
   -auto-netmask {{ l8opensim_auto_netmask }} \
   -port {{ l8opensim_web_port }} \
   -flow-collector {{ l8opensim_flow_collector }} \
-  -flow-protocol {{ l8opensim_flow_protocol }}
+  -flow-protocol {{ l8opensim_flow_protocol }} \
+  -trap-collector {{ l8opensim_trap_collector }} \
+  -syslog-collector {{ l8opensim_syslog_collector }}
 ExecStop=/usr/bin/docker stop l8opensim
 
 [Install]

--- a/opennms-lab-vars.yml
+++ b/opennms-lab-vars.yml
@@ -1,4 +1,6 @@
 ---
+l8opensim_image: "ghcr.io/labmonkeys-space/l8opensim:v0.4.1"
+
 opennms_distribution: Horizon
 opennms_version: "35.0.5"
 opennms_pkg_version: "{{ opennms_version }}*"


### PR DESCRIPTION
## Summary

- Wire l8opensim's `-trap-collector` and `-syslog-collector` CLI flags (v0.4.0+) through the bootstrap role so every netsim VM emits SNMP traps (`192.0.2.133:10162`) and UDP syslog (`192.0.2.133:10514`) to the Minion on bootstrap — symmetric with how IPFIX flows already work.
- Bump the baseline `l8opensim_image` to `v0.4.1` in both the role default and `opennms-lab-vars.yml` (the `v0.4.1` image is a detach-and-polish release over v0.4.0 with no behavior change).
- One-line README note under "Network for simulation" documenting the three baseline event streams.

## Why

Today's bootstrap simulator is silent on two of the three traffic classes the Minion can ingest. Every benchmark that wants trap or syslog load has to stitch together ad-hoc configuration against a v0.3.0 image that doesn't even expose those subsystems. Adopting v0.4.1 as the baseline and wiring both flags through the role turns traps and syslog into always-on load — same pattern as flows — while leaving `l8opensim_auto_count` and per-experiment `l8opensim_*_collector` overrides in place for tuning.

At the role default `l8opensim_auto_count: 1`, rates are negligible (~2 traps/min, ~6 syslog/min). Per-experiment `auto_count` overrides scale both linearly.

## Variable naming

Mirrors the upstream CLI flag names (`-trap-collector` → `l8opensim_trap_collector`, `-syslog-collector` → `l8opensim_syslog_collector`), consistent with `l8opensim_flow_collector` ↔ `-flow-collector`.

## Follow-up — submodule work

`ansible-opennms`'s `opennms_minion/50-firewall.yml` opens `10162/udp` but **not** `10514/udp`. In the current deployment this doesn't matter (Minion's syslog listener is off by default), but experiments that enable the listener without also opening UFW will see traffic silently dropped. Tracking as submodule follow-up — not fixed here.

## Test plan

Verification is against the live benchmark lab. Perform after merge + `terraform apply`:

- [ ] Run `ansible-playbook -i ansible-inventory.yml bootstrap/site.yml --tags l8opensim --limit netsim-benchmark-01` — `l8opensim.service` restarts cleanly on the netsim VM.
- [ ] On the netsim VM: `systemctl status l8opensim` shows the new `-trap-collector` / `-syslog-collector` flags in `ExecStart`; `docker logs l8opensim` shows trap and syslog subsystems initialized without errors.
- [ ] On the Minion VM: `sudo tcpdump -ni any 'udp port 10162 or udp port 10514'` shows inbound UDP from the `10.42.0.0/16` simulated device space — confirms sim → Minion routing end-to-end.
- [ ] At `l8opensim_auto_count: 1` (baseline), confirm the event rate is negligible and doesn't swamp Minion logs.