### PR TITLE
chore: upgrade OpenNMS Horizon to 36.0.0

### DIFF
--- a/opennms-lab-vars.yml
+++ b/opennms-lab-vars.yml
@@ -3,7 +3,7 @@ nl6_image: "ghcr.io/labmonkeys-space/nl6:v0.9.0"
 nl6_auto_count: 0
 
 opennms_distribution: Horizon
-opennms_version: "35.0.5"
+opennms_version: "36.0.0"
 opennms_pkg_version: "{{ opennms_version }}*"
 
 opennms_datasource_db_host: 192.0.2.196


### PR DESCRIPTION
## Summary
- Bump `opennms_version` in the global lab vars from `35.0.5` to `36.0.0`.

Scope kept surgical: experiment-specific `opennms-lab-vars.yml` files remain pinned at their historical versions, and the `ansible-opennms/` submodule defaults are overridden at playbook time via `--extra-vars`.

## Test plan
- [ ] Re-run the OpenNMS stack playbook against the benchmark lab and confirm Core, Minion, and Sentinel install at 36.0.0.
- [ ] Verify the OpenNMS UI reports the new version and that database schema migration completes cleanly.
- [ ] Smoke-test SNMP collection and event/alarm flow end-to-end via Kafka.

Assisted-by: ClaudeCode:claude-opus-4-7