### PR TITLE
fix(l8opensim): restart service on unit file change so image upgrades apply

### DIFF
--- a/bootstrap/roles/l8opensim/handlers/main.yml
+++ b/bootstrap/roles/l8opensim/handlers/main.yml
@@ -2,3 +2,13 @@
 - name: Reload systemd daemon
   ansible.builtin.systemd:
     daemon_reload: true
+
+- name: Restart l8opensim
+  ansible.builtin.systemd:
+    name: l8opensim.service
+    state: restarted
+
+- name: Restart opensim-forward
+  ansible.builtin.systemd:
+    name: opensim-forward.service
+    state: restarted

--- a/bootstrap/roles/l8opensim/tasks/main.yml
+++ b/bootstrap/roles/l8opensim/tasks/main.yml
@@ -29,7 +29,12 @@
     owner: root
     group: root
     mode: "0644"
-  notify: Reload systemd daemon
+  notify:
+    - Reload systemd daemon
+    - Restart l8opensim
+    # opensim-forward BindsTo l8opensim.service: restarting l8opensim
+    # cascades a stop to opensim-forward but does not start it again.
+    - Restart opensim-forward
   tags: ["l8opensim"]
 
 - name: Install opensim-forward systemd service
@@ -39,7 +44,9 @@
     owner: root
     group: root
     mode: "0644"
-  notify: Reload systemd daemon
+  notify:
+    - Reload systemd daemon
+    - Restart opensim-forward
   tags: ["l8opensim"]
 
 - name: Flush handlers before enabling services


### PR DESCRIPTION
## Summary

- The `l8opensim` role regenerates `/etc/systemd/system/l8opensim.service` from its Jinja template on every run, but only notifies `Reload systemd daemon`. The subsequent `ansible.builtin.systemd` task uses `state: started`, which is a no-op on an already-running unit, so systemd loads the new unit file but the running container stays on the previous image.
- Observed on `netsim-benchmark-01` after the v0.4.1 bump (PR #101): the unit file on disk pinned `ghcr.io/labmonkeys-space/l8opensim:v0.4.1`, but `docker ps` still showed `l8opensim:v0.3.0`. Same failure mode affects `opensim-forward.service`.
- Adds `Restart l8opensim` and `Restart opensim-forward` handlers and has the template tasks notify the matching restart after the daemon-reload. Ansible runs handlers in the order they're defined in `handlers/main.yml`, so the reload still fires before the restart.

## Test plan

- [ ] Run `./deploy.sh --provider kvm` against a lab that is still on an older `l8opensim` image and confirm the netsim VM's running container flips to the pinned version (`ssh -J labuser@bench-lab labuser@netsim-benchmark-01 'docker ps'`).
- [ ] Re-run the bootstrap play with no variable change and confirm neither restart handler fires (idempotency — templates produce no diff, handlers are not notified).
- [ ] Confirm `systemctl status l8opensim opensim-forward` shows both units `active (running)` after the play completes.