### PR TITLE
fix(l8opensim): default auto_count to 0 so benchmark lab starts clean

### DIFF
--- a/bootstrap/roles/l8opensim/defaults/main.yml
+++ b/bootstrap/roles/l8opensim/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 l8opensim_image: "ghcr.io/labmonkeys-space/l8opensim:v0.4.1"
 l8opensim_auto_start_ip: "10.42.0.1"
-l8opensim_auto_count: 1
+l8opensim_auto_count: 0
 l8opensim_auto_netmask: "16"
 l8opensim_web_port: 8080
 l8opensim_sim_network: "10.42.0.0/16"


### PR DESCRIPTION
## Summary

- The `l8opensim` role's default `l8opensim_auto_count: 1` caused the netsim VM's `/etc/systemd/system/l8opensim.service` to render with `-auto-count 1`, starting one auto-generated simulated device on every fresh deploy.
- `opennms-lab-vars.yml` pins the same variable to `0`, but that override is only passed to the OpenNMS playbook in `deploy.sh` — the bootstrap play (which owns the l8opensim role) never sees it. So the role falls back to its own default.
- Set the role default to `0` — the desired value for this project — so bootstrap renders the unit with `-auto-count 0` by default. The existing restart handler (#102) picks up the unit file change and recreates the container on the next deploy.

## Test plan

- [ ] `./deploy.sh --provider kvm` against a fresh lab and confirm `ssh -J labuser@bench-lab labuser@netsim-benchmark-01 'docker inspect l8opensim --format "{{.Config.Cmd}}"'` shows `-auto-count 0`.
- [ ] Rerun the bootstrap play with no variable change; confirm both template and restart tasks report `ok`.