### PR TITLE
fix(bootstrap): apply netplan before pgadmin to avoid SSH drop

### DIFF
--- a/bootstrap/preparation-playbook.yml
+++ b/bootstrap/preparation-playbook.yml
@@ -31,11 +31,22 @@
   roles:
     - docker_ce
 
-- name: Monitoring services
+- name: Pin DHCP client identifier (isolated so netplan applies before later roles)
   hosts: mon_servers
   become: true
   roles:
     - dhcp_clientid
+  post_tasks:
+    - name: Flush handlers so netplan apply runs now
+      ansible.builtin.meta: flush_handlers
+    - name: Wait for SSH after netplan apply
+      ansible.builtin.wait_for_connection:
+        timeout: 120
+
+- name: Monitoring services
+  hosts: mon_servers
+  become: true
+  roles:
     - ip_forwarding
     - grafana
     - pgadmin


### PR DESCRIPTION
## Summary
- Split the `dhcp_clientid` task into its own play so its `Apply netplan` handler flushes before `pgadmin`'s `meta: flush_handlers` fires.
- Previously the queued netplan apply ran mid-flush of pgadmin's handlers, renegotiating DHCP and (on the first run) shifting the lease — leaving the remaining `Restart pgadmin` handler unable to reach the host.

## Test plan
- [ ] Run `cd bootstrap && ansible-playbook -i inventory site.yml` against a fresh DB VM and confirm the play completes without SSH disconnect on first run.
- [ ] Re-run idempotently and confirm no handler-ordering regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)