### PR TITLE
chore(l8opensim): bump baseline image to v0.5.1

### DIFF
--- a/bootstrap/roles/l8opensim/defaults/main.yml
+++ b/bootstrap/roles/l8opensim/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-l8opensim_image: "ghcr.io/labmonkeys-space/l8opensim:v0.4.1"
+l8opensim_image: "ghcr.io/labmonkeys-space/l8opensim:v0.5.1"
 l8opensim_auto_start_ip: "10.42.0.1"
 l8opensim_auto_count: 0
 l8opensim_auto_netmask: "16"

--- a/opennms-lab-vars.yml
+++ b/opennms-lab-vars.yml
@@ -1,5 +1,5 @@
 ---
-l8opensim_image: "ghcr.io/labmonkeys-space/l8opensim:v0.4.1"
+l8opensim_image: "ghcr.io/labmonkeys-space/l8opensim:v0.5.1"
 
 opennms_distribution: Horizon
 opennms_version: "35.0.5"


### PR DESCRIPTION
## Summary
- Bump `l8opensim_image` from `v0.4.1` to `v0.5.1` in the role default (`bootstrap/roles/l8opensim/defaults/main.yml`) and in the global lab pin (`opennms-lab-vars.yml`).
- No other behavior changes.

## Test plan
- [ ] Re-run `bootstrap/preparation-playbook.yml` against the netsim VM and confirm the `l8opensim` systemd unit picks up `ghcr.io/labmonkeys-space/l8opensim:v0.5.1`.
- [ ] Verify the simulator container starts cleanly and the web UI on port 8080 is reachable.
- [ ] Verify SNMP responses from a simulated node in `10.42.0.0/16` after deploying with `auto_count > 0`.