### PR TITLE
feat(experiments): NMS-20027 painless-vs-drift flow query benchmark

### DIFF
--- a/experiments/nms-20027-painless-flows/.gitignore
+++ b/experiments/nms-20027-painless-flows/.gitignore
@@ -1,0 +1,3 @@
+build/
+results/
+.env

--- a/experiments/nms-20027-painless-flows/README.md
+++ b/experiments/nms-20027-painless-flows/README.md
@@ -60,13 +60,16 @@ curl -su admin:admin localhost:8980/opennms/rest/info   # version matches the SH
 # 3. Seed the corpus once (~2.2 h at 5k flows/s); reconcile ledger   [tasks 3.1–3.4]
 #    Pin the nl6 image in compose.yml first, then: docker compose up -d nl6
 #    Load scenarios/flow-seed.json into nl6 (REST API / UI — verify flags at nl6.eu).
-#    Record T0/T1 (epoch ms) and the reconciled doc count into build/corpus-identity.json.
+#    Then write build/corpus-identity.json with EXACTLY these keys (the scripts
+#    read them; the query window comes from here, never from hand-typed env):
+#      { "doc_count": <reconciled count>,
+#        "window_start_ms": <T0 epoch ms>, "window_end_ms": <T1 epoch ms> }
 
-# 4. Trials                                                          [tasks 4.1–4.6]
-WINDOW_START=<T0-ms> WINDOW_END=<T1-ms> VARIANT=variant-b-plugin ./bin/run-trials.sh
+# 4. Trials (window + doc count are read from corpus-identity.json)  [tasks 4.1–4.6]
+VARIANT=variant-b-plugin ./bin/run-trials.sh
 VARIANT=variant-b-plugin ./bin/emit-manifest.sh
 VARIANT=variant-c-painless docker compose up -d --force-recreate horizon   # flips the one line
-WINDOW_START=<T0-ms> WINDOW_END=<T1-ms> VARIANT=variant-c-painless ./bin/run-trials.sh
+VARIANT=variant-c-painless ./bin/run-trials.sh
 VARIANT=variant-c-painless ./bin/emit-manifest.sh
 
 # 5. Stats, correctness diff, report                                 [tasks 5.1–5.5]
@@ -76,6 +79,15 @@ VARIANT=variant-c-painless ./bin/emit-manifest.sh
 
 # 6. Teardown                                                        [task 6.1]
 docker compose down -v
