### PR TITLE
refactor(terraform/azure): topology-as-data via for_each (Phase 1)

### DIFF
--- a/terraform/azure/main.tf
+++ b/terraform/azure/main.tf
@@ -12,6 +12,84 @@ locals {
     "mon-benchmark-01"    = var.ip_monitoring
     "es-benchmark-01"     = var.ip_elasticsearch
   }
+
+  # Topology spec (keyed by role): the deployment-under-test as data. Node count
+  # is 1 per role today; interface addresses are the current lab.tfvars values so
+  # this refactor is byte-for-byte identical in plan. nic_label reproduces the
+  # legacy NIC-name token (monitoring -> "mon", elasticsearch -> "es").
+  topology = {
+    database = {
+      vm_name   = "db-benchmark-01"
+      nic_label = "database"
+      size      = "small"
+      public_ip = false
+      interfaces = [
+        { subnet = "mgmt", address = var.ip_database, routes = [] },
+        { subnet = "db", address = var.ip_database_db, routes = [] },
+      ]
+    }
+    core = {
+      vm_name   = "core-benchmark-01"
+      nic_label = "core"
+      size      = "medium"
+      public_ip = false
+      interfaces = [
+        { subnet = "mgmt", address = var.ip_core, routes = [] },
+        { subnet = "db", address = var.ip_core_db, routes = [] },
+        { subnet = "kafka", address = var.ip_core_kafka, routes = [] },
+      ]
+    }
+    kafka = {
+      vm_name   = "kafka-benchmark-01"
+      nic_label = "kafka"
+      size      = "small"
+      public_ip = false
+      interfaces = [
+        { subnet = "mgmt", address = var.ip_kafka, routes = [] },
+        { subnet = "kafka", address = var.ip_kafka_kafka, routes = [] },
+      ]
+    }
+    minion = {
+      vm_name   = "minion-benchmark-01"
+      nic_label = "minion"
+      size      = "small"
+      public_ip = false
+      interfaces = [
+        { subnet = "mgmt", address = var.ip_minion, routes = [] },
+        { subnet = "kafka", address = var.ip_minion_kafka, routes = [] },
+        { subnet = "sim", address = var.ip_minion_sim, routes = [{ to = var.net_sim_cidr, via = var.net_sim_gateway }] },
+      ]
+    }
+    netsim = {
+      vm_name   = "netsim-benchmark-01"
+      nic_label = "netsim"
+      size      = "small"
+      public_ip = false
+      interfaces = [
+        { subnet = "mgmt", address = var.ip_netsim, routes = [] },
+        { subnet = "sim", address = var.ip_netsim_sim, routes = [] },
+      ]
+    }
+    monitoring = {
+      vm_name   = "mon-benchmark-01"
+      nic_label = "mon"
+      size      = "small"
+      public_ip = true
+      interfaces = [
+        { subnet = "mgmt", address = var.ip_monitoring, routes = [] },
+      ]
+    }
+    elasticsearch = {
+      vm_name   = "es-benchmark-01"
+      nic_label = "es"
+      size      = "small"
+      public_ip = false
+      interfaces = [
+        { subnet = "mgmt", address = var.ip_elasticsearch, routes = [] },
+        { subnet = "db", address = var.ip_es_core, routes = [] },
+      ]
+    }
+  }
 }
 
 resource "azurerm_resource_group" "lab" {
@@ -28,77 +106,33 @@ resource "azurerm_proximity_placement_group" "lab" {
 module "network" {
   source = "./modules/network"
 
-  resource_group   = azurerm_resource_group.lab.name
-  location         = var.location
-  environment      = var.environment
-  vnet_name        = local.vnet_name
-  lab_cidr         = var.lab_cidr
-  subnet_db        = var.subnet_db
-  subnet_kafka     = var.subnet_kafka
-  subnet_sim       = var.subnet_sim
-  subnet_mgmt      = var.subnet_mgmt
-  ip_database_db   = var.ip_database_db
-  ip_database      = var.ip_database
-  ip_core_db       = var.ip_core_db
-  ip_core_kafka    = var.ip_core_kafka
-  ip_core          = var.ip_core
-  ip_kafka_kafka   = var.ip_kafka_kafka
-  ip_kafka         = var.ip_kafka
-  ip_minion_kafka  = var.ip_minion_kafka
-  ip_minion_sim    = var.ip_minion_sim
-  ip_minion        = var.ip_minion
-  ip_netsim        = var.ip_netsim
-  ip_netsim_sim    = var.ip_netsim_sim
-  ip_monitoring    = var.ip_monitoring
-  operator_cidr    = var.operator_cidr
-  ip_elasticsearch = var.ip_elasticsearch
-  ip_es_core       = var.ip_es_core
+  resource_group = azurerm_resource_group.lab.name
+  location       = var.location
+  environment    = var.environment
+  vnet_name      = local.vnet_name
+  lab_cidr       = var.lab_cidr
+  subnet_db      = var.subnet_db
+  subnet_kafka   = var.subnet_kafka
+  subnet_sim     = var.subnet_sim
+  subnet_mgmt    = var.subnet_mgmt
+  operator_cidr  = var.operator_cidr
+  topology       = local.topology
 }
 
 module "compute" {
   source = "./modules/compute"
 
-  resource_group         = azurerm_resource_group.lab.name
-  location               = var.location
-  ppg_id                 = azurerm_proximity_placement_group.lab.id
-  vm_size_small          = var.vm_size_small
-  vm_size_medium         = var.vm_size_medium
-  priority               = var.priority
-  admin_user             = var.admin_user
-  ssh_public_key         = trimspace(file(pathexpand("${var.ssh_key_path}.pub")))
-  net_sim_cidr           = var.net_sim_cidr
-  net_sim_gateway        = var.net_sim_gateway
-  hosts                  = local.hosts
-  ip_database            = var.ip_database
-  ip_core                = var.ip_core
-  ip_kafka               = var.ip_kafka
-  ip_minion              = var.ip_minion
-  ip_netsim              = var.ip_netsim
-  ip_monitoring          = var.ip_monitoring
-  ip_database_db         = var.ip_database_db
-  ip_core_db             = var.ip_core_db
-  ip_core_kafka          = var.ip_core_kafka
-  ip_kafka_kafka         = var.ip_kafka_kafka
-  ip_minion_kafka        = var.ip_minion_kafka
-  ip_minion_sim          = var.ip_minion_sim
-  ip_netsim_sim          = var.ip_netsim_sim
-  nic_database_mgmt      = module.network.nic_database_mgmt
-  nic_database_db        = module.network.nic_database_db
-  nic_core_mgmt          = module.network.nic_core_mgmt
-  nic_core_db            = module.network.nic_core_db
-  nic_core_kafka         = module.network.nic_core_kafka
-  nic_kafka_mgmt         = module.network.nic_kafka_mgmt
-  nic_kafka_kafka        = module.network.nic_kafka_kafka
-  nic_minion_mgmt        = module.network.nic_minion_mgmt
-  nic_minion_kafka       = module.network.nic_minion_kafka
-  nic_minion_sim         = module.network.nic_minion_sim
-  nic_netsim_mgmt        = module.network.nic_netsim_mgmt
-  nic_netsim_sim         = module.network.nic_netsim_sim
-  nic_monitoring_mgmt    = module.network.nic_monitoring_mgmt
-  ip_elasticsearch       = var.ip_elasticsearch
-  ip_es_core             = var.ip_es_core
-  nic_elasticsearch_mgmt = module.network.nic_elasticsearch_mgmt
-  nic_elasticsearch_db   = module.network.nic_elasticsearch_db
+  resource_group = azurerm_resource_group.lab.name
+  location       = var.location
+  ppg_id         = azurerm_proximity_placement_group.lab.id
+  vm_size_small  = var.vm_size_small
+  vm_size_medium = var.vm_size_medium
+  priority       = var.priority
+  admin_user     = var.admin_user
+  ssh_public_key = trimspace(file(pathexpand("${var.ssh_key_path}.pub")))
+  hosts          = local.hosts
+  nic_ids        = module.network.nic_ids
+  topology       = local.topology
 }
 
 module "diagram" {

--- a/terraform/azure/modules/compute/main.tf
+++ b/terraform/azure/modules/compute/main.tf
@@ -17,110 +17,48 @@ locals {
     sku       = "server"
     version   = "latest"
   }
+
+  # t-shirt size class -> Azure SKU
+  size_map = {
+    small  = var.vm_size_small
+    medium = var.vm_size_medium
+  }
 }
 
-module "cloud_init_database" {
-  source                   = "../../../modules/cloud-init"
-  vm_name                  = "db-benchmark-01"
-  admin_user               = var.admin_user
-  ssh_public_key           = var.ssh_public_key
-  hosts                    = var.hosts
+module "cloud_init" {
+  for_each = var.topology
+  source   = "../../../modules/cloud-init"
+
+  vm_name        = each.value.vm_name
+  admin_user     = var.admin_user
+  ssh_public_key = var.ssh_public_key
+  hosts          = var.hosts
+  # Azure delivers only user-data; static routes are installed via a systemd
+  # service in user-data rather than a separate network-config document.
   network_config_supported = false
   interfaces = [
-    { name = "eth0", address = var.ip_database, prefix = 26, gateway = null },
-    { name = "eth1", address = var.ip_database_db, prefix = 26, gateway = null },
+    for idx, iface in each.value.interfaces : {
+      name    = "eth${idx}"
+      address = iface.address
+      prefix  = 26
+      gateway = null
+      routes  = iface.routes
+    }
   ]
 }
 
-module "cloud_init_core" {
-  source                   = "../../../modules/cloud-init"
-  vm_name                  = "core-benchmark-01"
-  admin_user               = var.admin_user
-  ssh_public_key           = var.ssh_public_key
-  hosts                    = var.hosts
-  network_config_supported = false
-  interfaces = [
-    { name = "eth0", address = var.ip_core, prefix = 26, gateway = null },
-    { name = "eth1", address = var.ip_core_db, prefix = 26, gateway = null },
-    { name = "eth2", address = var.ip_core_kafka, prefix = 26, gateway = null },
-  ]
-}
+resource "azurerm_linux_virtual_machine" "vm" {
+  for_each = var.topology
 
-module "cloud_init_kafka" {
-  source                   = "../../../modules/cloud-init"
-  vm_name                  = "kafka-benchmark-01"
-  admin_user               = var.admin_user
-  ssh_public_key           = var.ssh_public_key
-  hosts                    = var.hosts
-  network_config_supported = false
-  interfaces = [
-    { name = "eth0", address = var.ip_kafka, prefix = 26, gateway = null },
-    { name = "eth1", address = var.ip_kafka_kafka, prefix = 26, gateway = null },
-  ]
-}
-
-module "cloud_init_minion" {
-  source                   = "../../../modules/cloud-init"
-  vm_name                  = "minion-benchmark-01"
-  admin_user               = var.admin_user
-  ssh_public_key           = var.ssh_public_key
-  hosts                    = var.hosts
-  network_config_supported = false
-  interfaces = [
-    { name = "eth0", address = var.ip_minion, prefix = 26, gateway = null },
-    { name = "eth1", address = var.ip_minion_kafka, prefix = 26, gateway = null },
-    { name = "eth2", address = var.ip_minion_sim, prefix = 26, gateway = null, routes = [{ to = var.net_sim_cidr, via = var.net_sim_gateway }] },
-  ]
-}
-
-module "cloud_init_netsim" {
-  source                   = "../../../modules/cloud-init"
-  vm_name                  = "netsim-benchmark-01"
-  admin_user               = var.admin_user
-  ssh_public_key           = var.ssh_public_key
-  hosts                    = var.hosts
-  network_config_supported = false
-  interfaces = [
-    { name = "eth0", address = var.ip_netsim, prefix = 26, gateway = null },
-    { name = "eth1", address = var.ip_netsim_sim, prefix = 26, gateway = null },
-  ]
-}
-
-module "cloud_init_monitoring" {
-  source                   = "../../../modules/cloud-init"
-  vm_name                  = "mon-benchmark-01"
-  admin_user               = var.admin_user
-  ssh_public_key           = var.ssh_public_key
-  hosts                    = var.hosts
-  network_config_supported = false
-  interfaces = [
-    { name = "eth0", address = var.ip_monitoring, prefix = 26, gateway = null },
-  ]
-}
-
-module "cloud_init_elasticsearch" {
-  source                   = "../../../modules/cloud-init"
-  vm_name                  = "es-benchmark-01"
-  admin_user               = var.admin_user
-  ssh_public_key           = var.ssh_public_key
-  hosts                    = var.hosts
-  network_config_supported = false
-  interfaces = [
-    { name = "eth0", address = var.ip_elasticsearch, prefix = 26, gateway = null },
-    { name = "eth1", address = var.ip_es_core, prefix = 26, gateway = null },
-  ]
-}
-
-resource "azurerm_linux_virtual_machine" "elasticsearch" {
-  name                         = "es-benchmark-01"
+  name                         = each.value.vm_name
   resource_group_name          = var.resource_group
   location                     = var.location
-  size                         = var.vm_size_small
+  size                         = local.size_map[each.value.size]
   priority                     = var.priority
   proximity_placement_group_id = var.ppg_id
   admin_username               = var.admin_user
-  network_interface_ids        = [var.nic_elasticsearch_mgmt, var.nic_elasticsearch_db]
-  custom_data                  = module.cloud_init_elasticsearch.user_data_base64
+  network_interface_ids        = [for iface in each.value.interfaces : var.nic_ids["${each.key}-${iface.subnet}"]]
+  custom_data                  = module.cloud_init[each.key].user_data_base64
 
   admin_ssh_key {
     username   = var.admin_user
@@ -140,176 +78,61 @@ resource "azurerm_linux_virtual_machine" "elasticsearch" {
   }
 }
 
-resource "azurerm_linux_virtual_machine" "database" {
-  name                         = "db-benchmark-01"
-  resource_group_name          = var.resource_group
-  location                     = var.location
-  size                         = var.vm_size_small
-  priority                     = var.priority
-  proximity_placement_group_id = var.ppg_id
-  admin_username               = var.admin_user
-  network_interface_ids        = [var.nic_database_mgmt, var.nic_database_db]
-  custom_data                  = module.cloud_init_database.user_data_base64
-
-  admin_ssh_key {
-    username   = var.admin_user
-    public_key = var.ssh_public_key
-  }
-
-  os_disk {
-    caching              = "ReadWrite"
-    storage_account_type = "Standard_LRS"
-  }
-
-  source_image_reference {
-    publisher = local.image.publisher
-    offer     = local.image.offer
-    sku       = local.image.sku
-    version   = local.image.version
-  }
+# Preserve state addresses across the per-role -> for_each refactor (no destroy).
+moved {
+  from = azurerm_linux_virtual_machine.database
+  to   = azurerm_linux_virtual_machine.vm["database"]
+}
+moved {
+  from = azurerm_linux_virtual_machine.core
+  to   = azurerm_linux_virtual_machine.vm["core"]
+}
+moved {
+  from = azurerm_linux_virtual_machine.kafka
+  to   = azurerm_linux_virtual_machine.vm["kafka"]
+}
+moved {
+  from = azurerm_linux_virtual_machine.minion
+  to   = azurerm_linux_virtual_machine.vm["minion"]
+}
+moved {
+  from = azurerm_linux_virtual_machine.netsim
+  to   = azurerm_linux_virtual_machine.vm["netsim"]
+}
+moved {
+  from = azurerm_linux_virtual_machine.monitoring
+  to   = azurerm_linux_virtual_machine.vm["monitoring"]
+}
+moved {
+  from = azurerm_linux_virtual_machine.elasticsearch
+  to   = azurerm_linux_virtual_machine.vm["elasticsearch"]
 }
 
-resource "azurerm_linux_virtual_machine" "core" {
-  name                         = "core-benchmark-01"
-  resource_group_name          = var.resource_group
-  location                     = var.location
-  size                         = var.vm_size_medium
-  priority                     = var.priority
-  proximity_placement_group_id = var.ppg_id
-  admin_username               = var.admin_user
-  network_interface_ids        = [var.nic_core_mgmt, var.nic_core_db, var.nic_core_kafka]
-  custom_data                  = module.cloud_init_core.user_data_base64
-
-  admin_ssh_key {
-    username   = var.admin_user
-    public_key = var.ssh_public_key
-  }
-
-  os_disk {
-    caching              = "ReadWrite"
-    storage_account_type = "Standard_LRS"
-  }
-
-  source_image_reference {
-    publisher = local.image.publisher
-    offer     = local.image.offer
-    sku       = local.image.sku
-    version   = local.image.version
-  }
+moved {
+  from = module.cloud_init_database
+  to   = module.cloud_init["database"]
 }
-
-resource "azurerm_linux_virtual_machine" "kafka" {
-  name                         = "kafka-benchmark-01"
-  resource_group_name          = var.resource_group
-  location                     = var.location
-  size                         = var.vm_size_small
-  priority                     = var.priority
-  proximity_placement_group_id = var.ppg_id
-  admin_username               = var.admin_user
-  network_interface_ids        = [var.nic_kafka_mgmt, var.nic_kafka_kafka]
-  custom_data                  = module.cloud_init_kafka.user_data_base64
-
-  admin_ssh_key {
-    username   = var.admin_user
-    public_key = var.ssh_public_key
-  }
-
-  os_disk {
-    caching              = "ReadWrite"
-    storage_account_type = "Standard_LRS"
-  }
-
-  source_image_reference {
-    publisher = local.image.publisher
-    offer     = local.image.offer
-    sku       = local.image.sku
-    version   = local.image.version
-  }
+moved {
+  from = module.cloud_init_core
+  to   = module.cloud_init["core"]
 }
-
-resource "azurerm_linux_virtual_machine" "minion" {
-  name                         = "minion-benchmark-01"
-  resource_group_name          = var.resource_group
-  location                     = var.location
-  size                         = var.vm_size_small
-  priority                     = var.priority
-  proximity_placement_group_id = var.ppg_id
-  admin_username               = var.admin_user
-  network_interface_ids        = [var.nic_minion_mgmt, var.nic_minion_kafka, var.nic_minion_sim]
-  custom_data                  = module.cloud_init_minion.user_data_base64
-
-  admin_ssh_key {
-    username   = var.admin_user
-    public_key = var.ssh_public_key
-  }
-
-  os_disk {
-    caching              = "ReadWrite"
-    storage_account_type = "Standard_LRS"
-  }
-
-  source_image_reference {
-    publisher = local.image.publisher
-    offer     = local.image.offer
-    sku       = local.image.sku
-    version   = local.image.version
-  }
+moved {
+  from = module.cloud_init_kafka
+  to   = module.cloud_init["kafka"]
 }
-
-resource "azurerm_linux_virtual_machine" "netsim" {
-  name                         = "netsim-benchmark-01"
-  resource_group_name          = var.resource_group
-  location                     = var.location
-  size                         = var.vm_size_small
-  priority                     = var.priority
-  proximity_placement_group_id = var.ppg_id
-  admin_username               = var.admin_user
-  network_interface_ids        = [var.nic_netsim_mgmt, var.nic_netsim_sim]
-  custom_data                  = module.cloud_init_netsim.user_data_base64
-
-  admin_ssh_key {
-    username   = var.admin_user
-    public_key = var.ssh_public_key
-  }
-
-  os_disk {
-    caching              = "ReadWrite"
-    storage_account_type = "Standard_LRS"
-  }
-
-  source_image_reference {
-    publisher = local.image.publisher
-    offer     = local.image.offer
-    sku       = local.image.sku
-    version   = local.image.version
-  }
+moved {
+  from = module.cloud_init_minion
+  to   = module.cloud_init["minion"]
 }
-
-resource "azurerm_linux_virtual_machine" "monitoring" {
-  name                         = "mon-benchmark-01"
-  resource_group_name          = var.resource_group
-  location                     = var.location
-  size                         = var.vm_size_small
-  priority                     = var.priority
-  proximity_placement_group_id = var.ppg_id
-  admin_username               = var.admin_user
-  network_interface_ids        = [var.nic_monitoring_mgmt]
-  custom_data                  = module.cloud_init_monitoring.user_data_base64
-
-  admin_ssh_key {
-    username   = var.admin_user
-    public_key = var.ssh_public_key
-  }
-
-  os_disk {
-    caching              = "ReadWrite"
-    storage_account_type = "Standard_LRS"
-  }
-
-  source_image_reference {
-    publisher = local.image.publisher
-    offer     = local.image.offer
-    sku       = local.image.sku
-    version   = local.image.version
-  }
+moved {
+  from = module.cloud_init_netsim
+  to   = module.cloud_init["netsim"]
+}
+moved {
+  from = module.cloud_init_monitoring
+  to   = module.cloud_init["monitoring"]
+}
+moved {
+  from = module.cloud_init_elasticsearch
+  to   = module.cloud_init["elasticsearch"]
 }

--- a/terraform/azure/modules/compute/variables.tf
+++ b/terraform/azure/modules/compute/variables.tf
@@ -9,36 +9,24 @@ variable "ssh_public_key" {
   type      = string
   sensitive = true
 }
-variable "net_sim_cidr" { type = string }
-variable "net_sim_gateway" { type = string }
+
+# /etc/hosts map injected into every node's cloud-init.
 variable "hosts" { type = map(string) }
-variable "ip_database" { type = string }
-variable "ip_core" { type = string }
-variable "ip_kafka" { type = string }
-variable "ip_minion" { type = string }
-variable "ip_netsim" { type = string }
-variable "ip_monitoring" { type = string }
-variable "ip_database_db" { type = string }
-variable "ip_core_db" { type = string }
-variable "ip_core_kafka" { type = string }
-variable "ip_kafka_kafka" { type = string }
-variable "ip_minion_kafka" { type = string }
-variable "ip_minion_sim" { type = string }
-variable "ip_netsim_sim" { type = string }
-variable "nic_database_mgmt" { type = string }
-variable "nic_database_db" { type = string }
-variable "nic_core_mgmt" { type = string }
-variable "nic_core_db" { type = string }
-variable "nic_core_kafka" { type = string }
-variable "nic_kafka_mgmt" { type = string }
-variable "nic_kafka_kafka" { type = string }
-variable "nic_minion_mgmt" { type = string }
-variable "nic_minion_kafka" { type = string }
-variable "nic_minion_sim" { type = string }
-variable "nic_netsim_mgmt" { type = string }
-variable "nic_netsim_sim" { type = string }
-variable "nic_monitoring_mgmt" { type = string }
-variable "ip_elasticsearch" { type = string }
-variable "ip_es_core" { type = string }
-variable "nic_elasticsearch_mgmt" { type = string }
-variable "nic_elasticsearch_db" { type = string }
+
+# NIC IDs keyed "<role>-<subnet>", from the network module.
+variable "nic_ids" { type = map(string) }
+
+# Topology spec (keyed by role); see terraform/azure/main.tf for the schema.
+variable "topology" {
+  type = map(object({
+    vm_name   = string
+    nic_label = string
+    size      = string
+    public_ip = bool
+    interfaces = list(object({
+      subnet  = string
+      address = string
+      routes  = list(object({ to = string, via = string }))
+    }))
+  }))
+}

--- a/terraform/azure/modules/network/main.tf
+++ b/terraform/azure/modules/network/main.tf
@@ -11,6 +11,27 @@ terraform {
 locals {
   env = var.environment
   loc = var.location
+
+  subnet_ids = {
+    db    = azurerm_subnet.db.id
+    kafka = azurerm_subnet.kafka.id
+    sim   = azurerm_subnet.sim.id
+    mgmt  = azurerm_subnet.mgmt.id
+  }
+
+  # Flatten role x interface into one NIC map keyed "<role>-<subnet>". Only the
+  # mgmt NIC of a public_ip role gets the monitoring public IP.
+  nics = merge([
+    for role, node in var.topology : {
+      for iface in node.interfaces :
+      "${role}-${iface.subnet}" => {
+        nic_label = node.nic_label
+        subnet    = iface.subnet
+        address   = iface.address
+        public_ip = node.public_ip && iface.subnet == "mgmt"
+      }
+    }
+  ]...)
 }
 
 # Public IP for monitoring jump host
@@ -58,7 +79,7 @@ resource "azurerm_subnet" "mgmt" {
   address_prefixes     = [var.subnet_mgmt]
 }
 
-# NSG — SSH from operator IP only on monitoring NIC
+# NSG — SSH/HTTPS from operator IP only, on the monitoring NIC
 resource "azurerm_network_security_group" "monitoring" {
   name                = "nsg-nic-${local.loc}-${local.env}-mon-vnet-mgmt"
   resource_group_name = var.resource_group
@@ -89,195 +110,87 @@ resource "azurerm_network_security_group" "monitoring" {
   }
 }
 
-# NICs — database
-resource "azurerm_network_interface" "database_db" {
-  name                = "nic-${local.loc}-${local.env}-database-vnet-db"
-  resource_group_name = var.resource_group
-  location            = var.location
-  ip_configuration {
-    name                          = "ipconfig1"
-    subnet_id                     = azurerm_subnet.db.id
-    private_ip_address_allocation = "Static"
-    private_ip_address            = var.ip_database_db
-  }
-}
+# NICs — one per role x interface (see local.nics). Names reproduce the previous
+# hand-written scheme "nic-<loc>-<env>-<nic_label>-vnet-<subnet>" exactly.
+resource "azurerm_network_interface" "nic" {
+  for_each = local.nics
 
-resource "azurerm_network_interface" "database_mgmt" {
-  name                = "nic-${local.loc}-${local.env}-database-vnet-mgmt"
+  name                = "nic-${local.loc}-${local.env}-${each.value.nic_label}-vnet-${each.value.subnet}"
   resource_group_name = var.resource_group
   location            = var.location
-  ip_configuration {
-    name                          = "ipconfig1"
-    subnet_id                     = azurerm_subnet.mgmt.id
-    private_ip_address_allocation = "Static"
-    private_ip_address            = var.ip_database
-  }
-}
 
-# NICs — core
-resource "azurerm_network_interface" "core_db" {
-  name                = "nic-${local.loc}-${local.env}-core-vnet-db"
-  resource_group_name = var.resource_group
-  location            = var.location
   ip_configuration {
     name                          = "ipconfig1"
-    subnet_id                     = azurerm_subnet.db.id
+    subnet_id                     = local.subnet_ids[each.value.subnet]
     private_ip_address_allocation = "Static"
-    private_ip_address            = var.ip_core_db
-  }
-}
-
-resource "azurerm_network_interface" "core_kafka" {
-  name                = "nic-${local.loc}-${local.env}-core-vnet-kafka"
-  resource_group_name = var.resource_group
-  location            = var.location
-  ip_configuration {
-    name                          = "ipconfig1"
-    subnet_id                     = azurerm_subnet.kafka.id
-    private_ip_address_allocation = "Static"
-    private_ip_address            = var.ip_core_kafka
-  }
-}
-
-resource "azurerm_network_interface" "core_mgmt" {
-  name                = "nic-${local.loc}-${local.env}-core-vnet-mgmt"
-  resource_group_name = var.resource_group
-  location            = var.location
-  ip_configuration {
-    name                          = "ipconfig1"
-    subnet_id                     = azurerm_subnet.mgmt.id
-    private_ip_address_allocation = "Static"
-    private_ip_address            = var.ip_core
-  }
-}
-
-# NICs — kafka
-resource "azurerm_network_interface" "kafka_kafka" {
-  name                = "nic-${local.loc}-${local.env}-kafka-vnet-kafka"
-  resource_group_name = var.resource_group
-  location            = var.location
-  ip_configuration {
-    name                          = "ipconfig1"
-    subnet_id                     = azurerm_subnet.kafka.id
-    private_ip_address_allocation = "Static"
-    private_ip_address            = var.ip_kafka_kafka
-  }
-}
-
-resource "azurerm_network_interface" "kafka_mgmt" {
-  name                = "nic-${local.loc}-${local.env}-kafka-vnet-mgmt"
-  resource_group_name = var.resource_group
-  location            = var.location
-  ip_configuration {
-    name                          = "ipconfig1"
-    subnet_id                     = azurerm_subnet.mgmt.id
-    private_ip_address_allocation = "Static"
-    private_ip_address            = var.ip_kafka
-  }
-}
-
-# NICs — minion
-resource "azurerm_network_interface" "minion_kafka" {
-  name                = "nic-${local.loc}-${local.env}-minion-vnet-kafka"
-  resource_group_name = var.resource_group
-  location            = var.location
-  ip_configuration {
-    name                          = "ipconfig1"
-    subnet_id                     = azurerm_subnet.kafka.id
-    private_ip_address_allocation = "Static"
-    private_ip_address            = var.ip_minion_kafka
-  }
-}
-
-resource "azurerm_network_interface" "minion_sim" {
-  name                = "nic-${local.loc}-${local.env}-minion-vnet-sim"
-  resource_group_name = var.resource_group
-  location            = var.location
-  ip_configuration {
-    name                          = "ipconfig1"
-    subnet_id                     = azurerm_subnet.sim.id
-    private_ip_address_allocation = "Static"
-    private_ip_address            = var.ip_minion_sim
-  }
-}
-
-resource "azurerm_network_interface" "minion_mgmt" {
-  name                = "nic-${local.loc}-${local.env}-minion-vnet-mgmt"
-  resource_group_name = var.resource_group
-  location            = var.location
-  ip_configuration {
-    name                          = "ipconfig1"
-    subnet_id                     = azurerm_subnet.mgmt.id
-    private_ip_address_allocation = "Static"
-    private_ip_address            = var.ip_minion
-  }
-}
-
-# NICs — netsim
-resource "azurerm_network_interface" "netsim_sim" {
-  name                = "nic-${local.loc}-${local.env}-netsim-vnet-sim"
-  resource_group_name = var.resource_group
-  location            = var.location
-  ip_configuration {
-    name                          = "ipconfig1"
-    subnet_id                     = azurerm_subnet.sim.id
-    private_ip_address_allocation = "Static"
-    private_ip_address            = var.ip_netsim_sim
-  }
-}
-
-resource "azurerm_network_interface" "netsim_mgmt" {
-  name                = "nic-${local.loc}-${local.env}-netsim-vnet-mgmt"
-  resource_group_name = var.resource_group
-  location            = var.location
-  ip_configuration {
-    name                          = "ipconfig1"
-    subnet_id                     = azurerm_subnet.mgmt.id
-    private_ip_address_allocation = "Static"
-    private_ip_address            = var.ip_netsim
-  }
-}
-
-# NICs — monitoring (jump host, gets public IP)
-resource "azurerm_network_interface" "monitoring_mgmt" {
-  name                = "nic-${local.loc}-${local.env}-mon-vnet-mgmt"
-  resource_group_name = var.resource_group
-  location            = var.location
-  ip_configuration {
-    name                          = "ipconfig1"
-    subnet_id                     = azurerm_subnet.mgmt.id
-    private_ip_address_allocation = "Static"
-    private_ip_address            = var.ip_monitoring
-    public_ip_address_id          = azurerm_public_ip.monitoring.id
-  }
-}
-
-# NICs — elasticsearch
-resource "azurerm_network_interface" "elasticsearch_mgmt" {
-  name                = "nic-${local.loc}-${local.env}-es-vnet-mgmt"
-  resource_group_name = var.resource_group
-  location            = var.location
-  ip_configuration {
-    name                          = "ipconfig1"
-    subnet_id                     = azurerm_subnet.mgmt.id
-    private_ip_address_allocation = "Static"
-    private_ip_address            = var.ip_elasticsearch
-  }
-}
-
-resource "azurerm_network_interface" "elasticsearch_db" {
-  name                = "nic-${local.loc}-${local.env}-es-vnet-db"
-  resource_group_name = var.resource_group
-  location            = var.location
-  ip_configuration {
-    name                          = "ipconfig1"
-    subnet_id                     = azurerm_subnet.db.id
-    private_ip_address_allocation = "Static"
-    private_ip_address            = var.ip_es_core
+    private_ip_address            = each.value.address
+    public_ip_address_id          = each.value.public_ip ? azurerm_public_ip.monitoring.id : null
   }
 }
 
 resource "azurerm_network_interface_security_group_association" "monitoring" {
-  network_interface_id      = azurerm_network_interface.monitoring_mgmt.id
+  network_interface_id      = azurerm_network_interface.nic["monitoring-mgmt"].id
   network_security_group_id = azurerm_network_security_group.monitoring.id
+}
+
+# Preserve state addresses across the count=1 -> for_each refactor (no destroy).
+moved {
+  from = azurerm_network_interface.database_mgmt
+  to   = azurerm_network_interface.nic["database-mgmt"]
+}
+moved {
+  from = azurerm_network_interface.database_db
+  to   = azurerm_network_interface.nic["database-db"]
+}
+moved {
+  from = azurerm_network_interface.core_mgmt
+  to   = azurerm_network_interface.nic["core-mgmt"]
+}
+moved {
+  from = azurerm_network_interface.core_db
+  to   = azurerm_network_interface.nic["core-db"]
+}
+moved {
+  from = azurerm_network_interface.core_kafka
+  to   = azurerm_network_interface.nic["core-kafka"]
+}
+moved {
+  from = azurerm_network_interface.kafka_mgmt
+  to   = azurerm_network_interface.nic["kafka-mgmt"]
+}
+moved {
+  from = azurerm_network_interface.kafka_kafka
+  to   = azurerm_network_interface.nic["kafka-kafka"]
+}
+moved {
+  from = azurerm_network_interface.minion_mgmt
+  to   = azurerm_network_interface.nic["minion-mgmt"]
+}
+moved {
+  from = azurerm_network_interface.minion_kafka
+  to   = azurerm_network_interface.nic["minion-kafka"]
+}
+moved {
+  from = azurerm_network_interface.minion_sim
+  to   = azurerm_network_interface.nic["minion-sim"]
+}
+moved {
+  from = azurerm_network_interface.netsim_mgmt
+  to   = azurerm_network_interface.nic["netsim-mgmt"]
+}
+moved {
+  from = azurerm_network_interface.netsim_sim
+  to   = azurerm_network_interface.nic["netsim-sim"]
+}
+moved {
+  from = azurerm_network_interface.monitoring_mgmt
+  to   = azurerm_network_interface.nic["monitoring-mgmt"]
+}
+moved {
+  from = azurerm_network_interface.elasticsearch_mgmt
+  to   = azurerm_network_interface.nic["elasticsearch-mgmt"]
+}
+moved {
+  from = azurerm_network_interface.elasticsearch_db
+  to   = azurerm_network_interface.nic["elasticsearch-db"]
 }

--- a/terraform/azure/modules/network/outputs.tf
+++ b/terraform/azure/modules/network/outputs.tf
@@ -1,16 +1,8 @@
-output "nic_database_db" { value = azurerm_network_interface.database_db.id }
-output "nic_database_mgmt" { value = azurerm_network_interface.database_mgmt.id }
-output "nic_core_db" { value = azurerm_network_interface.core_db.id }
-output "nic_core_kafka" { value = azurerm_network_interface.core_kafka.id }
-output "nic_core_mgmt" { value = azurerm_network_interface.core_mgmt.id }
-output "nic_kafka_kafka" { value = azurerm_network_interface.kafka_kafka.id }
-output "nic_kafka_mgmt" { value = azurerm_network_interface.kafka_mgmt.id }
-output "nic_minion_kafka" { value = azurerm_network_interface.minion_kafka.id }
-output "nic_minion_sim" { value = azurerm_network_interface.minion_sim.id }
-output "nic_minion_mgmt" { value = azurerm_network_interface.minion_mgmt.id }
-output "nic_netsim_sim" { value = azurerm_network_interface.netsim_sim.id }
-output "nic_netsim_mgmt" { value = azurerm_network_interface.netsim_mgmt.id }
-output "nic_monitoring_mgmt" { value = azurerm_network_interface.monitoring_mgmt.id }
-output "monitoring_public_ip" { value = azurerm_public_ip.monitoring.ip_address }
-output "nic_elasticsearch_mgmt" { value = azurerm_network_interface.elasticsearch_mgmt.id }
-output "nic_elasticsearch_db" { value = azurerm_network_interface.elasticsearch_db.id }
+# NIC IDs keyed "<role>-<subnet>" (e.g. "core-kafka"), consumed by the compute module.
+output "nic_ids" {
+  value = { for k, nic in azurerm_network_interface.nic : k => nic.id }
+}
+
+output "monitoring_public_ip" {
+  value = azurerm_public_ip.monitoring.ip_address
+}

--- a/terraform/azure/modules/network/variables.tf
+++ b/terraform/azure/modules/network/variables.tf
@@ -7,19 +7,20 @@ variable "subnet_db" { type = string }
 variable "subnet_kafka" { type = string }
 variable "subnet_sim" { type = string }
 variable "subnet_mgmt" { type = string }
-variable "ip_database_db" { type = string }
-variable "ip_database" { type = string }
-variable "ip_core_db" { type = string }
-variable "ip_core_kafka" { type = string }
-variable "ip_core" { type = string }
-variable "ip_kafka_kafka" { type = string }
-variable "ip_kafka" { type = string }
-variable "ip_minion_kafka" { type = string }
-variable "ip_minion_sim" { type = string }
-variable "ip_minion" { type = string }
-variable "ip_netsim" { type = string }
-variable "ip_netsim_sim" { type = string }
-variable "ip_monitoring" { type = string }
 variable "operator_cidr" { type = string }
-variable "ip_elasticsearch" { type = string }
-variable "ip_es_core" { type = string }
+
+# Topology spec (keyed by role). NICs are derived from each role's interfaces;
+# see terraform/azure/main.tf for the schema and the current layout.
+variable "topology" {
+  type = map(object({
+    vm_name   = string
+    nic_label = string
+    size      = string
+    public_ip = bool
+    interfaces = list(object({
+      subnet  = string
+      address = string
+      routes  = list(object({ to = string, via = string }))
+    }))
+  }))
+}


### PR DESCRIPTION
> [!WARNING]
> **DRAFT — do not merge until the live-state plan gate passes.** This refactor is verified with `make fmt` + `make validate-azure` only. The no-destroy guarantee can only be confirmed by `terraform plan` against the real Azure state (see below).

## Summary

Phase 1 of the deployment-topology restructure: turn the Azure lab into **topology-as-data**. The hand-written per-role NIC/VM/cloud-init resources become a single `topology` map(object) driving `for_each` over the network and compute modules. Azure is the reference implementation (it has live state); kvm/proxmox/vmware follow in later PRs.

Net effect: −249 lines, same infrastructure. Adding a node or scaling a role becomes a spec edit rather than copy-pasted HCL.

## What changed (Azure only)

- **`terraform/azure/main.tf`** — new `local.topology` (keyed by role: `vm_name`, `nic_label`, `size`, `public_ip`, ordered `interfaces` with per-interface `routes`); `network`/`compute` module calls slimmed from ~40 flat `ip_*`/`nic_*` args to `topology` + `nic_ids`.
- **network module** — 15 hand-written NICs → one `azurerm_network_interface.nic` with `for_each`; subnets/vnet/public-IP/NSG stay static; outputs a `nic_ids` map.
- **compute module** — 7 VMs + 7 cloud-init modules → `for_each`; `size` via a t-shirt→SKU `size_map`.
- **29 `moved` blocks** (15 NIC + 7 VM + 7 cloud-init) remap old addresses to the new `for_each` keys.

Unchanged: the shared `inventory` and `diagram` modules (inventory is byte-identical for count=1), and the other provider roots.

## Parity design (why this should be a no-op plan)

- Interface addresses = current `lab.tfvars` values (no derivation), so NIC `private_ip_address` is unchanged.
- NIC names reproduce `nic-<loc>-<env>-<nic_label>-vnet-<subnet>` exactly (`nic_label`: monitoring→`mon`, elasticsearch→`es`).
- `custom_data` unchanged: Azure user-data depends only on `vm_name`, the shared `hosts` map, and static routes — **not** interface addresses.
- `network_interface_ids` order and VM sizes preserved per role.

## Required verification before merge

Run against live state and confirm **0 to add, 0 to change (or benign in-place only), 0 to destroy** — only `moved` notices:

```bash
terraform -chdir=terraform/azure plan \
  -var-file=../lab.tfvars -var-file=azure.tfvars \
  -var operator_cidr="$(dig +short myip.opendns.com @resolver1.opendns.com)/32"
```

(Omitting `operator_cidr` may show a benign in-place NSG rule diff; pass your IP to avoid it.) If the plan shows any destroy/recreate, comment the resource and we adjust the `moved` map before merging.

Blueprint (spec schema, moved map, verification protocol): `_bmad-output/planning-artifacts/phase1-topology-as-data-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
