### PR TITLE
chore(nl6): bump image to v0.9.0

### DIFF
--- a/bootstrap/roles/nl6/defaults/main.yml
+++ b/bootstrap/roles/nl6/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-nl6_image: "ghcr.io/labmonkeys-space/nl6:v0.6.0"
+nl6_image: "ghcr.io/labmonkeys-space/nl6:v0.9.0"
 nl6_auto_start_ip: "10.42.0.1"
 nl6_auto_count: 0
 nl6_auto_netmask: "16"

--- a/opennms-lab-vars.yml
+++ b/opennms-lab-vars.yml
@@ -1,5 +1,5 @@
 ---
-nl6_image: "ghcr.io/labmonkeys-space/nl6:v0.6.0"
+nl6_image: "ghcr.io/labmonkeys-space/nl6:v0.9.0"
 nl6_auto_count: 0
 
 opennms_distribution: Horizon


### PR DESCRIPTION
## Summary
- Bump `nl6_image` from `v0.6.0` to `v0.9.0` in both the global lab vars and the `nl6` role defaults.

## Test plan
- [ ] Re-run the bootstrap playbook against the netsim VM and confirm the new image pulls and starts cleanly.
- [ ] Verify the simulator emits IPFIX/SNMP traps/syslog to the Minion as expected.

Assisted-by: ClaudeCode:claude-opus-4-7