### PR TITLE
chore: complete nl6 route rename and pin app_starter image

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,7 +423,7 @@ Replace `<monitoring-public-ip>` with the actual public IP assigned to the monit
 | Kafka UI             | `https://<monitoring-public-ip>/kafka`      | no login required           |
 | pgAdmin              | `https://<monitoring-public-ip>/pgadmin`    | admin@benchmark.lab / admin |
 | Kibana               | `https://<monitoring-public-ip>/kibana`     | no login required           |
-| SNMP Sim (nl6) | `https://<monitoring-public-ip>/opensim`    | no login required           |
+| SNMP Sim (nl6) | `https://<monitoring-public-ip>/nl6`        | no login required           |
 
 > [!TIP]
 > To reach every VM on the management network (`192.0.2.192/26`) without a bastion host, install [Tailscale](https://tailscale.com) on the monitoring VM and advertise the subnet:

--- a/bootstrap/roles/app_starter/defaults/main.yml
+++ b/bootstrap/roles/app_starter/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-app_starter_image: ghcr.io/indigo423/app-starter:latest
+app_starter_image: ghcr.io/indigo423/app-starter:v0.1.1
 app_starter_port: "3010"
 app_starter_cpus: "0.5"
 app_starter_memory: 128m

--- a/bootstrap/roles/traefik/files/traefik/dynamic/routes.yml
+++ b/bootstrap/roles/traefik/files/traefik/dynamic/routes.yml
@@ -52,7 +52,7 @@ http:
         - kibana-strip
       tls: {}
     opensim:
-      rule: "PathPrefix(`/opensim`)"
+      rule: "PathPrefix(`/nl6`)"
       entryPoints:
         - websecure
       service: opensim
@@ -73,7 +73,7 @@ http:
     opensim-strip:
       stripPrefix:
         prefixes:
-          - /opensim
+          - /nl6
 
   services:
     grafana:


### PR DESCRIPTION
## Summary

- Rename the Traefik path prefix and stripPrefix middleware from `/opensim` to `/nl6` (follow-up to #105) and update the README service table to match.
- Pin `app_starter_image` from the floating `:latest` tag to `:v0.1.1` for reproducible bootstrap runs.

## Test plan

- [ ] `ansible-playbook -i inventory site.yml` on the monitoring VM applies the new Traefik route without errors
- [ ] `https://<monitoring>/nl6` reaches the SNMP simulator UI; `https://<monitoring>/opensim` returns 404
- [ ] `app-starter` container on a fresh bootstrap pulls `ghcr.io/indigo423/app-starter:v0.1.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)