### PR TITLE
fix: bump OpenNMS pin to 36.0.2, the only version apt still serves

### DIFF
--- a/opennms-lab-vars.yml
+++ b/opennms-lab-vars.yml
@@ -3,7 +3,11 @@ nl6_image: "ghcr.io/labmonkeys-space/nl6:v0.9.0"
 nl6_auto_count: 0
 
 opennms_distribution: Horizon
-opennms_version: "36.0.0"
+# The OpenNMS apt "stable" dist retains only the current point release —
+# superseded versions are removed, so a stale pin fails with
+# "no available installation candidate". Keep this in sync with what
+# debian.opennms.org actually serves.
+opennms_version: "36.0.2"
 opennms_pkg_version: "{{ opennms_version }}*"
 
 opennms_datasource_db_host: 192.0.2.196


### PR DESCRIPTION
## Why

`opennms-playbook.yml` fails on `core-benchmark-01` — all four core packages report:

```
no available installation candidate for opennms-common=36.0.0*
```

Root cause: `opennms-lab-vars.yml` pins `opennms_version: "36.0.0"` (and as an `--extra-vars` file it overrides the collection default), but debian.opennms.org's `stable` dist (codename `opennms-36`, updated 2026-07-08) retains **only the current point release, `36.0.2-1`**. The 36.0.0 debs were removed when 36.0.2 shipped — no cache refresh brings them back.

## What

`opennms_version: "36.0.0"` → `"36.0.2"` in the root `opennms-lab-vars.yml`, with a comment documenting the repo's retention behavior so the next stale pin is diagnosed faster.

36.0.2 is also the `indigo423.opennms` v0.4.7 collection default — the version upstream built and smoke-tested against — so lab pin and collection are aligned again.

## Caveats

- **Substrate change**: results are not directly comparable to 36.0.0-pinned runs. Unavoidable — the old pin is uninstallable.
- **Same time bomb in experiments** (not touched here): both `experiments/c1km1_*/opennms-lab-vars.yml` pin `33.1.8`, which the `opennms-33` dist has likely pruned the same way. Left for a separate decision since those files define historical experiments.

## Verification

- YAML parses; `opennms_version = 36.0.2`.
- `opennms-common` versions in `dists/stable/main/binary-amd64/Packages.gz`: exactly `36.0.2-1`.
- Real proof: next playbook run getting past `Installing OpenNMS core system` on `core-benchmark-01`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)