### PR TITLE
ci(dependabot): cover all terraform roots via directory glob

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,18 +1,11 @@
 ---
 version: 2
 updates:
+  # Glob covers every Terraform root under terraform/ (azure, kvm, proxmox,
+  # vmware) and self-heals when a new platform directory is added.
   - package-ecosystem: "terraform"
-    directory: "/terraform/azure"
-    schedule:
-      interval: "weekly"
-
-  - package-ecosystem: "terraform"
-    directory: "/terraform/kvm"
-    schedule:
-      interval: "weekly"
-
-  - package-ecosystem: "terraform"
-    directory: "/terraform/proxmox"
+    directories:
+      - "/terraform/*"
     schedule:
       interval: "weekly"
 


### PR DESCRIPTION
## Why

Dependabot's terraform coverage enumerated `/terraform/azure`, `/terraform/kvm`, and `/terraform/proxmox` explicitly. The list drifted: `terraform/vmware` (pinning `hashicorp/vsphere ~> 2.10`) was added after the config was written and receives no update PRs.

## What

Collapse the three explicit `terraform` blocks into one using `directories: ["/terraform/*"]`:

- covers all four current roots (`azure`, `kvm`, `proxmox`, `vmware`)
- self-heals when a new platform directory is added under `terraform/`
- `github-actions` entry unchanged

Nested modules (`terraform/*/modules/*`) are deliberately not covered — root-module constraints govern what gets installed; module-level bumps are churn. Ansible Galaxy pins in `requirements.yml` stay manual by design (no Dependabot ecosystem; the `indigo423.opennms` SHA pin must never auto-bump for benchmark reproducibility).

## Verification

- `.github/dependabot.yml` parses as YAML with the two expected update entries.
- Post-merge: confirm Insights → Dependency graph → Dependabot lists four terraform jobs and reports no error for `/terraform/modules` (matched by the glob but containing no root manifests). Fallback if the glob misbehaves: explicit four-entry `directories` list.
- Expect an initial `hashicorp/vsphere` bump PR for `terraform/vmware`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)