### PR TITLE
ci: pin workflow actions to immutable SHAs

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -15,10 +15,10 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Cache Ansible collections
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: ~/.ansible/collections
           key: ansible-collections-${{ hashFiles('requirements.yml', 'bootstrap/requirements.yml') }}
@@ -42,6 +42,6 @@ jobs:
           echo "ANSIBLE_VAULT_PASSWORD_FILE=$HOME/.config/ansible-opennms/vault-pass" >> "$GITHUB_ENV"
 
       - name: Run ansible-lint
-        uses: ansible/ansible-lint@v26
+        uses: ansible/ansible-lint@262624cd0ab22a4221293216856c59671ce7aa5e  # v26.6.0
         with:
           requirements_file: bootstrap/requirements.yml

--- a/.github/workflows/terraform-lint.yml
+++ b/.github/workflows/terraform-lint.yml
@@ -11,9 +11,9 @@ jobs:
     name: Format Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
-      - uses: hashicorp/setup-terraform@v4
+      - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e  # v4.0.1
         with:
           terraform_version: "~1.5"
 
@@ -24,9 +24,9 @@ jobs:
     name: Validate (Azure)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
-      - uses: hashicorp/setup-terraform@v4
+      - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e  # v4.0.1
         with:
           terraform_version: "~1.5"
 
@@ -42,9 +42,9 @@ jobs:
     name: Validate (KVM)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
-      - uses: hashicorp/setup-terraform@v4
+      - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e  # v4.0.1
         with:
           terraform_version: "~1.5"
 
@@ -63,9 +63,9 @@ jobs:
     name: Validate (Proxmox)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
-      - uses: hashicorp/setup-terraform@v4
+      - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e  # v4.0.1
         with:
           terraform_version: "~1.5"
 
@@ -83,9 +83,9 @@ jobs:
     name: Validate (VMware)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
-      - uses: hashicorp/setup-terraform@v4
+      - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e  # v4.0.1
         with:
           terraform_version: "~1.5"
 
@@ -103,9 +103,9 @@ jobs:
     name: TFLint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
-      - uses: terraform-linters/setup-tflint@v6
+      - uses: terraform-linters/setup-tflint@6e1e0642c0289bd619021bf6b34e3c08ed1e005a  # v6.3.0
         with:
           tflint_version: latest
 


### PR DESCRIPTION
## Why

Both workflows pinned actions by mutable major tag (`@v7`, `@v6`, …). Tags can be repointed — a compromised or malicious re-tag silently changes what runs in CI. The repo convention is commit-SHA pins with the full semver in a trailing comment.

## What

All 15 `uses:` references across `ansible-lint.yml` and `terraform-lint.yml` converted to `<sha>  # v<semver>`:

| Action | Pinned version | SHA |
|---|---|---|
| actions/checkout | v7.0.0 | `9c091bb` |
| actions/cache | v6.1.0 | `55cc834` |
| ansible/ansible-lint | v26.6.0 | `262624c` |
| hashicorp/setup-terraform | v4.0.1 | `dfe3c3f` |
| terraform-linters/setup-tflint | v6.3.0 | `6e1e064` |

SHAs resolved via the GitHub API: each major tag dereferenced to its commit, then cross-matched to the full-semver tag pointing at the same commit. Versions are identical to what the tags resolve to today — no behavior change.

Dependabot (already covering `github-actions`) maintains pins in this format going forward, so future bumps arrive as SHA+comment updates instead of tag bumps.

## Verification

- Both files parse as YAML.
- Scripted check: all 15 `uses:` refs match `@[0-9a-f]{40}`, each with a semver comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)