### PR TITLE
chore(deps): bump indigo423.opennms to v0.4.7

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -9,7 +9,7 @@ collections:
   # update only via a deliberate PR, never automatically.
   - name: https://github.com/opennms-forge/ansible-opennms.git
     type: git
-    version: d0d5b1732cab6c1e5ce5a48970f2ec86bc4b5fb7  # v0.4.6
+    version: 286d031cdc5237b0d6c3f91b65ec3f0845b393ef  # v0.4.7
 
   # Transitive collections used by the OpenNMS deployment roles. Pinned by
   # Galaxy version string (weaker than SHA pinning, matches the prior


### PR DESCRIPTION
## Why

Upstream released `ansible-opennms` **v0.4.7** (also now published on galaxy.ansible.com). This is the deliberate, manual SHA bump the reproducibility policy requires — never automated.

## What

`requirements.yml`: `d0d5b17` (v0.4.6) → `286d031c` (v0.4.7). One line.

Upstream v0.4.6…v0.4.7 contains:
- **fix**: three deployment blockers found by end-to-end smoke test (#109) — touches `opennms_core` database setup/defaults/vars, `opennms_minion`, `opennms_repositories`, `opennms_sentinel`, `stub_kafka`
- **deps**: OpenNMS → 36.0.2, jmx_exporter → 1.6.0

⚠️ **Benchmark substrate change**: results produced after this merge are not directly comparable to runs pinned at v0.4.6 (different OpenNMS version, different role logic).

## Pin form unchanged

The pin stays **git URL + SHA**, not a Galaxy version string, even though the collection is now on galaxy.ansible.com — Galaxy versions are republishable; git SHAs are immutable (see `openspec/specs` reproducibility requirements).

Dependency check: v0.4.7's `galaxy.yml` declares `community.postgresql >=4.2.0`, `community.general >=12.6.0`, `grafana.grafana >=6.1.0` — all satisfied by the existing pins in `requirements.yml`; no transitive bumps needed.

## Verification

Scratch-prefix install from this branch's `requirements.yml`:
- `indigo423.opennms:0.4.7` builds from the git SHA and installs successfully
- all 12 roles present (`common` … `stub_pgsql`)
- transitive collections resolve without `--pre`

## ⚠️ Rollback note (one-way migration marker)

This is the **first SHA bump** since the submodule→collection migration (PR #110). From this point, `git revert` of the migration commit is no longer a valid rollback path — roll forward via a corrective change to `requirements.yml` instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)