+```
+
+**From-scratch reset** (rerun the experiment, or after re-pinning the SHA): the
+named volumes and the host-side identity files have independent lifecycles and
+MUST be cleared together, or the guards report contradictory states
+("already built" vs. "corpus lost"):
+
+```sh
+docker compose down -v && rm -rf build/ results/ .env
 ```
 
 ## Verify-at-use gates (do not skip)

--- a/experiments/nms-20027-painless-flows/README.md
+++ b/experiments/nms-20027-painless-flows/README.md
@@ -1,0 +1,93 @@
+# NMS-20027: Painless proportional_sum vs. elasticsearch-drift-plugin
+
+A/B benchmark of [OpenNMS PR #8638](https://github.com/OpenNMS/opennms/pull/8638) (NMS-20027):
+does computing flow `proportional_sum` with inline Painless `scripted_metric` scripts regress
+netflow query performance vs. the [elasticsearch-drift-plugin](https://github.com/OpenNMS-Plugins/elasticsearch-drift-plugin)?
+
+Unlike the other directories under `experiments/`, this is **not** an Azure-lab Ansible
+experiment — it is a local single-host container experiment (OpenNMS Core + PostgreSQL +
+Elasticsearch + nl6 only; no Minion/Sentinel/Kafka). The full Stage-0 plan, design and task
+list live in `openspec/changes/nms-20027-painless-flow-benchmark/`.
+
+## Design in one paragraph
+
+One build (OpenNMS/opennms @ `03b6b6dd8cfb3d3b90094530d7b2d10439fe0a48`), two variants that
+differ in exactly one config line — `proportionalSumStrategy` in
+`etc/org.opennms.features.flows.persistence.elastic.cfg`: **B** = `plugin` (drift plugin path),
+**C** = `painless` (PR default). Elasticsearch 8.18.2 carries drift plugin `v2.0.7_es-8.18.2`
+in *both* variants (idle in C) so the cluster is identical. A 40M-flow corpus is seeded once
+via nl6 (send-ledger reconciled) and is read-only during trials. 6 trials × 2 query shapes
+(dense whole-window / sparse fine-window) per variant; trial 1 discarded. The Painless path
+intentionally fixes NMS-20001, so a B↔C correctness diff of series/totals is mandatory and is
+reported next to the latency delta.
+
+**Scope: relative A/B only.** Generator and SUT are co-located — no absolute flows/sec or QPS
+figure from this experiment is valid.
+
+## Layout
+
+| Path | Purpose |
+|---|---|
+| `compose.yml` | The 4-service stack (database, horizon, elasticsearch, nl6) |
+| `es/Dockerfile` | ES 8.18.2 + drift plugin `v2.0.7_es-8.18.2` |
+| `variants/variant-b-plugin/` | etc-overlay for variant B (`proportionalSumStrategy=plugin`) |
+| `variants/variant-c-painless/` | etc-overlay for variant C (`proportionalSumStrategy=painless`) |
+| `scenarios/flow-seed.json` | nl6 IPFIX seed scenario: 5000 flows/s × 8000 s = 40M flows |
+| `queries/queries.json` | The fixed query set (dense + sparse shapes) |
+| `bin/build-sut.sh` | Tasks 1.1–1.4: pinned checkout → assembly tarball → image (skip-rebuild aware) |
+| `bin/run-trials.sh` | Task 4.2: trial runner with doc-count guard and raw-response persistence |
+| `bin/emit-manifest.sh` | Task 4.6: run-time manifest probes + schema validation |
+| `run-manifest.schema.json` | Contract schema (copied from the opennms-benchmark skill) |
+| `build/`, `results/` | Generated at run time — gitignored |
+
+The two variant directories MUST stay byte-identical except the `proportionalSumStrategy`
+line. Any additional config (e.g. enabling the telemetryd IPFIX listener) is applied to
+*both* directories identically — it is a control and part of `config_delta`.
+
+## Runbook (maps to `tasks.md`)
+
+```sh
+# 1. Build the shared fixture (~1–1.5 h once; re-runs skip)          [tasks 1.1–1.4]
+./bin/build-sut.sh
+
+# 2. Bring up variant B; verify plugin + smoke query                 [tasks 2.1–2.5]
+#    (scoped service list: nl6's image is unpinned until step 3, and an
+#     unpullable image aborts an unscoped `up` entirely)
+VARIANT=variant-b-plugin docker compose up -d database elasticsearch horizon
+curl -s localhost:9200/_cat/plugins            # drift plugin listed
+curl -su admin:admin localhost:8980/opennms/rest/info   # version matches the SHA build
+
+# 3. Seed the corpus once (~2.2 h at 5k flows/s); reconcile ledger   [tasks 3.1–3.4]
+#    Pin the nl6 image in compose.yml first, then: docker compose up -d nl6
+#    Load scenarios/flow-seed.json into nl6 (REST API / UI — verify flags at nl6.eu).
+#    Record T0/T1 (epoch ms) and the reconciled doc count into build/corpus-identity.json.
+
+# 4. Trials                                                          [tasks 4.1–4.6]
+WINDOW_START=<T0-ms> WINDOW_END=<T1-ms> VARIANT=variant-b-plugin ./bin/run-trials.sh
+VARIANT=variant-b-plugin ./bin/emit-manifest.sh
+VARIANT=variant-c-painless docker compose up -d --force-recreate horizon   # flips the one line
+WINDOW_START=<T0-ms> WINDOW_END=<T1-ms> VARIANT=variant-c-painless ./bin/run-trials.sh
+VARIANT=variant-c-painless ./bin/emit-manifest.sh
+
+# 5. Stats, correctness diff, report                                 [tasks 5.1–5.5]
+#    Compute median/p95/min–max over trials 2–6; diff results/variant-b-plugin vs
+#    results/variant-c-painless; splice runs+manifests JSON into the skill's
+#    report-template.html (<script id="benchmark-data"> is the only edit).
+
+# 6. Teardown                                                        [task 6.1]
+docker compose down -v
+```
+
+## Verify-at-use gates (do not skip)
+
+- **ES compatibility smoke check** (task 2.3): one flow query from the PR build against
+  ES 8.18.2 before seeding. On failure: fall back to ES 7.17.13 + plugin `v2.0.5_es-7.17.13`
+  (edit `es/Dockerfile`), same for both variants.
+- **nl6 image + scenario flags** (task 3.1): pin a real nl6 release in `compose.yml`
+  (`TODO-pin-release` placeholder fails the pull on purpose) and verify the scenario format
+  against nl6 upstream docs; record the image digest as `workload.generator_version`.
+- **Query-shape rendering** (task 4.1): on variant C confirm the dense query renders a
+  `scripted_metric` *with* `nBuckets` and the sparse one *without* (enable Elastic query
+  logging or inspect via ES slow log) before starting timed trials.
+- **Seed rate re-budget** (task 3.2): check the ledger rate 30 min in; below ~5k flows/s,
+  recompute the wall-clock budget before continuing.

--- a/experiments/nms-20027-painless-flows/bin/build-sut.sh
+++ b/experiments/nms-20027-painless-flows/bin/build-sut.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: Apache-2.0
+#
+# Tasks 1.1-1.4: build the shared fixture ONCE — pinned checkout -> assembly
+# tarball -> container image. Re-runs skip completed steps (shared-fixture rule:
+# never rebuild an identical SHA). Identities land in build/fixture-identity.json.
+set -euo pipefail
+
+PINNED_SHA=03b6b6dd8cfb3d3b90094530d7b2d10439fe0a48
+IMAGE_TAG="horizon-bench:${PINNED_SHA:0:8}"
+EXP_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+BUILD_DIR="${BUILD_DIR:-$EXP_DIR/build}"
+SRC_DIR="$BUILD_DIR/opennms"
+IDENTITY="$BUILD_DIR/fixture-identity.json"
+
+mkdir -p "$BUILD_DIR"
+
+if [ -f "$IDENTITY" ]; then
+  echo "HORIZON_IMAGE=$(jq -r '.image' "$IDENTITY")" > "$EXP_DIR/.env"
+  echo "fixture-identity.json exists — fixture already built, reusing (task 1.4):"
+  cat "$IDENTITY"
+  exit 0
+fi
+
+# --- 1.1 pinned checkout + toolchain record ---------------------------------
+if [ ! -d "$SRC_DIR/.git" ]; then
+  git clone https://github.com/OpenNMS/opennms "$SRC_DIR"
+fi
+git -C "$SRC_DIR" fetch origin "$PINNED_SHA"
+git -C "$SRC_DIR" checkout --detach "$PINNED_SHA"
+
+JAVA_VERSION="$(java -version 2>&1 | head -1)"
+MVN_VERSION="$( (cd "$SRC_DIR" && ./mvnw --version 2>/dev/null || mvn --version) | head -1)"
+echo "toolchain: $JAVA_VERSION / $MVN_VERSION"
+
+# --- 1.2 assembly tarball ----------------------------------------------------
+# Exact invocation is defined by the checked-out branch (README/.circleci) —
+# historically ./compile.pl then ./assemble.pl. Verify there before trusting this.
+TARBALL="$(ls "$SRC_DIR"/opennms-full-assembly/target/*.tar.gz 2>/dev/null | head -1 || true)"
+if [ -z "$TARBALL" ]; then
+  (cd "$SRC_DIR" && ./compile.pl && ./assemble.pl -Dopennms.home=/opt/opennms)
+  TARBALL="$(ls "$SRC_DIR"/opennms-full-assembly/target/*.tar.gz | head -1)"
+fi
+TARBALL_SHA256="$(shasum -a 256 "$TARBALL" | awk '{print $1}')"
+echo "tarball: $TARBALL ($TARBALL_SHA256)"
+
+# --- 1.3 container image from the tarball ------------------------------------
+docker build -t "$IMAGE_TAG" "$SRC_DIR/opennms-container/core"
+IMAGE_DIGEST="$(docker inspect --format '{{.Id}}' "$IMAGE_TAG")"
+
+# --- record identities (feeds every run manifest) -----------------------------
+jq -n \
+  --arg sha "$PINNED_SHA" \
+  --arg tarball "$(basename "$TARBALL")" \
+  --arg tarball_sha256 "$TARBALL_SHA256" \
+  --arg image "$IMAGE_TAG" \
+  --arg image_digest "$IMAGE_DIGEST" \
+  --arg java "$JAVA_VERSION" \
+  --arg maven "$MVN_VERSION" \
+  '{git_sha: $sha, tarball: $tarball, tarball_sha256: $tarball_sha256,
+    image: $image, image_digest: $image_digest,
+    toolchain: {java: $java, maven: $maven}}' > "$IDENTITY"
+
+echo "HORIZON_IMAGE=$IMAGE_TAG" > "$EXP_DIR/.env"
+
+echo "fixture built once — identity:"
+cat "$IDENTITY"

--- a/experiments/nms-20027-painless-flows/bin/build-sut.sh
+++ b/experiments/nms-20027-painless-flows/bin/build-sut.sh
@@ -37,10 +37,20 @@ echo "toolchain: $JAVA_VERSION / $MVN_VERSION"
 # --- 1.2 assembly tarball ----------------------------------------------------
 # Exact invocation is defined by the checked-out branch (README/.circleci) —
 # historically ./compile.pl then ./assemble.pl. Verify there before trusting this.
+# A tarball is only reused when the marker ties it to the pinned SHA — a
+# leftover from an interrupted or different-SHA build is discarded, never
+# silently baked into the fixture.
+MARKER="$SRC_DIR/opennms-full-assembly/target/.built-from-sha"
 TARBALL="$(ls "$SRC_DIR"/opennms-full-assembly/target/*.tar.gz 2>/dev/null | head -1 || true)"
+if [ -n "$TARBALL" ] && [ "$(cat "$MARKER" 2>/dev/null || true)" != "$PINNED_SHA" ]; then
+  echo "discarding stale tarball not tied to $PINNED_SHA: $TARBALL"
+  rm -f "$SRC_DIR"/opennms-full-assembly/target/*.tar.gz "$MARKER"
+  TARBALL=""
+fi
 if [ -z "$TARBALL" ]; then
   (cd "$SRC_DIR" && ./compile.pl && ./assemble.pl -Dopennms.home=/opt/opennms)
   TARBALL="$(ls "$SRC_DIR"/opennms-full-assembly/target/*.tar.gz | head -1)"
+  echo "$PINNED_SHA" > "$MARKER"
 fi
 TARBALL_SHA256="$(shasum -a 256 "$TARBALL" | awk '{print $1}')"
 echo "tarball: $TARBALL ($TARBALL_SHA256)"

--- a/experiments/nms-20027-painless-flows/bin/build-sut.sh
+++ b/experiments/nms-20027-painless-flows/bin/build-sut.sh
@@ -51,13 +51,15 @@ echo "toolchain: $JAVA_VERSION / $MVN_VERSION"
 # leftover from an interrupted or different-SHA build is discarded, never
 # silently baked into the fixture.
 MARKER="$SRC_DIR/opennms-full-assembly/target/.built-from-sha"
+# The assembly emits a core + an optional tarball; opennms-container/core
+# consumes the CORE one. Anything other than exactly one core tarball aborts.
 pick_tarball() {
   local list count
-  list="$(ls "$SRC_DIR"/opennms-full-assembly/target/*.tar.gz 2>/dev/null || true)"
+  list="$(ls "$SRC_DIR"/opennms-full-assembly/target/*-core.tar.gz 2>/dev/null || true)"
   count="$(printf '%s' "$list" | grep -c . || true)"
   if [ "$count" -gt 1 ]; then
-    echo "ABORT: multiple tarballs in opennms-full-assembly/target — the fixture" >&2
-    echo "identity would be ambiguous. Remove all but the core assembly tarball:" >&2
+    echo "ABORT: multiple *-core.tar.gz in opennms-full-assembly/target — the" >&2
+    echo "fixture identity would be ambiguous. Remove all but one:" >&2
     printf '%s\n' "$list" >&2
     exit 1
   fi

--- a/experiments/nms-20027-painless-flows/bin/build-sut.sh
+++ b/experiments/nms-20027-painless-flows/bin/build-sut.sh
@@ -17,10 +17,15 @@ IDENTITY="$BUILD_DIR/fixture-identity.json"
 mkdir -p "$BUILD_DIR"
 
 if [ -f "$IDENTITY" ]; then
-  echo "HORIZON_IMAGE=$(jq -r '.image' "$IDENTITY")" > "$EXP_DIR/.env"
-  echo "fixture-identity.json exists — fixture already built, reusing (task 1.4):"
-  cat "$IDENTITY"
-  exit 0
+  IDENTITY_SHA="$(jq -r '.git_sha' "$IDENTITY")"
+  if [ "$IDENTITY_SHA" = "$PINNED_SHA" ]; then
+    echo "HORIZON_IMAGE=$(jq -r '.image' "$IDENTITY")" > "$EXP_DIR/.env"
+    echo "fixture-identity.json matches $PINNED_SHA — fixture already built, reusing (task 1.4):"
+    cat "$IDENTITY"
+    exit 0
+  fi
+  echo "fixture-identity.json is for $IDENTITY_SHA, not $PINNED_SHA — rebuilding"
+  rm -f "$IDENTITY"
 fi
 
 # --- 1.1 pinned checkout + toolchain record ---------------------------------
@@ -29,6 +34,11 @@ if [ ! -d "$SRC_DIR/.git" ]; then
 fi
 git -C "$SRC_DIR" fetch origin "$PINNED_SHA"
 git -C "$SRC_DIR" checkout --detach "$PINNED_SHA"
+if [ -n "$(git -C "$SRC_DIR" status --porcelain)" ]; then
+  echo "ABORT: source tree has local modifications — a tarball built from it would" >&2
+  echo "carry uncommitted changes while the manifest certifies $PINNED_SHA." >&2
+  exit 1
+fi
 
 JAVA_VERSION="$(java -version 2>&1 | head -1)"
 MVN_VERSION="$( (cd "$SRC_DIR" && ./mvnw --version 2>/dev/null || mvn --version) | head -1)"
@@ -41,7 +51,19 @@ echo "toolchain: $JAVA_VERSION / $MVN_VERSION"
 # leftover from an interrupted or different-SHA build is discarded, never
 # silently baked into the fixture.
 MARKER="$SRC_DIR/opennms-full-assembly/target/.built-from-sha"
-TARBALL="$(ls "$SRC_DIR"/opennms-full-assembly/target/*.tar.gz 2>/dev/null | head -1 || true)"
+pick_tarball() {
+  local list count
+  list="$(ls "$SRC_DIR"/opennms-full-assembly/target/*.tar.gz 2>/dev/null || true)"
+  count="$(printf '%s' "$list" | grep -c . || true)"
+  if [ "$count" -gt 1 ]; then
+    echo "ABORT: multiple tarballs in opennms-full-assembly/target — the fixture" >&2
+    echo "identity would be ambiguous. Remove all but the core assembly tarball:" >&2
+    printf '%s\n' "$list" >&2
+    exit 1
+  fi
+  printf '%s' "$list"
+}
+TARBALL="$(pick_tarball)"
 if [ -n "$TARBALL" ] && [ "$(cat "$MARKER" 2>/dev/null || true)" != "$PINNED_SHA" ]; then
   echo "discarding stale tarball not tied to $PINNED_SHA: $TARBALL"
   rm -f "$SRC_DIR"/opennms-full-assembly/target/*.tar.gz "$MARKER"
@@ -49,7 +71,8 @@ if [ -n "$TARBALL" ] && [ "$(cat "$MARKER" 2>/dev/null || true)" != "$PINNED_SHA
 fi
 if [ -z "$TARBALL" ]; then
   (cd "$SRC_DIR" && ./compile.pl && ./assemble.pl -Dopennms.home=/opt/opennms)
-  TARBALL="$(ls "$SRC_DIR"/opennms-full-assembly/target/*.tar.gz | head -1)"
+  TARBALL="$(pick_tarball)"
+  [ -n "$TARBALL" ] || { echo "ABORT: assembly produced no tarball" >&2; exit 1; }
   echo "$PINNED_SHA" > "$MARKER"
 fi
 TARBALL_SHA256="$(shasum -a 256 "$TARBALL" | awk '{print $1}')"

--- a/experiments/nms-20027-painless-flows/bin/build-sut.sh
+++ b/experiments/nms-20027-painless-flows/bin/build-sut.sh
@@ -70,7 +70,10 @@ if [ -n "$TARBALL" ] && [ "$(cat "$MARKER" 2>/dev/null || true)" != "$PINNED_SHA
   TARBALL=""
 fi
 if [ -z "$TARBALL" ]; then
-  (cd "$SRC_DIR" && ./compile.pl && ./assemble.pl -Dopennms.home=/opt/opennms)
+  # -DskipTests=true: unit tests don't change the artifact, and the shell-test
+  # harness (core/cli run-tests.sh) exits 1 on macOS even when all tests pass.
+  (cd "$SRC_DIR" && ./compile.pl -DskipTests=true \
+    && ./assemble.pl -DskipTests=true -Dopennms.home=/opt/opennms)
   TARBALL="$(pick_tarball)"
   [ -n "$TARBALL" ] || { echo "ABORT: assembly produced no tarball" >&2; exit 1; }
   echo "$PINNED_SHA" > "$MARKER"

--- a/experiments/nms-20027-painless-flows/bin/build-sut.sh
+++ b/experiments/nms-20027-painless-flows/bin/build-sut.sh
@@ -84,7 +84,13 @@ TARBALL_SHA256="$(shasum -a 256 "$TARBALL" | awk '{print $1}')"
 echo "tarball: $TARBALL ($TARBALL_SHA256)"
 
 # --- 1.3 container image from the tarball ------------------------------------
-docker build -t "$IMAGE_TAG" "$SRC_DIR/opennms-container/core"
+# Upstream recipe: `make image` sanity-checks the tarball, unpacks it into
+# tarball-root/, and drives docker buildx with the branch's build args.
+# It requires the DEFAULT buildx builder to be active and tags the result
+# opennms/horizon:<pom-version>; we retag to our pinned fixture tag.
+UPSTREAM_VERSION="$("$SRC_DIR/.circleci/scripts/pom2version.sh" "$SRC_DIR/pom.xml")"
+make -C "$SRC_DIR/opennms-container/core" image
+docker image tag "opennms/horizon:$UPSTREAM_VERSION" "$IMAGE_TAG"
 IMAGE_DIGEST="$(docker inspect --format '{{.Id}}' "$IMAGE_TAG")"
 
 # --- record identities (feeds every run manifest) -----------------------------

--- a/experiments/nms-20027-painless-flows/bin/emit-manifest.sh
+++ b/experiments/nms-20027-painless-flows/bin/emit-manifest.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: Apache-2.0
+#
+# Task 4.6: emit one run manifest per variant from RUN-TIME probes (never
+# backfilled — a run without a run-time manifest is rerun, not patched), then
+# validate against run-manifest.schema.json. IV: sut.config_delta.
+set -euo pipefail
+
+VARIANT="${VARIANT:?set VARIANT=variant-b-plugin or variant-c-painless}"
+BASE_URL="${BASE_URL:-http://localhost:8980/opennms}"
+ES_URL="${ES_URL:-http://localhost:9200}"
+EXP_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+IDENTITY="$EXP_DIR/build/fixture-identity.json"
+CORPUS="$EXP_DIR/build/corpus-identity.json"       # written after seed reconciliation (task 3.4)
+OUT="$EXP_DIR/results/$VARIANT/run-manifest.json"
+HORIZON_CTR="$(docker compose -f "$EXP_DIR/compose.yml" ps -q horizon)"
+
+[ -f "$IDENTITY" ] || { echo "missing $IDENTITY — run bin/build-sut.sh first" >&2; exit 1; }
+[ -f "$CORPUS" ]   || { echo "missing $CORPUS — seed + reconcile first (tasks 3.x)" >&2; exit 1; }
+
+# --- run-time probes (measure.md table) --------------------------------------
+VERSION="$(curl -su admin:admin "$BASE_URL/rest/info" | jq -r '.displayVersion // .version')"
+JVM_CMDLINE="$(docker exec "$HORIZON_CTR" sh -c "ps -o args= -p 1 || cat /proc/1/cmdline | tr '\0' ' '")"
+JVM_VERSION="$(docker exec "$HORIZON_CTR" java -version 2>&1 | head -1)"
+# Heap/GC derived from the RUNNING process, never from config files (measure.md).
+JVM_HEAP="$(grep -oE '\-Xms[^ ]+ \-Xmx[^ ]+' <<<"$JVM_CMDLINE" || echo 'PROBE FAILED — rerun, do not backfill')"
+JVM_GC="$(grep -oE '\-XX:\+Use[A-Za-z0-9]+GC' <<<"$JVM_CMDLINE" | head -1 || echo 'PROBE FAILED — rerun, do not backfill')"
+# ES + drift plugin are declared controls with a documented fallback pair —
+# record them so a mid-experiment fallback swap cannot pass the gate unnoticed.
+ES_VERSION="$(curl -sf "$ES_URL/" | jq -r '.version.number')"
+ES_PLUGINS="$(curl -sf "$ES_URL/_cat/plugins?h=component,version" | sort | tr '\n' ';')"
+DB_VERSION="$(docker exec "$(docker compose -f "$EXP_DIR/compose.yml" ps -q database)" \
+  psql -U postgres -tAc 'SELECT version()')"
+TSS_BACKEND="$(docker exec "$HORIZON_CTR" sh -c \
+  "grep -h '^org.opennms.timeseries.strategy' /opt/opennms/etc/opennms.properties* 2>/dev/null | tail -1" \
+  || echo 'org.opennms.timeseries.strategy=rrd (default)')"
+CONFIG_DELTA="overlay $VARIANT: $(shasum -a 256 "$EXP_DIR/variants/$VARIANT/org.opennms.features.flows.persistence.elastic.cfg" | awk '{print $1}') proportionalSumStrategy=$(grep -o 'proportionalSumStrategy=.*' "$EXP_DIR/variants/$VARIANT/org.opennms.features.flows.persistence.elastic.cfg")"
+
+case "$(uname)" in
+  Darwin) CPU="$(sysctl -n machdep.cpu.brand_string) ($(sysctl -n hw.ncpu) cores)"
+          RAM_GB=$(( $(sysctl -n hw.memsize) / 1073741824 ));;
+  *)      CPU="$(lscpu | awk -F': +' '/Model name/{print $2}') ($(nproc) cores)"
+          RAM_GB=$(( $(awk '/MemTotal/{print $2}' /proc/meminfo) / 1048576 ));;
+esac
+
+NL6_VERSION="$(docker inspect --format '{{index .RepoDigests 0}}' \
+  "$(docker compose -f "$EXP_DIR/compose.yml" ps -q nl6 2>/dev/null || true)" 2>/dev/null \
+  || echo 'nl6 not running — copy generator_version from the seed record')"
+
+jq -n \
+  --arg variant "$VARIANT" \
+  --arg version "$VERSION" \
+  --arg jvm_version "$JVM_VERSION" \
+  --arg jvm_cmdline "$JVM_CMDLINE" \
+  --arg jvm_heap "$JVM_HEAP" \
+  --arg jvm_gc "$JVM_GC" \
+  --arg es_version "$ES_VERSION" \
+  --arg es_plugins "$ES_PLUGINS" \
+  --arg db "$DB_VERSION" \
+  --arg tss "$TSS_BACKEND" \
+  --arg config_delta "$CONFIG_DELTA" \
+  --arg cpu "$CPU" --argjson ram "$RAM_GB" --arg os "$(uname -srm)" \
+  --arg nl6 "$NL6_VERSION" \
+  --arg started "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  --slurpfile fixture "$IDENTITY" \
+  --slurpfile corpus "$CORPUS" \
+  '{
+    experiment: {
+      question: "Does replacing the elasticsearch-drift-plugin proportional_sum aggregation with inline Painless scripts (PR #8638 / NMS-20027) regress netflow query performance?",
+      independent_variable: "sut.config_delta",
+      variant: $variant
+    },
+    sut: {
+      version_identity: { version: $version, git_sha: $fixture[0].git_sha,
+                          image_digest: $fixture[0].image_digest,
+                          tarball_sha256: $fixture[0].tarball_sha256 },
+      jvm: { version: $jvm_version,
+             heap: $jvm_heap, gc: $jvm_gc, flags: $jvm_cmdline },
+      elasticsearch: { version: $es_version, plugins: $es_plugins },
+      db_version: $db,
+      tss_backend: $tss,
+      config_delta: $config_delta,
+      provisioner: "container-branch"
+    },
+    host: { cpu: $cpu, ram_gb: $ram, disk: "nvme (laptop)", os: $os,
+            generator_colocated: true,
+            hygiene_notes: "laptop scope: governor/turbo not pinned; relative A/B only" },
+    workload: {
+      axis: "rest-ui",
+      generator_scenario: "queries/queries.json (6 trials x dense+sparse, fixed order, trial 1 discarded)",
+      generator_version: "curl (trial runner) / seed: \($nl6)",
+      parameters: { trials: 6, shapes: ["dense", "sparse"], warmup_discarded: 1 },
+      fixtures: [
+        { name: "sut-image", identity: $fixture[0].image_digest },
+        { name: "assembly-tarball", identity: $fixture[0].tarball_sha256 },
+        { name: "flow-corpus", identity: ($corpus[0] | tostring) }
+      ]
+    },
+    run: { id: "\($variant)-\($started)", started_at: $started },
+    comparability_key: [
+      "sut.version_identity",
+      "sut.jvm.heap",
+      "sut.jvm.gc",
+      "sut.elasticsearch",
+      "sut.db_version",
+      "sut.tss_backend",
+      "sut.config_delta",
+      "host.cpu",
+      "host.ram_gb",
+      "host.disk",
+      "host.generator_colocated",
+      "workload.axis",
+      "workload.generator_scenario",
+      "workload.generator_version",
+      "workload.parameters",
+      "workload.fixtures"
+    ]
+  }' > "$OUT"
+
+npx --yes ajv-cli validate --spec=draft2020 \
+  -s "$EXP_DIR/run-manifest.schema.json" -d "$OUT"
+echo "manifest emitted + validated: $OUT"

--- a/experiments/nms-20027-painless-flows/bin/emit-manifest.sh
+++ b/experiments/nms-20027-painless-flows/bin/emit-manifest.sh
@@ -44,12 +44,21 @@ DB_VERSION="$(docker exec "$(docker compose -f "$EXP_DIR/compose.yml" ps -q data
 TSS_BACKEND="$(docker exec "$HORIZON_CTR" sh -c \
   "grep -h '^org.opennms.timeseries.strategy' /opt/opennms/etc/opennms.properties* 2>/dev/null | tail -1" \
   || echo 'org.opennms.timeseries.strategy=rrd (default)')"
-# Hash the WHOLE overlay dir (README: everything mounted is the config_delta),
-# so a stray difference in any added control file fails the gate.
+# The IV is ONLY the proportionalSumStrategy line; it goes into config_delta,
+# which the gate exempts as the declared IV. Everything ELSE in the overlay is
+# a control, so its hash lives in sut.overlay_sha — a gated comparability path
+# (an exempted config_delta could never catch a stray control-file difference).
+# The hash strips the IV line, so byte-identical controls give the SAME sha on
+# both variants: dotfiles excluded, C collation, filenames included.
 OVERLAY_DIR="$EXP_DIR/variants/$VARIANT"
-OVERLAY_SHA="$(cd "$OVERLAY_DIR" && find . -type f | sort | xargs shasum -a 256 | shasum -a 256 | awk '{print $1}')"
-STRATEGY="$(grep -o 'proportionalSumStrategy=.*' "$OVERLAY_DIR/org.opennms.features.flows.persistence.elastic.cfg")"
-CONFIG_DELTA="overlay $VARIANT (all files): $OVERLAY_SHA $STRATEGY"
+STRATEGY="$(grep -o 'proportionalSumStrategy=.*' \
+  "$OVERLAY_DIR/org.opennms.features.flows.persistence.elastic.cfg")"
+OVERLAY_SHA="$(cd "$OVERLAY_DIR" && LC_ALL=C find . -type f -not -name '.*' | LC_ALL=C sort | \
+  while read -r f; do
+    printf '== %s\n' "$f"
+    grep -v '^proportionalSumStrategy=' "$f" || true
+  done | shasum -a 256 | awk '{print $1}')"
+CONFIG_DELTA="overlay $VARIANT: $STRATEGY"
 
 case "$(uname)" in
   Darwin) CPU="$(sysctl -n machdep.cpu.brand_string) ($(sysctl -n hw.ncpu) cores)"
@@ -74,6 +83,7 @@ jq -n \
   --arg db "$DB_VERSION" \
   --arg tss "$TSS_BACKEND" \
   --arg config_delta "$CONFIG_DELTA" \
+  --arg overlay_sha "$OVERLAY_SHA" \
   --arg cpu "$CPU" --argjson ram "$RAM_GB" --arg os "$(uname -srm)" \
   --arg nl6 "$NL6_VERSION" \
   --arg started "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
@@ -96,6 +106,7 @@ jq -n \
       db_version: $db,
       tss_backend: $tss,
       config_delta: $config_delta,
+      overlay_sha: $overlay_sha,
       provisioner: "container-branch"
     },
     host: { cpu: $cpu, ram_gb: $ram, disk: "nvme (laptop)", os: $os,
@@ -121,6 +132,7 @@ jq -n \
       "sut.db_version",
       "sut.tss_backend",
       "sut.config_delta",
+      "sut.overlay_sha",
       "host.cpu",
       "host.ram_gb",
       "host.disk",

--- a/experiments/nms-20027-painless-flows/bin/emit-manifest.sh
+++ b/experiments/nms-20027-painless-flows/bin/emit-manifest.sh
@@ -13,19 +13,28 @@ ES_URL="${ES_URL:-http://localhost:9200}"
 EXP_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 IDENTITY="$EXP_DIR/build/fixture-identity.json"
 CORPUS="$EXP_DIR/build/corpus-identity.json"       # written after seed reconciliation (task 3.4)
+PARAMS="$EXP_DIR/results/$VARIANT/trial-params.json"  # written by run-trials.sh on a valid block
 OUT="$EXP_DIR/results/$VARIANT/run-manifest.json"
 HORIZON_CTR="$(docker compose -f "$EXP_DIR/compose.yml" ps -q horizon)"
 
 [ -f "$IDENTITY" ] || { echo "missing $IDENTITY — run bin/build-sut.sh first" >&2; exit 1; }
 [ -f "$CORPUS" ]   || { echo "missing $CORPUS — seed + reconcile first (tasks 3.x)" >&2; exit 1; }
+[ -f "$PARAMS" ]   || { echo "missing $PARAMS — run bin/run-trials.sh for $VARIANT first" >&2; exit 1; }
 
 # --- run-time probes (measure.md table) --------------------------------------
 VERSION="$(curl -su admin:admin "$BASE_URL/rest/info" | jq -r '.displayVersion // .version')"
 JVM_CMDLINE="$(docker exec "$HORIZON_CTR" sh -c "ps -o args= -p 1 || cat /proc/1/cmdline | tr '\0' ' '")"
 JVM_VERSION="$(docker exec "$HORIZON_CTR" java -version 2>&1 | head -1)"
 # Heap/GC derived from the RUNNING process, never from config files (measure.md).
-JVM_HEAP="$(grep -oE '\-Xms[^ ]+ \-Xmx[^ ]+' <<<"$JVM_CMDLINE" || echo 'PROBE FAILED — rerun, do not backfill')"
-JVM_GC="$(grep -oE '\-XX:\+Use[A-Za-z0-9]+GC' <<<"$JVM_CMDLINE" | head -1 || echo 'PROBE FAILED — rerun, do not backfill')"
+# A failed probe ABORTS: a sentinel value would compare equal across variants
+# and pass the comparability gate on a control it never verified.
+JVM_HEAP="$(grep -oE '\-Xms[^ ]+ \-Xmx[^ ]+' <<<"$JVM_CMDLINE" || true)"
+JVM_GC="$(grep -oE '\-XX:\+Use[A-Za-z0-9]+GC' <<<"$JVM_CMDLINE" | head -1 || true)"
+if [ -z "$JVM_HEAP" ] || [ -z "$JVM_GC" ]; then
+  echo "ABORT: heap/GC probe failed on running cmdline: $JVM_CMDLINE" >&2
+  echo "Fix the probe or the SUT and re-emit — never backfill." >&2
+  exit 1
+fi
 # ES + drift plugin are declared controls with a documented fallback pair —
 # record them so a mid-experiment fallback swap cannot pass the gate unnoticed.
 ES_VERSION="$(curl -sf "$ES_URL/" | jq -r '.version.number')"
@@ -35,7 +44,12 @@ DB_VERSION="$(docker exec "$(docker compose -f "$EXP_DIR/compose.yml" ps -q data
 TSS_BACKEND="$(docker exec "$HORIZON_CTR" sh -c \
   "grep -h '^org.opennms.timeseries.strategy' /opt/opennms/etc/opennms.properties* 2>/dev/null | tail -1" \
   || echo 'org.opennms.timeseries.strategy=rrd (default)')"
-CONFIG_DELTA="overlay $VARIANT: $(shasum -a 256 "$EXP_DIR/variants/$VARIANT/org.opennms.features.flows.persistence.elastic.cfg" | awk '{print $1}') proportionalSumStrategy=$(grep -o 'proportionalSumStrategy=.*' "$EXP_DIR/variants/$VARIANT/org.opennms.features.flows.persistence.elastic.cfg")"
+# Hash the WHOLE overlay dir (README: everything mounted is the config_delta),
+# so a stray difference in any added control file fails the gate.
+OVERLAY_DIR="$EXP_DIR/variants/$VARIANT"
+OVERLAY_SHA="$(cd "$OVERLAY_DIR" && find . -type f | sort | xargs shasum -a 256 | shasum -a 256 | awk '{print $1}')"
+STRATEGY="$(grep -o 'proportionalSumStrategy=.*' "$OVERLAY_DIR/org.opennms.features.flows.persistence.elastic.cfg")"
+CONFIG_DELTA="overlay $VARIANT (all files): $OVERLAY_SHA $STRATEGY"
 
 case "$(uname)" in
   Darwin) CPU="$(sysctl -n machdep.cpu.brand_string) ($(sysctl -n hw.ncpu) cores)"
@@ -65,6 +79,7 @@ jq -n \
   --arg started "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
   --slurpfile fixture "$IDENTITY" \
   --slurpfile corpus "$CORPUS" \
+  --slurpfile params "$PARAMS" \
   '{
     experiment: {
       question: "Does replacing the elasticsearch-drift-plugin proportional_sum aggregation with inline Painless scripts (PR #8638 / NMS-20027) regress netflow query performance?",
@@ -88,9 +103,9 @@ jq -n \
             hygiene_notes: "laptop scope: governor/turbo not pinned; relative A/B only" },
     workload: {
       axis: "rest-ui",
-      generator_scenario: "queries/queries.json (6 trials x dense+sparse, fixed order, trial 1 discarded)",
+      generator_scenario: "queries/queries.json (fixed order, trial 1 discarded)",
       generator_version: "curl (trial runner) / seed: \($nl6)",
-      parameters: { trials: 6, shapes: ["dense", "sparse"], warmup_discarded: 1 },
+      parameters: $params[0],
       fixtures: [
         { name: "sut-image", identity: $fixture[0].image_digest },
         { name: "assembly-tarball", identity: $fixture[0].tarball_sha256 },

--- a/experiments/nms-20027-painless-flows/bin/run-trials.sh
+++ b/experiments/nms-20027-painless-flows/bin/run-trials.sh
@@ -18,8 +18,12 @@ TRIALS="${TRIALS:-6}"
 
 EXP_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 QUERIES="$EXP_DIR/queries/queries.json"
+CORPUS_ID="$EXP_DIR/build/corpus-identity.json"
 OUT="$EXP_DIR/results/$VARIANT"
 mkdir -p "$OUT"
+
+[ -f "$CORPUS_ID" ] || { echo "missing $CORPUS_ID — seed + reconcile first (tasks 3.x)" >&2; exit 1; }
+EXPECTED_COUNT="$(jq -r '.doc_count' "$CORPUS_ID")"
 
 T0="$WINDOW_START"
 T1="$WINDOW_END"
@@ -30,7 +34,11 @@ doc_count() { curl -sf "$ES_URL/netflow-*/_count" | jq -r '.count'; }
 
 PRE_COUNT="$(doc_count)"
 echo "$PRE_COUNT" > "$OUT/doc-count.pre"
-echo "corpus doc count (pre): $PRE_COUNT"
+if [ "$PRE_COUNT" != "$EXPECTED_COUNT" ]; then
+  echo "ABORT: corpus doc count $PRE_COUNT != seeded count $EXPECTED_COUNT (corpus-identity.json) — corpus lost or mutated" >&2
+  exit 1
+fi
+echo "corpus doc count (pre): $PRE_COUNT (matches seeded identity)"
 
 jq -c '.queries[]' "$QUERIES" | while read -r q; do
   shape="$(jq -r '.shape' <<<"$q")"
@@ -67,4 +75,13 @@ if [ "$PRE_COUNT" != "$POST_COUNT" ]; then
   echo "ABORT: corpus mutated during trials ($PRE_COUNT -> $POST_COUNT) — block results are invalid" >&2
   exit 1
 fi
+
+# Run record of what ACTUALLY executed — emit-manifest.sh embeds this as
+# workload.parameters so mismatched windows/trial counts fail the gate.
+jq -n --argjson trials "$TRIALS" \
+      --argjson window_start_ms "$T0" --argjson window_end_ms "$T1" \
+      --argjson shapes "$(jq '[.queries[].shape] | unique' "$QUERIES")" \
+  '{trials: $trials, window_start_ms: $window_start_ms, window_end_ms: $window_end_ms,
+    shapes: $shapes, warmup_discarded: 1}' > "$OUT/trial-params.json"
+
 echo "corpus doc count stable ($POST_COUNT) — block valid, results in $OUT"

--- a/experiments/nms-20027-painless-flows/bin/run-trials.sh
+++ b/experiments/nms-20027-painless-flows/bin/run-trials.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: Apache-2.0
+#
+# Task 4.2: trial runner. 6 trials x 2 shapes in the fixed order of
+# queries/queries.json; every raw response persisted (status/body/timing) keyed
+# by variant/shape/trial. Doc-count guard before/after the block aborts on any
+# corpus mutation (spec: corpus-seed). Trial 1 is warmup — persisted but marked
+# discarded; statistics use trials 2-6 only (computed later, task 5.1).
+set -euo pipefail
+
+VARIANT="${VARIANT:?set VARIANT=variant-b-plugin or variant-c-painless}"
+WINDOW_START="${WINDOW_START:?seed window start, epoch ms}"
+WINDOW_END="${WINDOW_END:?seed window end, epoch ms}"
+BASE_URL="${BASE_URL:-http://localhost:8980/opennms}"
+ES_URL="${ES_URL:-http://localhost:9200}"
+TRIALS="${TRIALS:-6}"
+
+EXP_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+QUERIES="$EXP_DIR/queries/queries.json"
+OUT="$EXP_DIR/results/$VARIANT"
+mkdir -p "$OUT"
+
+T0="$WINDOW_START"
+T1="$WINDOW_END"
+T0_PLUS_1H=$((T0 + 3600000))
+STEP_DENSE=$(( (T1 - T0) / 288 ))
+
+doc_count() { curl -sf "$ES_URL/netflow-*/_count" | jq -r '.count'; }
+
+PRE_COUNT="$(doc_count)"
+echo "$PRE_COUNT" > "$OUT/doc-count.pre"
+echo "corpus doc count (pre): $PRE_COUNT"
+
+jq -c '.queries[]' "$QUERIES" | while read -r q; do
+  shape="$(jq -r '.shape' <<<"$q")"
+  name="$(jq -r '.name' <<<"$q")"
+  path="$(jq -r '.path' <<<"$q")"
+  path="${path//\$\{T0\}/$T0}"
+  path="${path//\$\{T1\}/$T1}"
+  path="${path//\$\{T0_PLUS_1H\}/$T0_PLUS_1H}"
+  path="${path//\$\{STEP_DENSE\}/$STEP_DENSE}"
+
+  qdir="$OUT/$shape/$name"
+  mkdir -p "$qdir"
+  for trial in $(seq 1 "$TRIALS"); do
+    body="$qdir/trial-$trial.body.json"
+    status_time="$(curl -su admin:admin -o "$body" \
+      -w '%{http_code} %{time_total}' "$BASE_URL$path")"
+    status="${status_time% *}"
+    time_total="${status_time#* }"
+    [ "$status" = "200" ] || { echo "ABORT: $name trial $trial returned HTTP $status" >&2; exit 1; }
+    jq -n --arg variant "$VARIANT" --arg shape "$shape" --arg name "$name" \
+          --arg path "$path" --argjson trial "$trial" \
+          --argjson status "$status" --argjson time_total_s "$time_total" \
+          --argjson discarded "$([ "$trial" -eq 1 ] && echo true || echo false)" \
+      '{variant:$variant, shape:$shape, name:$name, path:$path, trial:$trial,
+        status:$status, time_total_s:$time_total_s, warmup_discarded:$discarded}' \
+      > "$qdir/trial-$trial.meta.json"
+    echo "$VARIANT $shape/$name trial $trial: ${time_total}s"
+  done
+done
+
+POST_COUNT="$(doc_count)"
+echo "$POST_COUNT" > "$OUT/doc-count.post"
+if [ "$PRE_COUNT" != "$POST_COUNT" ]; then
+  echo "ABORT: corpus mutated during trials ($PRE_COUNT -> $POST_COUNT) — block results are invalid" >&2
+  exit 1
+fi
+echo "corpus doc count stable ($POST_COUNT) — block valid, results in $OUT"

--- a/experiments/nms-20027-painless-flows/bin/run-trials.sh
+++ b/experiments/nms-20027-painless-flows/bin/run-trials.sh
@@ -10,8 +10,6 @@
 set -euo pipefail
 
 VARIANT="${VARIANT:?set VARIANT=variant-b-plugin or variant-c-painless}"
-WINDOW_START="${WINDOW_START:?seed window start, epoch ms}"
-WINDOW_END="${WINDOW_END:?seed window end, epoch ms}"
 BASE_URL="${BASE_URL:-http://localhost:8980/opennms}"
 ES_URL="${ES_URL:-http://localhost:9200}"
 TRIALS="${TRIALS:-6}"
@@ -23,10 +21,22 @@ OUT="$EXP_DIR/results/$VARIANT"
 mkdir -p "$OUT"
 
 [ -f "$CORPUS_ID" ] || { echo "missing $CORPUS_ID — seed + reconcile first (tasks 3.x)" >&2; exit 1; }
+# corpus-identity.json contract (written by the seed step, task 3.4 — see README):
+#   { "doc_count": <n>, "window_start_ms": <T0>, "window_end_ms": <T1> }
+# The query window comes from HERE, not from env — the seeded window is the
+# only window the corpus can answer for; a hand-typed one can silently miss it.
 EXPECTED_COUNT="$(jq -r '.doc_count' "$CORPUS_ID")"
+T0="$(jq -r '.window_start_ms' "$CORPUS_ID")"
+T1="$(jq -r '.window_end_ms' "$CORPUS_ID")"
+case "$EXPECTED_COUNT/$T0/$T1" in *null*)
+  echo "ABORT: $CORPUS_ID must contain doc_count, window_start_ms, window_end_ms (got: $(cat "$CORPUS_ID"))" >&2
+  exit 1;;
+esac
 
-T0="$WINDOW_START"
-T1="$WINDOW_END"
+# Never let a stale run record survive an aborted re-run of this variant.
+rm -f "$OUT/trial-params.json"
+QUERIES_SHA="$(shasum -a 256 "$QUERIES" | awk '{print $1}')"
+
 T0_PLUS_1H=$((T0 + 3600000))
 STEP_DENSE=$(( (T1 - T0) / 288 ))
 
@@ -81,7 +91,8 @@ fi
 jq -n --argjson trials "$TRIALS" \
       --argjson window_start_ms "$T0" --argjson window_end_ms "$T1" \
       --argjson shapes "$(jq '[.queries[].shape] | unique' "$QUERIES")" \
+      --arg queries_sha256 "$QUERIES_SHA" \
   '{trials: $trials, window_start_ms: $window_start_ms, window_end_ms: $window_end_ms,
-    shapes: $shapes, warmup_discarded: 1}' > "$OUT/trial-params.json"
+    shapes: $shapes, queries_sha256: $queries_sha256, warmup_discarded: 1}' > "$OUT/trial-params.json"
 
 echo "corpus doc count stable ($POST_COUNT) — block valid, results in $OUT"

--- a/experiments/nms-20027-painless-flows/compose.yml
+++ b/experiments/nms-20027-painless-flows/compose.yml
@@ -23,6 +23,7 @@ services:
     # Built once from PR #8638 by bin/build-sut.sh (shared-fixture rule), which
     # writes HORIZON_IMAGE into .env — the single source of truth for the tag.
     image: ${HORIZON_IMAGE:?run bin/build-sut.sh first — it writes HORIZON_IMAGE into .env}
+    command: ["-s"]    # init/update database + start (the image defaults to printing usage)
     depends_on:
       database:
         condition: service_healthy

--- a/experiments/nms-20027-painless-flows/compose.yml
+++ b/experiments/nms-20027-painless-flows/compose.yml
@@ -16,6 +16,8 @@ services:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 10s
       retries: 6
+    volumes:
+      - pgdata:/var/lib/postgresql/data
 
   horizon:
     # Built once from PR #8638 by bin/build-sut.sh (shared-fixture rule), which
@@ -54,6 +56,10 @@ services:
       test: ["CMD-SHELL", "curl -sf http://localhost:9200/_cluster/health || exit 1"]
       interval: 10s
       retries: 12
+    volumes:
+      # The 40M-flow corpus is a multi-hour fixture — it MUST survive container
+      # recreation. Only the intentional teardown (`down -v`) removes it.
+      - esdata:/usr/share/elasticsearch/data
     ports:
       - "9200:9200"    # doc-count guard + correctness-diff access
 
@@ -68,3 +74,7 @@ services:
       - /dev/net/tun
     volumes:
       - ./scenarios:/etc/nl6/scenarios:ro
+
+volumes:
+  esdata:
+  pgdata:

--- a/experiments/nms-20027-painless-flows/compose.yml
+++ b/experiments/nms-20027-painless-flows/compose.yml
@@ -65,9 +65,9 @@ services:
 
   nl6:
     # Seed generator (push telemetry only — no TUN routing needed for flows).
-    # TODO(task 3.1): pin a real release tag/digest before use; the placeholder
-    # fails `docker pull` on purpose. Record the digest as workload.generator_version.
-    image: ghcr.io/labmonkeys-space/nl6:TODO-pin-release
+    # Pinned by immutable digest (v0.17.0, released 2026-07-20, linux/amd64+arm64);
+    # emit-manifest records the RepoDigest as workload.generator_version.
+    image: ghcr.io/labmonkeys-space/nl6:v0.17.0@sha256:c1934b7997366d4c2d417d24e79486e88637d10ff34cdaffc9ce5d5af0195ab5
     cap_add:
       - NET_ADMIN
     devices:

--- a/experiments/nms-20027-painless-flows/compose.yml
+++ b/experiments/nms-20027-painless-flows/compose.yml
@@ -1,0 +1,70 @@
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: Apache-2.0
+#
+# NMS-20027 painless-vs-drift-plugin A/B stack (laptop-container scope).
+# Core + PostgreSQL + Elasticsearch + nl6 only — no Minion/Sentinel/Kafka.
+# Select the variant via VARIANT=variant-b-plugin | variant-c-painless.
+# Co-located layout: valid for relative A/B claims only (never absolute capacity).
+
+services:
+  database:
+    image: postgres:15.13            # pinned; recorded as sut.db_version in the manifest
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 10s
+      retries: 6
+
+  horizon:
+    # Built once from PR #8638 by bin/build-sut.sh (shared-fixture rule), which
+    # writes HORIZON_IMAGE into .env — the single source of truth for the tag.
+    image: ${HORIZON_IMAGE:?run bin/build-sut.sh first — it writes HORIZON_IMAGE into .env}
+    depends_on:
+      database:
+        condition: service_healthy
+      elasticsearch:
+        condition: service_healthy
+    environment:
+      TZ: UTC
+      POSTGRES_HOST: database
+      POSTGRES_PORT: 5432
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      # Pinned JVM controls (manifest: sut.jvm) — never rely on image defaults.
+      JAVA_OPTS: -Xms4g -Xmx4g -XX:+UseG1GC
+    volumes:
+      # The ONLY difference between variants is the proportionalSumStrategy line
+      # inside this overlay. Everything mounted here is the manifest's config_delta.
+      - ./variants/${VARIANT:?set VARIANT=variant-b-plugin or variant-c-painless}:/opt/opennms-etc-overlay:ro
+    ports:
+      - "8980:8980"    # base_url (REST/UI — the trial runner's target)
+      - "8101:8101"    # Karaf shell (measure vitals)
+
+  elasticsearch:
+    # ES 8.18.2 + drift plugin v2.0.7_es-8.18.2, identical for BOTH variants
+    # (plugin idle in variant C). Fallback pair: ES 7.17.13 + v2.0.5_es-7.17.13.
+    build: ./es
+    environment:
+      discovery.type: single-node
+      xpack.security.enabled: "false"
+      ES_JAVA_OPTS: -Xms4g -Xmx4g      # pinned control; scripted_metric runs here
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:9200/_cluster/health || exit 1"]
+      interval: 10s
+      retries: 12
+    ports:
+      - "9200:9200"    # doc-count guard + correctness-diff access
+
+  nl6:
+    # Seed generator (push telemetry only — no TUN routing needed for flows).
+    # TODO(task 3.1): pin a real release tag/digest before use; the placeholder
+    # fails `docker pull` on purpose. Record the digest as workload.generator_version.
+    image: ghcr.io/labmonkeys-space/nl6:TODO-pin-release
+    cap_add:
+      - NET_ADMIN
+    devices:
+      - /dev/net/tun
+    volumes:
+      - ./scenarios:/etc/nl6/scenarios:ro

--- a/experiments/nms-20027-painless-flows/es/Dockerfile
+++ b/experiments/nms-20027-painless-flows/es/Dockerfile
@@ -1,0 +1,13 @@
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: Apache-2.0
+#
+# Elasticsearch 8.18.2 with the OpenNMS drift plugin — used by BOTH variants
+# (idle in variant C) so the cluster is byte-identical across the A/B.
+# The plugin is version-locked: image and plugin MUST move together.
+# Fallback pair (if the PR build fails the ES 8.18.2 smoke check):
+#   FROM docker.elastic.co/elasticsearch/elasticsearch:7.17.13
+#   ...download/v2.0.5_es-7.17.13/elasticsearch-drift-plugin-7.17.13-2.0.5.zip
+FROM docker.elastic.co/elasticsearch/elasticsearch:8.18.2
+
+RUN bin/elasticsearch-plugin install --batch \
+    https://github.com/OpenNMS-Plugins/elasticsearch-drift-plugin/releases/download/v2.0.7_es-8.18.2/elasticsearch-drift-plugin-8.18.2-2.0.7.zip

--- a/experiments/nms-20027-painless-flows/queries/queries.json
+++ b/experiments/nms-20027-painless-flows/queries/queries.json
@@ -1,0 +1,11 @@
+{
+  "_comment": "Fixed query set (SPDX-License-Identifier: Apache-2.0 — JSON carries no header). Order is the trial order — do not reorder between variants. Tokens substituted by bin/run-trials.sh: T0/T1 = seed window bounds (epoch ms), T0_PLUS_1H = T0 + 3600000, STEP_DENSE = (T1-T0)/288 rounded to ms. dense = whole-window series (Painless dense path: scripted_metric WITH nBuckets); sparse = fine-grained sub-window (sparse path: WITHOUT nBuckets). Verify the shape->path mapping on variant C before timed trials (task 4.1).",
+  "queries": [
+    { "shape": "dense",  "name": "app-series-topn",  "path": "/rest/flows/applications/series?start=${T0}&end=${T1}&step=${STEP_DENSE}&N=10" },
+    { "shape": "dense",  "name": "conv-series-topn", "path": "/rest/flows/conversations/series?start=${T0}&end=${T1}&step=${STEP_DENSE}&N=10" },
+    { "shape": "dense",  "name": "app-totals",       "path": "/rest/flows/applications?start=${T0}&end=${T1}&N=10" },
+    { "shape": "sparse", "name": "app-series-fine",  "path": "/rest/flows/applications/series?start=${T0}&end=${T0_PLUS_1H}&step=30000&N=10" },
+    { "shape": "sparse", "name": "conv-series-fine", "path": "/rest/flows/conversations/series?start=${T0}&end=${T0_PLUS_1H}&step=30000&N=10" },
+    { "shape": "sparse", "name": "app-totals-fine",  "path": "/rest/flows/applications?start=${T0}&end=${T0_PLUS_1H}&N=10" }
+  ]
+}

--- a/experiments/nms-20027-painless-flows/run-manifest.schema.json
+++ b/experiments/nms-20027-painless-flows/run-manifest.schema.json
@@ -1,0 +1,127 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/indigo423/skills/opennms-benchmark/run-manifest.schema.json",
+  "title": "OpenNMS benchmark run manifest",
+  "$comment": "SPDX-License-Identifier: Apache-2.0 (JSON carries no comment header; this $comment and the repo LICENSE govern). Contract 1: every run emits one of these, gathered at run time (see references/measure.md). Contract 3: the comparability gate compares two runs on `comparability_key` paths only, exempting the path named in experiment.independent_variable.",
+  "type": "object",
+  "required": ["experiment", "sut", "host", "workload", "run", "comparability_key"],
+  "properties": {
+    "experiment": {
+      "type": "object",
+      "required": ["question", "independent_variable", "variant"],
+      "properties": {
+        "question": { "type": "string", "description": "The performance question, verbatim from the Stage-0 plan" },
+        "independent_variable": {
+          "type": "string",
+          "description": "Dot-path of the ONE manifest field that may differ between compared runs, e.g. 'sut.config_delta' or 'sut.version_identity'"
+        },
+        "variant": { "type": "string", "description": "This run's variant name, e.g. 'baseline-drift-plugin' or 'painless-dense'" },
+        "plan": { "type": "string", "description": "The full Stage-0 plan text" }
+      }
+    },
+    "sut": {
+      "type": "object",
+      "required": ["version_identity", "jvm", "db_version", "tss_backend", "config_delta"],
+      "properties": {
+        "version_identity": {
+          "type": "object",
+          "required": ["version"],
+          "properties": {
+            "version": { "type": "string", "description": "As reported by /rest/info" },
+            "git_sha": { "type": "string" },
+            "image_digest": { "type": "string" },
+            "tarball_sha256": { "type": "string" },
+            "package_version": { "type": "string" }
+          }
+        },
+        "jvm": {
+          "type": "object",
+          "required": ["heap", "gc"],
+          "properties": {
+            "version": { "type": "string" },
+            "heap": { "type": "string", "description": "e.g. '-Xms8g -Xmx8g'" },
+            "gc": { "type": "string", "description": "e.g. 'G1GC'" },
+            "flags": { "type": "string", "description": "Full flags from the running process (jcmd VM.flags), not from config files" }
+          }
+        },
+        "db_version": { "type": "string" },
+        "tss_backend": { "type": "string", "description": "rrd | newts | integration/cortex, from the running instance" },
+        "config_delta": {
+          "type": "string",
+          "description": "Diff (or its sha256 + summary) of /opt/opennms/etc vs. stock for this version"
+        },
+        "provisioner": { "type": "string", "enum": ["container-released", "container-branch", "ssh-package", "ssh-tarball"] }
+      }
+    },
+    "host": {
+      "type": "object",
+      "required": ["cpu", "ram_gb", "disk"],
+      "properties": {
+        "cpu": { "type": "string", "description": "Model + core count" },
+        "ram_gb": { "type": "number" },
+        "disk": { "type": "string", "description": "Type (nvme/ssd/hdd) and relevant layout" },
+        "os": { "type": "string" },
+        "generator_colocated": { "type": "boolean", "description": "true when the load generator shares this host — restricts valid claims to relative A/B (scope-validity rule)" },
+        "hygiene_notes": { "type": "string", "description": "Governor pinning, turbo, anything that could NOT be pinned" }
+      }
+    },
+    "workload": {
+      "type": "object",
+      "required": ["axis", "generator_scenario"],
+      "properties": {
+        "axis": { "type": "string", "enum": ["push-telemetry", "snmp-collection", "provisioning", "rest-ui"] },
+        "generator_scenario": {
+          "type": "string",
+          "description": "nl6 scenario name + parameters for nl6-driven axes; HTTP-tool config (targets hash, rate, duration) for rest-ui"
+        },
+        "generator_version": {
+          "type": "string",
+          "description": "Load-generator build identity (nl6 image digest / version, vegeta version) — the ledger's ground truth depends on it; a :latest tag is not an identity"
+        },
+        "parameters": { "type": "object", "description": "Axis parameters: N devices, rate, window, protocol, ..." },
+        "fixtures": {
+          "type": "array",
+          "description": "Shared build-once/seed-once artifacts with identities (image digest, corpus doc-count + seed scenario)",
+          "items": {
+            "type": "object",
+            "required": ["name", "identity"],
+            "properties": { "name": { "type": "string" }, "identity": { "type": "string" } }
+          }
+        }
+      }
+    },
+    "run": {
+      "type": "object",
+      "$comment": "Per-run incidentals — NEVER part of the comparability key.",
+      "required": ["id", "started_at"],
+      "properties": {
+        "id": { "type": "string" },
+        "started_at": { "type": "string", "description": "ISO 8601" },
+        "ended_at": { "type": "string", "description": "ISO 8601" },
+        "trial": { "type": "integer", "minimum": 1 }
+      }
+    },
+    "comparability_key": {
+      "type": "array",
+      "description": "Dot-paths of the controlled fields the report's gate compares. Two runs are comparable iff these match on every path except experiment.independent_variable. Use the default unless the plan justifies otherwise.",
+      "items": { "type": "string" },
+      "default": [
+        "sut.version_identity",
+        "sut.jvm.heap",
+        "sut.jvm.gc",
+        "sut.db_version",
+        "sut.tss_backend",
+        "sut.config_delta",
+        "host.cpu",
+        "host.ram_gb",
+        "host.disk",
+        "host.generator_colocated",
+        "workload.axis",
+        "workload.generator_scenario",
+        "workload.generator_version",
+        "workload.parameters",
+        "workload.fixtures"
+      ]
+    }
+  }
+}

--- a/experiments/nms-20027-painless-flows/scenarios/flow-seed.json
+++ b/experiments/nms-20027-painless-flows/scenarios/flow-seed.json
@@ -1,0 +1,22 @@
+{
+  "_comment": "NMS-20027 corpus seed (SPDX-License-Identifier: Apache-2.0 — JSON carries no header; repo LICENSE governs). One-time 40M-flow corpus build: 5000 flows/s x 8000 s. NOT a steady-state ingestion benchmark — the ledger reconciliation gates corpus admission (accepted must match in_window within tolerance or the corpus is rejected). Verify loadtest field names against nl6 upstream (nl6.eu) before use — task 3.1.",
+  "name": "nms-20027-corpus-seed",
+  "axis": "push-telemetry",
+  "protocol": "ipfix",
+  "loadtest": {
+    "phases": ["arm", "run", "report"],
+    "window_s": 8000,
+    "rate_per_s": 5000,
+    "senders": 200
+  },
+  "reconcile": {
+    "delivered": "ledger in_window count",
+    "accepted": "Elasticsearch netflow-* doc count over the same window",
+    "disqualifiers": "non-zero send_failures/dropped = generator was the bottleneck; divergence beyond tolerance = corpus rejected (spec: corpus-seed)"
+  },
+  "manifest_fields": {
+    "workload.axis": "push-telemetry (seed only; trials are rest-ui)",
+    "workload.generator_scenario": "nms-20027-corpus-seed ipfix @ 5000/s x 8000s",
+    "workload.parameters": { "protocol": "ipfix", "rate_per_s": 5000, "window_s": 8000, "target_flows": 40000000 }
+  }
+}

--- a/experiments/nms-20027-painless-flows/variants/variant-b-plugin/org.opennms.features.flows.persistence.elastic.cfg
+++ b/experiments/nms-20027-painless-flows/variants/variant-b-plugin/org.opennms.features.flows.persistence.elastic.cfg
@@ -1,0 +1,8 @@
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: Apache-2.0
+#
+# The proportionalSumStrategy line below is the experiment's independent
+# variable (B=plugin, C=painless). This file MUST be byte-identical across
+# both variant directories except that one line.
+elasticUrl=http://elasticsearch:9200
+proportionalSumStrategy=plugin

--- a/experiments/nms-20027-painless-flows/variants/variant-c-painless/org.opennms.features.flows.persistence.elastic.cfg
+++ b/experiments/nms-20027-painless-flows/variants/variant-c-painless/org.opennms.features.flows.persistence.elastic.cfg
@@ -1,0 +1,8 @@
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: Apache-2.0
+#
+# The proportionalSumStrategy line below is the experiment's independent
+# variable (B=plugin, C=painless). This file MUST be byte-identical across
+# both variant directories except that one line.
+elasticUrl=http://elasticsearch:9200
+proportionalSumStrategy=painless


### PR DESCRIPTION
## Summary

Adds `experiments/nms-20027-painless-flows/` — a self-contained local container experiment answering: **does replacing the elasticsearch-drift-plugin `proportional_sum` aggregation with inline Painless scripts ([OpenNMS/opennms#8638](https://github.com/OpenNMS/opennms/pull/8638) / NMS-20027) regress netflow query performance?**

Unlike the other `experiments/` directories this is not an Azure-lab Ansible experiment: it runs OpenNMS Core + PostgreSQL + Elasticsearch + nl6 on a single host, and its results are valid for **relative A/B claims only**.

## Design

- **One build, one variable**: both variants are the same assembly build of PR #8638 @ `03b6b6dd`, differing only in `proportionalSumStrategy=plugin|painless` (one line in the etc-overlay; variant dirs verified byte-identical otherwise)
- **Identical ES for both variants**: 8.18.2 + drift plugin `v2.0.7_es-8.18.2` (idle in the painless variant); ES + plugin identity is probed into every run manifest so a fallback swap can't silently contaminate the comparison
- **40M-flow corpus** seeded once via nl6 with send-ledger reconciliation; read-only during trials (doc-count guard aborts on mutation)
- **6 trials × 2 query shapes** (dense whole-window / sparse fine-window — the PR's two Painless code paths), trial 1 discarded as warmup
- **Mandatory correctness diff**: the painless path intentionally fixes NMS-20001, so B↔C series/totals deltas are reported next to the latency delta, never merged into it
- Run manifests are emitted from run-time probes and validated against `run-manifest.schema.json` (`comparability_key` included — verified with ajv)

## Test plan

- [x] `bash -n` on all scripts
- [x] `docker compose config` passes for both variants; fails with an instructive error when `HORIZON_IMAGE` is unset (single source of truth written by `bin/build-sut.sh`)
- [x] Manifest shape validated against the schema with `ajv-cli --spec=draft2020` (stubbed probes)
- [x] Variant overlays byte-identical except the `proportionalSumStrategy` line
- [ ] Execution (build → seed → trials → report) — follows in a separate run; runbook in the experiment README

🤖 Generated with [Claude Code](https://claude.com/claude-code)