### PR TITLE
refactor(terraform/kvm): topology-as-data via for_each (Phase 1, live target)

### DIFF
--- a/terraform/kvm/main.tf
+++ b/terraform/kvm/main.tf
@@ -8,6 +8,82 @@ locals {
     "mon-benchmark-01"    = var.ip_monitoring
     "es-benchmark-01"     = var.ip_elasticsearch
   }
+
+  # Default route for lab VMs is the mgmt network gateway (.1 of subnet_mgmt).
+  # The monitoring VM is the exception: it routes out via its DHCP external NIC.
+  gateway_mgmt = cidrhost(var.subnet_mgmt, 1)
+
+  # Topology spec (keyed by role): the deployment-under-test as data. Node count
+  # is 1 per role today; interface addresses/gateways/sizes are the current
+  # values, so this refactor is byte-for-byte identical in plan. One interfaces
+  # list per role drives both cloud-init network-config and the domain NICs.
+  topology = {
+    elasticsearch = {
+      vm_name = "es-benchmark-01"
+      memory  = 8192
+      vcpu    = 4
+      interfaces = [
+        { subnet = "mgmt", iface_name = "enp1s0", address = var.ip_elasticsearch, prefix = 26, gateway = local.gateway_mgmt },
+        { subnet = "db", iface_name = "enp2s0", address = var.ip_es_core, prefix = 26, gateway = null },
+      ]
+    }
+    database = {
+      vm_name = "db-benchmark-01"
+      memory  = 4096
+      vcpu    = 2
+      interfaces = [
+        { subnet = "mgmt", iface_name = "enp1s0", address = var.ip_database, prefix = 26, gateway = local.gateway_mgmt },
+        { subnet = "db", iface_name = "enp2s0", address = var.ip_database_db, prefix = 26, gateway = null },
+      ]
+    }
+    core = {
+      vm_name = "core-benchmark-01"
+      memory  = 16384
+      vcpu    = 4
+      interfaces = [
+        { subnet = "mgmt", iface_name = "enp1s0", address = var.ip_core, prefix = 26, gateway = local.gateway_mgmt },
+        { subnet = "db", iface_name = "enp2s0", address = var.ip_core_db, prefix = 26, gateway = null },
+        { subnet = "kafka", iface_name = "enp3s0", address = var.ip_core_kafka, prefix = 26, gateway = null },
+      ]
+    }
+    kafka = {
+      vm_name = "kafka-benchmark-01"
+      memory  = 4096
+      vcpu    = 2
+      interfaces = [
+        { subnet = "mgmt", iface_name = "enp1s0", address = var.ip_kafka, prefix = 26, gateway = local.gateway_mgmt },
+        { subnet = "kafka", iface_name = "enp2s0", address = var.ip_kafka_kafka, prefix = 26, gateway = null },
+      ]
+    }
+    minion = {
+      vm_name = "minion-benchmark-01"
+      memory  = 4096
+      vcpu    = 2
+      interfaces = [
+        { subnet = "mgmt", iface_name = "enp1s0", address = var.ip_minion, prefix = 26, gateway = local.gateway_mgmt },
+        { subnet = "kafka", iface_name = "enp2s0", address = var.ip_minion_kafka, prefix = 26, gateway = null },
+        { subnet = "sim", iface_name = "enp3s0", address = var.ip_minion_sim, prefix = 26, gateway = null, routes = [{ to = var.net_sim_cidr, via = var.net_sim_gateway }] },
+      ]
+    }
+    netsim = {
+      vm_name = "netsim-benchmark-01"
+      memory  = 4096
+      vcpu    = 2
+      interfaces = [
+        { subnet = "mgmt", iface_name = "enp1s0", address = var.ip_netsim, prefix = 26, gateway = local.gateway_mgmt },
+        { subnet = "sim", iface_name = "enp2s0", address = var.ip_netsim_sim, prefix = 26, gateway = null },
+      ]
+    }
+    monitoring = {
+      vm_name = "mon-benchmark-01"
+      memory  = 4096
+      vcpu    = 2
+      interfaces = [
+        { subnet = "mgmt", iface_name = "enp1s0", address = var.ip_monitoring, prefix = 26, gateway = null },
+        { subnet = "external", iface_name = "enp2s0", address = null, prefix = null, gateway = null },
+      ]
+    }
+  }
 }
 
 module "network" {
@@ -27,31 +103,14 @@ module "compute" {
   ubuntu_cloud_image  = var.ubuntu_cloud_image
   admin_user          = var.admin_user
   ssh_public_key      = trimspace(file(pathexpand("${var.ssh_key_path}.pub")))
-  net_sim_cidr        = var.net_sim_cidr
-  net_sim_gateway     = var.net_sim_gateway
   hosts               = local.hosts
-  ip_database         = var.ip_database
-  ip_core             = var.ip_core
-  ip_kafka            = var.ip_kafka
-  ip_minion           = var.ip_minion
-  ip_netsim           = var.ip_netsim
-  ip_monitoring       = var.ip_monitoring
-  ip_database_db      = var.ip_database_db
-  ip_core_db          = var.ip_core_db
-  ip_core_kafka       = var.ip_core_kafka
-  ip_kafka_kafka      = var.ip_kafka_kafka
-  ip_minion_kafka     = var.ip_minion_kafka
-  ip_minion_sim       = var.ip_minion_sim
-  ip_netsim_sim       = var.ip_netsim_sim
-  ip_elasticsearch    = var.ip_elasticsearch
-  ip_es_core          = var.ip_es_core
   network_db_id       = module.network.network_db_id
   network_kafka_id    = module.network.network_kafka_id
   network_sim_id      = module.network.network_sim_id
   network_mgmt_id     = module.network.network_mgmt_id
   network_external_id = module.network.network_external_id
-  gateway_mgmt        = cidrhost(var.subnet_mgmt, 1)
   disk_sizes_gb       = var.disk_sizes_gb
+  topology            = local.topology
 }
 
 module "diagram" {

--- a/terraform/kvm/modules/compute/main.tf
+++ b/terraform/kvm/modules/compute/main.tf
@@ -9,6 +9,14 @@ terraform {
 }
 
 locals {
+  network_ids = {
+    mgmt     = var.network_mgmt_id
+    db       = var.network_db_id
+    kafka    = var.network_kafka_id
+    sim      = var.network_sim_id
+    external = var.network_external_id
+  }
+
   cloud_init_meta_data = {
     database      = <<-EOF
       instance-id: db-benchmark-01
@@ -45,7 +53,6 @@ locals {
 # Download before running terraform apply:
 #   wget -O /var/lib/libvirt/images/noble-server-cloudimg-amd64.img \
 #     https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img
-
 resource "libvirt_volume" "ubuntu_base" {
   name = "ubuntu-24.04-base"
   pool = var.storage_pool
@@ -68,8 +75,11 @@ resource "libvirt_volume" "ubuntu_base" {
   }
 }
 
-resource "libvirt_volume" "elasticsearch" {
-  name = "es-benchmark-01.qcow2"
+# OS disk per role — qcow2 backed by the shared Ubuntu base image.
+resource "libvirt_volume" "os" {
+  for_each = var.topology
+
+  name = "${each.value.vm_name}.qcow2"
   pool = var.storage_pool
 
   target = {
@@ -81,338 +91,62 @@ resource "libvirt_volume" "elasticsearch" {
     format = { type = "qcow2" }
   }
 
-  capacity      = var.disk_sizes_gb["elasticsearch"]
+  capacity      = var.disk_sizes_gb[each.key]
   capacity_unit = "GiB"
 }
 
-resource "libvirt_volume" "database" {
-  name = "db-benchmark-01.qcow2"
-  pool = var.storage_pool
+module "cloud_init" {
+  for_each = var.topology
+  source   = "../../../modules/cloud-init"
 
-  target = {
-    format = { type = "qcow2" }
-  }
-
-  backing_store = {
-    path   = libvirt_volume.ubuntu_base.path
-    format = { type = "qcow2" }
-  }
-
-  capacity      = var.disk_sizes_gb["database"]
-  capacity_unit = "GiB"
-}
-
-resource "libvirt_volume" "core" {
-  name = "core-benchmark-01.qcow2"
-  pool = var.storage_pool
-
-  target = {
-    format = { type = "qcow2" }
-  }
-
-  backing_store = {
-    path   = libvirt_volume.ubuntu_base.path
-    format = { type = "qcow2" }
-  }
-
-  capacity      = var.disk_sizes_gb["core"]
-  capacity_unit = "GiB"
-}
-
-resource "libvirt_volume" "kafka" {
-  name = "kafka-benchmark-01.qcow2"
-  pool = var.storage_pool
-
-  target = {
-    format = { type = "qcow2" }
-  }
-
-  backing_store = {
-    path   = libvirt_volume.ubuntu_base.path
-    format = { type = "qcow2" }
-  }
-
-  capacity      = var.disk_sizes_gb["kafka"]
-  capacity_unit = "GiB"
-}
-
-resource "libvirt_volume" "minion" {
-  name = "minion-benchmark-01.qcow2"
-  pool = var.storage_pool
-
-  target = {
-    format = { type = "qcow2" }
-  }
-
-  backing_store = {
-    path   = libvirt_volume.ubuntu_base.path
-    format = { type = "qcow2" }
-  }
-
-  capacity      = var.disk_sizes_gb["minion"]
-  capacity_unit = "GiB"
-}
-
-resource "libvirt_volume" "netsim" {
-  name = "netsim-benchmark-01.qcow2"
-  pool = var.storage_pool
-
-  target = {
-    format = { type = "qcow2" }
-  }
-
-  backing_store = {
-    path   = libvirt_volume.ubuntu_base.path
-    format = { type = "qcow2" }
-  }
-
-  capacity      = var.disk_sizes_gb["netsim"]
-  capacity_unit = "GiB"
-}
-
-resource "libvirt_volume" "monitoring" {
-  name = "mon-benchmark-01.qcow2"
-  pool = var.storage_pool
-
-  target = {
-    format = { type = "qcow2" }
-  }
-
-  backing_store = {
-    path   = libvirt_volume.ubuntu_base.path
-    format = { type = "qcow2" }
-  }
-
-  capacity      = var.disk_sizes_gb["monitoring"]
-  capacity_unit = "GiB"
-}
-
-module "cloud_init_elasticsearch" {
-  source         = "../../../modules/cloud-init"
-  vm_name        = "es-benchmark-01"
+  vm_name        = each.value.vm_name
   admin_user     = var.admin_user
   ssh_public_key = var.ssh_public_key
   hosts          = var.hosts
   extra_packages = var.extra_packages
   interfaces = [
-    { name = "enp1s0", address = var.ip_elasticsearch, prefix = 26, gateway = var.gateway_mgmt },
-    { name = "enp2s0", address = var.ip_es_core, prefix = 26, gateway = null },
+    for i in each.value.interfaces : {
+      name    = i.iface_name
+      address = i.address
+      prefix  = i.prefix
+      gateway = i.gateway
+      routes  = i.routes
+    }
   ]
 }
 
-module "cloud_init_database" {
-  source         = "../../../modules/cloud-init"
-  vm_name        = "db-benchmark-01"
-  admin_user     = var.admin_user
-  ssh_public_key = var.ssh_public_key
-  hosts          = var.hosts
-  extra_packages = var.extra_packages
-  interfaces = [
-    { name = "enp1s0", address = var.ip_database, prefix = 26, gateway = var.gateway_mgmt },
-    { name = "enp2s0", address = var.ip_database_db, prefix = 26, gateway = null },
-  ]
+resource "libvirt_cloudinit_disk" "ci" {
+  for_each = var.topology
+
+  name           = "${each.value.vm_name}-cloudinit"
+  user_data      = module.cloud_init[each.key].user_data
+  meta_data      = local.cloud_init_meta_data[each.key]
+  network_config = module.cloud_init[each.key].network_config
 }
 
-module "cloud_init_core" {
-  source         = "../../../modules/cloud-init"
-  vm_name        = "core-benchmark-01"
-  admin_user     = var.admin_user
-  ssh_public_key = var.ssh_public_key
-  hosts          = var.hosts
-  extra_packages = var.extra_packages
-  interfaces = [
-    { name = "enp1s0", address = var.ip_core, prefix = 26, gateway = var.gateway_mgmt },
-    { name = "enp2s0", address = var.ip_core_db, prefix = 26, gateway = null },
-    { name = "enp3s0", address = var.ip_core_kafka, prefix = 26, gateway = null },
-  ]
-}
+# The cloud-init disk exposed as a pool volume (ISO) so the domain can attach it.
+resource "libvirt_volume" "ci_iso" {
+  for_each = var.topology
 
-module "cloud_init_kafka" {
-  source         = "../../../modules/cloud-init"
-  vm_name        = "kafka-benchmark-01"
-  admin_user     = var.admin_user
-  ssh_public_key = var.ssh_public_key
-  hosts          = var.hosts
-  extra_packages = var.extra_packages
-  interfaces = [
-    { name = "enp1s0", address = var.ip_kafka, prefix = 26, gateway = var.gateway_mgmt },
-    { name = "enp2s0", address = var.ip_kafka_kafka, prefix = 26, gateway = null },
-  ]
-}
-
-module "cloud_init_minion" {
-  source         = "../../../modules/cloud-init"
-  vm_name        = "minion-benchmark-01"
-  admin_user     = var.admin_user
-  ssh_public_key = var.ssh_public_key
-  hosts          = var.hosts
-  extra_packages = var.extra_packages
-  interfaces = [
-    { name = "enp1s0", address = var.ip_minion, prefix = 26, gateway = var.gateway_mgmt },
-    { name = "enp2s0", address = var.ip_minion_kafka, prefix = 26, gateway = null },
-    { name = "enp3s0", address = var.ip_minion_sim, prefix = 26, gateway = null, routes = [{ to = var.net_sim_cidr, via = var.net_sim_gateway }] },
-  ]
-}
-
-module "cloud_init_netsim" {
-  source         = "../../../modules/cloud-init"
-  vm_name        = "netsim-benchmark-01"
-  admin_user     = var.admin_user
-  ssh_public_key = var.ssh_public_key
-  hosts          = var.hosts
-  extra_packages = var.extra_packages
-  interfaces = [
-    { name = "enp1s0", address = var.ip_netsim, prefix = 26, gateway = var.gateway_mgmt },
-    { name = "enp2s0", address = var.ip_netsim_sim, prefix = 26, gateway = null },
-  ]
-}
-
-module "cloud_init_monitoring" {
-  source         = "../../../modules/cloud-init"
-  vm_name        = "mon-benchmark-01"
-  admin_user     = var.admin_user
-  ssh_public_key = var.ssh_public_key
-  hosts          = var.hosts
-  extra_packages = var.extra_packages
-  interfaces = [
-    { name = "enp1s0", address = var.ip_monitoring, prefix = 26, gateway = null },
-    { name = "enp2s0", address = null, prefix = null, gateway = null },
-  ]
-}
-
-resource "libvirt_cloudinit_disk" "elasticsearch" {
-  name           = "es-benchmark-01-cloudinit"
-  user_data      = module.cloud_init_elasticsearch.user_data
-  meta_data      = local.cloud_init_meta_data.elasticsearch
-  network_config = module.cloud_init_elasticsearch.network_config
-}
-
-resource "libvirt_cloudinit_disk" "database" {
-  name           = "db-benchmark-01-cloudinit"
-  user_data      = module.cloud_init_database.user_data
-  meta_data      = local.cloud_init_meta_data.database
-  network_config = module.cloud_init_database.network_config
-}
-
-resource "libvirt_cloudinit_disk" "core" {
-  name           = "core-benchmark-01-cloudinit"
-  user_data      = module.cloud_init_core.user_data
-  meta_data      = local.cloud_init_meta_data.core
-  network_config = module.cloud_init_core.network_config
-}
-
-resource "libvirt_cloudinit_disk" "kafka" {
-  name           = "kafka-benchmark-01-cloudinit"
-  user_data      = module.cloud_init_kafka.user_data
-  meta_data      = local.cloud_init_meta_data.kafka
-  network_config = module.cloud_init_kafka.network_config
-}
-
-resource "libvirt_cloudinit_disk" "minion" {
-  name           = "minion-benchmark-01-cloudinit"
-  user_data      = module.cloud_init_minion.user_data
-  meta_data      = local.cloud_init_meta_data.minion
-  network_config = module.cloud_init_minion.network_config
-}
-
-resource "libvirt_cloudinit_disk" "netsim" {
-  name           = "netsim-benchmark-01-cloudinit"
-  user_data      = module.cloud_init_netsim.user_data
-  meta_data      = local.cloud_init_meta_data.netsim
-  network_config = module.cloud_init_netsim.network_config
-}
-
-resource "libvirt_cloudinit_disk" "monitoring" {
-  name           = "mon-benchmark-01-cloudinit"
-  user_data      = module.cloud_init_monitoring.user_data
-  meta_data      = local.cloud_init_meta_data.monitoring
-  network_config = module.cloud_init_monitoring.network_config
-}
-
-resource "libvirt_volume" "elasticsearch_cloudinit" {
-  name = "es-benchmark-01-cloudinit.iso"
+  name = "${each.value.vm_name}-cloudinit.iso"
   pool = var.storage_pool
 
   create = {
     content = {
-      url = "file://${libvirt_cloudinit_disk.elasticsearch.path}"
+      url = "file://${libvirt_cloudinit_disk.ci[each.key].path}"
     }
   }
 }
 
-resource "libvirt_volume" "database_cloudinit" {
-  name = "db-benchmark-01-cloudinit.iso"
-  pool = var.storage_pool
+resource "libvirt_domain" "vm" {
+  for_each = var.topology
 
-  create = {
-    content = {
-      url = "file://${libvirt_cloudinit_disk.database.path}"
-    }
-  }
-}
-
-resource "libvirt_volume" "core_cloudinit" {
-  name = "core-benchmark-01-cloudinit.iso"
-  pool = var.storage_pool
-
-  create = {
-    content = {
-      url = "file://${libvirt_cloudinit_disk.core.path}"
-    }
-  }
-}
-
-resource "libvirt_volume" "kafka_cloudinit" {
-  name = "kafka-benchmark-01-cloudinit.iso"
-  pool = var.storage_pool
-
-  create = {
-    content = {
-      url = "file://${libvirt_cloudinit_disk.kafka.path}"
-    }
-  }
-}
-
-resource "libvirt_volume" "minion_cloudinit" {
-  name = "minion-benchmark-01-cloudinit.iso"
-  pool = var.storage_pool
-
-  create = {
-    content = {
-      url = "file://${libvirt_cloudinit_disk.minion.path}"
-    }
-  }
-}
-
-resource "libvirt_volume" "netsim_cloudinit" {
-  name = "netsim-benchmark-01-cloudinit.iso"
-  pool = var.storage_pool
-
-  create = {
-    content = {
-      url = "file://${libvirt_cloudinit_disk.netsim.path}"
-    }
-  }
-}
-
-resource "libvirt_volume" "monitoring_cloudinit" {
-  name = "mon-benchmark-01-cloudinit.iso"
-  pool = var.storage_pool
-
-  create = {
-    content = {
-      url = "file://${libvirt_cloudinit_disk.monitoring.path}"
-    }
-  }
-}
-
-resource "libvirt_domain" "elasticsearch" {
-  name        = "es-benchmark-01"
+  name        = each.value.vm_name
   type        = "kvm"
   running     = true
-  memory      = 8192
+  memory      = each.value.memory
   memory_unit = "MiB"
-  vcpu        = 4
+  vcpu        = each.value.vcpu
 
   os = {
     type         = "hvm"
@@ -430,8 +164,8 @@ resource "libvirt_domain" "elasticsearch" {
       {
         source = {
           volume = {
-            pool   = libvirt_volume.elasticsearch.pool
-            volume = libvirt_volume.elasticsearch.name
+            pool   = libvirt_volume.os[each.key].pool
+            volume = libvirt_volume.os[each.key].name
           }
         }
         driver = {
@@ -447,8 +181,8 @@ resource "libvirt_domain" "elasticsearch" {
         device = "cdrom"
         source = {
           volume = {
-            pool   = libvirt_volume.elasticsearch_cloudinit.pool
-            volume = libvirt_volume.elasticsearch_cloudinit.name
+            pool   = libvirt_volume.ci_iso[each.key].pool
+            volume = libvirt_volume.ci_iso[each.key].name
           }
         }
         target = {
@@ -458,25 +192,14 @@ resource "libvirt_domain" "elasticsearch" {
       }
     ]
     interfaces = [
-      {
+      for i in each.value.interfaces : {
         type = "network"
         model = {
           type = "virtio"
         }
         source = {
           network = {
-            network = var.network_mgmt_id
-          }
-        }
-      },
-      {
-        type = "network"
-        model = {
-          type = "virtio"
-        }
-        source = {
-          network = {
-            network = var.network_db_id
+            network = local.network_ids[i.subnet]
           }
         }
       }
@@ -521,714 +244,148 @@ resource "libvirt_domain" "elasticsearch" {
   }
 }
 
-resource "libvirt_domain" "database" {
-  name        = "db-benchmark-01"
-  type        = "kvm"
-  running     = true
-  memory      = 4096
-  memory_unit = "MiB"
-  vcpu        = 2
-
-  os = {
-    type         = "hvm"
-    type_arch    = "x86_64"
-    type_machine = "q35"
-    boot         = [{ dev = "hd" }]
-  }
-
-  features = {
-    acpi = true
-  }
-
-  devices = {
-    disks = [
-      {
-        source = {
-          volume = {
-            pool   = libvirt_volume.database.pool
-            volume = libvirt_volume.database.name
-          }
-        }
-        driver = {
-          name = "qemu"
-          type = "qcow2"
-        }
-        target = {
-          dev = "vda"
-          bus = "virtio"
-        }
-      },
-      {
-        device = "cdrom"
-        source = {
-          volume = {
-            pool   = libvirt_volume.database_cloudinit.pool
-            volume = libvirt_volume.database_cloudinit.name
-          }
-        }
-        target = {
-          dev = "sdb"
-          bus = "sata"
-        }
-      }
-    ]
-    interfaces = [
-      {
-        type = "network"
-        model = {
-          type = "virtio"
-        }
-        source = {
-          network = {
-            network = var.network_mgmt_id
-          }
-        }
-      },
-      {
-        type = "network"
-        model = {
-          type = "virtio"
-        }
-        source = {
-          network = {
-            network = var.network_db_id
-          }
-        }
-      }
-    ]
-    consoles = [
-      {
-        type        = "pty"
-        target_port = 0
-        target_type = "serial"
-      }
-    ]
-    channels = [
-      {
-        target = {
-          virt_io = {
-            name = "org.qemu.guest_agent.0"
-          }
-        }
-        source = {
-          unix = {}
-        }
-      }
-    ]
-    graphics = [
-      {
-        vnc = {
-          auto_port = true
-          listen    = "0.0.0.0"
-        }
-      }
-    ]
-    videos = [
-      {
-        model = {
-          type    = "vga"
-          primary = "yes"
-          heads   = 1
-          vram    = 16384
-        }
-      }
-    ]
-  }
+# Preserve state addresses across the per-role -> for_each refactor (no destroy).
+moved {
+  from = libvirt_volume.elasticsearch
+  to   = libvirt_volume.os["elasticsearch"]
+}
+moved {
+  from = libvirt_volume.database
+  to   = libvirt_volume.os["database"]
+}
+moved {
+  from = libvirt_volume.core
+  to   = libvirt_volume.os["core"]
+}
+moved {
+  from = libvirt_volume.kafka
+  to   = libvirt_volume.os["kafka"]
+}
+moved {
+  from = libvirt_volume.minion
+  to   = libvirt_volume.os["minion"]
+}
+moved {
+  from = libvirt_volume.netsim
+  to   = libvirt_volume.os["netsim"]
+}
+moved {
+  from = libvirt_volume.monitoring
+  to   = libvirt_volume.os["monitoring"]
 }
 
-resource "libvirt_domain" "core" {
-  name        = "core-benchmark-01"
-  type        = "kvm"
-  running     = true
-  memory      = 16384
-  memory_unit = "MiB"
-  vcpu        = 4
-
-  os = {
-    type         = "hvm"
-    type_arch    = "x86_64"
-    type_machine = "q35"
-    boot         = [{ dev = "hd" }]
-  }
-
-  features = {
-    acpi = true
-  }
-
-  devices = {
-    disks = [
-      {
-        source = {
-          volume = {
-            pool   = libvirt_volume.core.pool
-            volume = libvirt_volume.core.name
-          }
-        }
-        driver = {
-          name = "qemu"
-          type = "qcow2"
-        }
-        target = {
-          dev = "vda"
-          bus = "virtio"
-        }
-      },
-      {
-        device = "cdrom"
-        source = {
-          volume = {
-            pool   = libvirt_volume.core_cloudinit.pool
-            volume = libvirt_volume.core_cloudinit.name
-          }
-        }
-        target = {
-          dev = "sdb"
-          bus = "sata"
-        }
-      }
-    ]
-    interfaces = [
-      {
-        type = "network"
-        model = {
-          type = "virtio"
-        }
-        source = {
-          network = {
-            network = var.network_mgmt_id
-          }
-        }
-      },
-      {
-        type = "network"
-        model = {
-          type = "virtio"
-        }
-        source = {
-          network = {
-            network = var.network_db_id
-          }
-        }
-      },
-      {
-        type = "network"
-        model = {
-          type = "virtio"
-        }
-        source = {
-          network = {
-            network = var.network_kafka_id
-          }
-        }
-      }
-    ]
-    consoles = [
-      {
-        type        = "pty"
-        target_port = 0
-        target_type = "serial"
-      }
-    ]
-    channels = [
-      {
-        target = {
-          virt_io = {
-            name = "org.qemu.guest_agent.0"
-          }
-        }
-        source = {
-          unix = {}
-        }
-      }
-    ]
-    graphics = [
-      {
-        vnc = {
-          auto_port = true
-          listen    = "0.0.0.0"
-        }
-      }
-    ]
-    videos = [
-      {
-        model = {
-          type    = "vga"
-          primary = "yes"
-          heads   = 1
-          vram    = 16384
-        }
-      }
-    ]
-  }
+moved {
+  from = libvirt_volume.elasticsearch_cloudinit
+  to   = libvirt_volume.ci_iso["elasticsearch"]
+}
+moved {
+  from = libvirt_volume.database_cloudinit
+  to   = libvirt_volume.ci_iso["database"]
+}
+moved {
+  from = libvirt_volume.core_cloudinit
+  to   = libvirt_volume.ci_iso["core"]
+}
+moved {
+  from = libvirt_volume.kafka_cloudinit
+  to   = libvirt_volume.ci_iso["kafka"]
+}
+moved {
+  from = libvirt_volume.minion_cloudinit
+  to   = libvirt_volume.ci_iso["minion"]
+}
+moved {
+  from = libvirt_volume.netsim_cloudinit
+  to   = libvirt_volume.ci_iso["netsim"]
+}
+moved {
+  from = libvirt_volume.monitoring_cloudinit
+  to   = libvirt_volume.ci_iso["monitoring"]
 }
 
-resource "libvirt_domain" "kafka" {
-  name        = "kafka-benchmark-01"
-  type        = "kvm"
-  running     = true
-  memory      = 4096
-  memory_unit = "MiB"
-  vcpu        = 2
-
-  os = {
-    type         = "hvm"
-    type_arch    = "x86_64"
-    type_machine = "q35"
-    boot         = [{ dev = "hd" }]
-  }
-
-  features = {
-    acpi = true
-  }
-
-  devices = {
-    disks = [
-      {
-        source = {
-          volume = {
-            pool   = libvirt_volume.kafka.pool
-            volume = libvirt_volume.kafka.name
-          }
-        }
-        driver = {
-          name = "qemu"
-          type = "qcow2"
-        }
-        target = {
-          dev = "vda"
-          bus = "virtio"
-        }
-      },
-      {
-        device = "cdrom"
-        source = {
-          volume = {
-            pool   = libvirt_volume.kafka_cloudinit.pool
-            volume = libvirt_volume.kafka_cloudinit.name
-          }
-        }
-        target = {
-          dev = "sdb"
-          bus = "sata"
-        }
-      }
-    ]
-    interfaces = [
-      {
-        type = "network"
-        model = {
-          type = "virtio"
-        }
-        source = {
-          network = {
-            network = var.network_mgmt_id
-          }
-        }
-      },
-      {
-        type = "network"
-        model = {
-          type = "virtio"
-        }
-        source = {
-          network = {
-            network = var.network_kafka_id
-          }
-        }
-      }
-    ]
-    consoles = [
-      {
-        type        = "pty"
-        target_port = 0
-        target_type = "serial"
-      }
-    ]
-    channels = [
-      {
-        target = {
-          virt_io = {
-            name = "org.qemu.guest_agent.0"
-          }
-        }
-        source = {
-          unix = {}
-        }
-      }
-    ]
-    graphics = [
-      {
-        vnc = {
-          auto_port = true
-          listen    = "0.0.0.0"
-        }
-      }
-    ]
-    videos = [
-      {
-        model = {
-          type    = "vga"
-          primary = "yes"
-          heads   = 1
-          vram    = 16384
-        }
-      }
-    ]
-  }
+moved {
+  from = libvirt_cloudinit_disk.elasticsearch
+  to   = libvirt_cloudinit_disk.ci["elasticsearch"]
+}
+moved {
+  from = libvirt_cloudinit_disk.database
+  to   = libvirt_cloudinit_disk.ci["database"]
+}
+moved {
+  from = libvirt_cloudinit_disk.core
+  to   = libvirt_cloudinit_disk.ci["core"]
+}
+moved {
+  from = libvirt_cloudinit_disk.kafka
+  to   = libvirt_cloudinit_disk.ci["kafka"]
+}
+moved {
+  from = libvirt_cloudinit_disk.minion
+  to   = libvirt_cloudinit_disk.ci["minion"]
+}
+moved {
+  from = libvirt_cloudinit_disk.netsim
+  to   = libvirt_cloudinit_disk.ci["netsim"]
+}
+moved {
+  from = libvirt_cloudinit_disk.monitoring
+  to   = libvirt_cloudinit_disk.ci["monitoring"]
 }
 
-resource "libvirt_domain" "minion" {
-  name        = "minion-benchmark-01"
-  type        = "kvm"
-  running     = true
-  memory      = 4096
-  memory_unit = "MiB"
-  vcpu        = 2
-
-  os = {
-    type         = "hvm"
-    type_arch    = "x86_64"
-    type_machine = "q35"
-    boot         = [{ dev = "hd" }]
-  }
-
-  features = {
-    acpi = true
-  }
-
-  devices = {
-    disks = [
-      {
-        source = {
-          volume = {
-            pool   = libvirt_volume.minion.pool
-            volume = libvirt_volume.minion.name
-          }
-        }
-        driver = {
-          name = "qemu"
-          type = "qcow2"
-        }
-        target = {
-          dev = "vda"
-          bus = "virtio"
-        }
-      },
-      {
-        device = "cdrom"
-        source = {
-          volume = {
-            pool   = libvirt_volume.minion_cloudinit.pool
-            volume = libvirt_volume.minion_cloudinit.name
-          }
-        }
-        target = {
-          dev = "sdb"
-          bus = "sata"
-        }
-      }
-    ]
-    interfaces = [
-      {
-        type = "network"
-        model = {
-          type = "virtio"
-        }
-        source = {
-          network = {
-            network = var.network_mgmt_id
-          }
-        }
-      },
-      {
-        type = "network"
-        model = {
-          type = "virtio"
-        }
-        source = {
-          network = {
-            network = var.network_kafka_id
-          }
-        }
-      },
-      {
-        type = "network"
-        model = {
-          type = "virtio"
-        }
-        source = {
-          network = {
-            network = var.network_sim_id
-          }
-        }
-      }
-    ]
-    consoles = [
-      {
-        type        = "pty"
-        target_port = 0
-        target_type = "serial"
-      }
-    ]
-    channels = [
-      {
-        target = {
-          virt_io = {
-            name = "org.qemu.guest_agent.0"
-          }
-        }
-        source = {
-          unix = {}
-        }
-      }
-    ]
-    graphics = [
-      {
-        vnc = {
-          auto_port = true
-          listen    = "0.0.0.0"
-        }
-      }
-    ]
-    videos = [
-      {
-        model = {
-          type    = "vga"
-          primary = "yes"
-          heads   = 1
-          vram    = 16384
-        }
-      }
-    ]
-  }
+moved {
+  from = libvirt_domain.elasticsearch
+  to   = libvirt_domain.vm["elasticsearch"]
+}
+moved {
+  from = libvirt_domain.database
+  to   = libvirt_domain.vm["database"]
+}
+moved {
+  from = libvirt_domain.core
+  to   = libvirt_domain.vm["core"]
+}
+moved {
+  from = libvirt_domain.kafka
+  to   = libvirt_domain.vm["kafka"]
+}
+moved {
+  from = libvirt_domain.minion
+  to   = libvirt_domain.vm["minion"]
+}
+moved {
+  from = libvirt_domain.netsim
+  to   = libvirt_domain.vm["netsim"]
+}
+moved {
+  from = libvirt_domain.monitoring
+  to   = libvirt_domain.vm["monitoring"]
 }
 
-resource "libvirt_domain" "netsim" {
-  name        = "netsim-benchmark-01"
-  type        = "kvm"
-  running     = true
-  memory      = 4096
-  memory_unit = "MiB"
-  vcpu        = 2
-
-  os = {
-    type         = "hvm"
-    type_arch    = "x86_64"
-    type_machine = "q35"
-    boot         = [{ dev = "hd" }]
-  }
-
-  features = {
-    acpi = true
-  }
-
-  devices = {
-    disks = [
-      {
-        source = {
-          volume = {
-            pool   = libvirt_volume.netsim.pool
-            volume = libvirt_volume.netsim.name
-          }
-        }
-        driver = {
-          name = "qemu"
-          type = "qcow2"
-        }
-        target = {
-          dev = "vda"
-          bus = "virtio"
-        }
-      },
-      {
-        device = "cdrom"
-        source = {
-          volume = {
-            pool   = libvirt_volume.netsim_cloudinit.pool
-            volume = libvirt_volume.netsim_cloudinit.name
-          }
-        }
-        target = {
-          dev = "sdb"
-          bus = "sata"
-        }
-      }
-    ]
-    interfaces = [
-      {
-        type = "network"
-        model = {
-          type = "virtio"
-        }
-        source = {
-          network = {
-            network = var.network_mgmt_id
-          }
-        }
-      },
-      {
-        type = "network"
-        model = {
-          type = "virtio"
-        }
-        source = {
-          network = {
-            network = var.network_sim_id
-          }
-        }
-      }
-    ]
-    consoles = [
-      {
-        type        = "pty"
-        target_port = 0
-        target_type = "serial"
-      }
-    ]
-    channels = [
-      {
-        target = {
-          virt_io = {
-            name = "org.qemu.guest_agent.0"
-          }
-        }
-        source = {
-          unix = {}
-        }
-      }
-    ]
-    graphics = [
-      {
-        vnc = {
-          auto_port = true
-          listen    = "0.0.0.0"
-        }
-      }
-    ]
-    videos = [
-      {
-        model = {
-          type    = "vga"
-          primary = "yes"
-          heads   = 1
-          vram    = 16384
-        }
-      }
-    ]
-  }
+moved {
+  from = module.cloud_init_elasticsearch
+  to   = module.cloud_init["elasticsearch"]
 }
-
-resource "libvirt_domain" "monitoring" {
-  name        = "mon-benchmark-01"
-  type        = "kvm"
-  running     = true
-  memory      = 4096
-  memory_unit = "MiB"
-  vcpu        = 2
-
-  os = {
-    type         = "hvm"
-    type_arch    = "x86_64"
-    type_machine = "q35"
-    boot         = [{ dev = "hd" }]
-  }
-
-  features = {
-    acpi = true
-  }
-
-  devices = {
-    disks = [
-      {
-        source = {
-          volume = {
-            pool   = libvirt_volume.monitoring.pool
-            volume = libvirt_volume.monitoring.name
-          }
-        }
-        driver = {
-          name = "qemu"
-          type = "qcow2"
-        }
-        target = {
-          dev = "vda"
-          bus = "virtio"
-        }
-      },
-      {
-        device = "cdrom"
-        source = {
-          volume = {
-            pool   = libvirt_volume.monitoring_cloudinit.pool
-            volume = libvirt_volume.monitoring_cloudinit.name
-          }
-        }
-        target = {
-          dev = "sdb"
-          bus = "sata"
-        }
-      }
-    ]
-    interfaces = [
-      {
-        type = "network"
-        model = {
-          type = "virtio"
-        }
-        source = {
-          network = {
-            network = var.network_mgmt_id
-          }
-        }
-      },
-      {
-        type = "network"
-        model = {
-          type = "virtio"
-        }
-        source = {
-          network = {
-            network = var.network_external_id
-          }
-        }
-      }
-    ]
-    consoles = [
-      {
-        type        = "pty"
-        target_port = 0
-        target_type = "serial"
-      }
-    ]
-    channels = [
-      {
-        target = {
-          virt_io = {
-            name = "org.qemu.guest_agent.0"
-          }
-        }
-        source = {
-          unix = {}
-        }
-      }
-    ]
-    graphics = [
-      {
-        vnc = {
-          auto_port = true
-          listen    = "0.0.0.0"
-        }
-      }
-    ]
-    videos = [
-      {
-        model = {
-          type    = "vga"
-          primary = "yes"
-          heads   = 1
-          vram    = 16384
-        }
-      }
-    ]
-  }
+moved {
+  from = module.cloud_init_database
+  to   = module.cloud_init["database"]
+}
+moved {
+  from = module.cloud_init_core
+  to   = module.cloud_init["core"]
+}
+moved {
+  from = module.cloud_init_kafka
+  to   = module.cloud_init["kafka"]
+}
+moved {
+  from = module.cloud_init_minion
+  to   = module.cloud_init["minion"]
+}
+moved {
+  from = module.cloud_init_netsim
+  to   = module.cloud_init["netsim"]
+}
+moved {
+  from = module.cloud_init_monitoring
+  to   = module.cloud_init["monitoring"]
 }

--- a/terraform/kvm/modules/compute/variables.tf
+++ b/terraform/kvm/modules/compute/variables.tf
@@ -5,38 +5,21 @@ variable "ssh_public_key" {
   type      = string
   sensitive = true
 }
-variable "net_sim_cidr" { type = string }
-variable "net_sim_gateway" { type = string }
 variable "hosts" { type = map(string) }
-variable "ip_database" { type = string }
-variable "ip_core" { type = string }
-variable "ip_kafka" { type = string }
-variable "ip_minion" { type = string }
-variable "ip_netsim" { type = string }
-variable "ip_monitoring" { type = string }
-variable "ip_database_db" { type = string }
-variable "ip_core_db" { type = string }
-variable "ip_core_kafka" { type = string }
-variable "ip_kafka_kafka" { type = string }
-variable "ip_minion_kafka" { type = string }
-variable "ip_minion_sim" { type = string }
-variable "ip_netsim_sim" { type = string }
-variable "network_db_id" { type = string }
-variable "network_kafka_id" { type = string }
-variable "network_sim_id" { type = string }
 variable "extra_packages" {
   type    = list(string)
   default = ["qemu-guest-agent"]
 }
+
+variable "network_db_id" { type = string }
+variable "network_kafka_id" { type = string }
+variable "network_sim_id" { type = string }
 variable "network_mgmt_id" { type = string }
-variable "gateway_mgmt" { type = string }
 variable "network_external_id" { type = string }
-variable "ip_elasticsearch" { type = string }
-variable "ip_es_core" { type = string }
 
 variable "disk_sizes_gb" {
   type        = map(number)
-  description = "Disk size in GB per VM"
+  description = "Disk size in GB per role (keyed by topology role name)"
   default = {
     database      = 50
     core          = 100
@@ -46,4 +29,23 @@ variable "disk_sizes_gb" {
     monitoring    = 30
     elasticsearch = 50
   }
+}
+
+# Topology spec (keyed by role); see terraform/kvm/main.tf for the schema. One
+# interfaces list per role drives both the cloud-init network-config and the
+# libvirt_domain network interfaces (in the same order).
+variable "topology" {
+  type = map(object({
+    vm_name = string
+    memory  = number
+    vcpu    = number
+    interfaces = list(object({
+      subnet     = string
+      iface_name = string
+      address    = optional(string)
+      prefix     = optional(number)
+      gateway    = optional(string)
+      routes     = optional(list(object({ to = string, via = string })), [])
+    }))
+  }))
 }


### PR DESCRIPTION
> [!WARNING]
> **DRAFT — do not merge until the live `terraform plan` gate passes on your libvirt host.** Verified here with `make fmt`, `make validate-kvm`, and a static moved-vs-state cross-check. The no-destroy guarantee is confirmed for *addresses*; attribute-level parity (cloud-init content) is confirmed only by a real plan.

## Summary

Phase 1 of the deployment-topology restructure, on the **live provider**. KVM/libvirt is the only deployment with real state (37 resources), so it's both the highest-stakes and the verifiable target. The hand-written per-role libvirt resources become a single `topology` map(object) driving `for_each`.

Net: the 1234-line compute module drops to ~430 lines, same infrastructure.

## What changed (kvm only)

- **`terraform/kvm/main.tf`** — new `local.topology` (keyed by role: `vm_name`, `memory`, `vcpu`, and one ordered `interfaces` list per role with `subnet`/`iface_name`/`address`/`prefix`/`gateway`/`routes`); `compute` call slimmed from ~30 flat args to `topology` + network IDs + `disk_sizes_gb`.
- **compute module** — `7×{os volume, cloudinit disk, cloudinit iso, domain} + 7 cloud-init modules` → four `for_each` resources + one `for_each` module. One interfaces list drives both the cloud-init network-config **and** the domain NICs (same order).
- **35 `moved` blocks** (7 os-vol + 7 iso-vol + 7 cloudinit-disk + 7 domain + 7 cloud-init module) remap old addresses to the new `for_each` keys.

Unchanged: `libvirt_volume.ubuntu_base`, the 5 `libvirt_network`s, and the shared inventory/diagram modules.

## Parity design (why this should be a no-op plan)

- `meta_data` heredocs kept verbatim (indexed by role) — no cloud-init drift there.
- cloud-init module inputs reproduced exactly (interface names `enp1s0/2s0/3s0`, addresses, `prefix=26`, mgmt `gateway` = `.1` of subnet_mgmt except monitoring=null, minion sim route, monitoring DHCP external NIC) → identical `user_data`/`network_config` → cloud-init disk unchanged.
- Per-role `memory`/`vcpu`/disk size and domain NIC order preserved.

## Static verification already done

Cross-checked the `moved` map against the live state file:
- **28 migratable resources ↔ 28 `moved` blocks — 0 would be destroyed**, no typos, no duplicate targets (+7 no-op module moves; the cloud-init module has no state resources).

## Required verification before merge

Run on the libvirt host and confirm **0 to add, 0 to destroy** (only `moved` notices + at most benign in-place):

```bash
terraform -chdir=terraform/kvm plan \
  -var-file=../lab.tfvars -var-file=../disk-sizes.tfvars -var-file=kvm.tfvars
```

If anything shows destroy/recreate (watch the `libvirt_cloudinit_disk`/`libvirt_domain` resources), paste it here and we adjust before merge.

Blueprint: `_bmad-output/planning-artifacts/phase1-topology-as-data-design.md` (Azure-oriented, but the pattern is identical).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
