### PR TITLE
fix: use apt version encoding for Grafana security-release pin

### DIFF
--- a/opennms-lab-vars.yml
+++ b/opennms-lab-vars.yml
@@ -23,7 +23,11 @@ opennms_es_port: 9200
 # Pinned to a Grafana 12.x release so the stock grafana.grafana 6.1.0 collection
 # works as-is. Grafana 13 needs a grafana-cli --homepath fix for plugin installs
 # that only exists in a non-Galaxy hotfix build (see requirements.yml).
-grafana_version: "12.4.3+security-02"
+# NOTE: this is the apt package version. Grafana's download pages call this
+# release "12.4.3+security-02", but apt.grafana.com encodes it as "12.4.3-02" —
+# the "+security" form matches nothing and apt fails with
+# "no available installation candidate".
+grafana_version: "12.4.3-02"
 # Datasources are provisioned by bootstrap/roles/grafana via files.
 # Empty list overrides the submodule's group_vars (which the collection
 # would otherwise use to call its datasource module — rejecting plugin types).


### PR DESCRIPTION
## Why

`ansible-playbook opennms-playbook.yml` fails on `mon-benchmark-01` at `grafana.grafana.grafana : Install Grafana`:

```
no available installation candidate for grafana=12.4.3+security-02
```

The pin in `opennms-lab-vars.yml` uses Grafana's download-page naming (`12.4.3+security-02`), but apt.grafana.com encodes security releases as `<version>-<build>`. The repo currently offers `12.4.2, 12.4.3, 12.4.3-02, 12.4.4, 12.4.5` — the `+security` form matches nothing, so apt has no installation candidate. (The host's apt cache is current; the version string is genuinely absent, not stale metadata.)

## What

`grafana_version: "12.4.3+security-02"` → `"12.4.3-02"`, plus a comment documenting the encoding gotcha so nobody "fixes" it back to the `+security` form.

This is **byte-identical software** to what the old pin meant (security build 02 of Grafana 12.4.3) — benchmark comparability is unaffected. Staying on 12.4.x also keeps the stock `grafana.grafana 6.1.0` collection constraint documented above the pin.

## Verification

- YAML parses.
- `12.4.3-02` confirmed present in `apt.grafana.com/dists/stable/main/binary-amd64/Packages.gz` (exact-match grep).
- `grafana_version` is pinned only here — no per-experiment override carries the old string.
- Real proof is the next `opennms-playbook.yml` run against `mon-benchmark-01` getting past the Install Grafana task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)