### PR TITLE
feat(deployments): provider-agnostic deployment library (Phase 2 scaffolding)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,10 @@ SHELL := /usr/bin/env bash
 # Providers with a Terraform root under terraform/<provider>/.
 PROVIDERS := azure kvm proxmox vmware
 
+# Deployment library — provider-agnostic topology specs under deployments/<slug>/.
+DEPLOYMENTS_DIR := deployments
+DESCRIPTOR := python3 $(DEPLOYMENTS_DIR)/bin/topology-descriptor.py
+
 # Ansible verbosity passthrough (e.g. V=-vvv).
 V ?=
 # Extra args forwarded verbatim to terraform via deploy.sh (e.g. TF_ARGS="-var foo=bar").
@@ -96,6 +100,27 @@ lint: fmt validate tflint lint-ansible ## Run all lint checks
 .PHONY: providers
 providers: ## List available providers
 	@echo "$(PROVIDERS)"
+
+# ── deployment library ──────────────────────────────────────────────────────────
+
+.PHONY: deployments
+deployments: ## List deployments and their canonical descriptors
+	@for f in $(DEPLOYMENTS_DIR)/*/topology.yml; do \
+	  slug=$$(basename $$(dirname $$f)); \
+	  printf "  \033[36m%-22s\033[0m %s\n" "$$slug" "$$($(DESCRIPTOR) $$f 2>/dev/null)"; \
+	done
+
+.PHONY: deployment
+deployment: guard-DEPLOYMENT ## Show + validate one deployment spec (DEPLOYMENT=<slug>)
+	@f="$(DEPLOYMENTS_DIR)/$(DEPLOYMENT)/topology.yml"; \
+	[ -f "$$f" ] || { echo "Error: no such deployment '$(DEPLOYMENT)' ($$f not found)" >&2; exit 1; }; \
+	$(DESCRIPTOR) --validate "$$f" && echo && cat "$$f"
+
+.PHONY: validate-deployments
+validate-deployments: ## Validate every deployment spec against the schema
+	@rc=0; for f in $(DEPLOYMENTS_DIR)/*/topology.yml; do \
+	  $(DESCRIPTOR) --validate "$$f" >/dev/null || { $(DESCRIPTOR) --validate "$$f"; rc=1; }; \
+	done; [ $$rc -eq 0 ] && echo "all deployment specs valid" || exit $$rc
 
 .PHONY: help
 help: ## Show this help

--- a/deployments/README.md
+++ b/deployments/README.md
@@ -1,0 +1,119 @@
+# Deployment Library
+
+A **deployment** is a "topology under test": which components run, how many nodes
+of each, and how they are grouped — expressed as provider-agnostic data. One
+deployment can be provisioned onto any Terraform provider and can host many
+**experiments** (the workloads run against it).
+
+```
+deployments/
+  <slug>/
+    topology.yml     # the provider-agnostic spec (source of truth)
+  bin/
+    topology-descriptor.py   # derive the canonical descriptor from a spec
+```
+
+## Status (Phase 2)
+
+The specs and tooling here are live. The Terraform **consumption** of a spec —
+translating it into a provider's `local.topology` so `make deploy DEPLOYMENT=…
+PROVIDER=…` provisions it — lands in Phase 2b, once the Phase 1 `for_each`
+refactor (topology-as-data) is merged per provider. Until then, `make
+deployments` / `make deployment` list and validate the library, and the
+descriptor tool works standalone.
+
+## Spec schema (`topology.yml`)
+
+```yaml
+name: mimir-ha                 # must equal the directory slug
+description: 3-node HA Mimir stack, multi-Minion, nl6 load
+roles:                         # keyed by component role
+  elasticsearch:
+    count: 3                   # node count (0 or omit = excluded)
+    size: large                # t-shirt class (see below)
+    subnets: [mgmt, db]        # ordered; first is the mgmt/primary NIC
+    groups: [elasticsearch, docker_engine]   # Ansible inventory groups
+  minion:
+    count: 2
+    size: small
+    subnets: [mgmt, kafka, sim]
+    routes: { sim: net_sim }   # named static route on the given subnet's NIC
+    groups: [minion]
+  monitoring:
+    count: 1
+    size: small
+    subnets: [mgmt, external]
+    public_ip: true            # jump host (external/DHCP NIC + public reachability)
+    groups: [mon_servers, docker_engine, grafana]
+```
+
+### Roles → component codes
+
+Each role maps to a stable 2–3 char code used in the canonical descriptor:
+
+| role | code | role | code |
+|---|---|---|---|
+| `core` | `on` | `elasticsearch` | `es` |
+| `minion` | `mn` | `mimir` | `mm` |
+| `sentinel` | `sn` | `victoriametrics` | `vm` |
+| `database` | `pg` | `clickhouse` | `ch` |
+| `kafka` | `kf` | `akvorado` | `ak` |
+| `rrd` | `rr` | `loadgen` (nl6) | `nl6` |
+
+`monitoring` is always-present infrastructure (Grafana/Prometheus/Jaeger) and is
+**excluded** from the descriptor. `loadgen` is the nl6 generator — included by
+default; opt out by omitting the role or setting `count: 0`.
+
+### Size classes (provider translates to concrete resources)
+
+| class | vCPU | RAM | notes |
+|---|---|---|---|
+| `small` | 2 | 4 GiB | db, kafka, minion, netsim, mon |
+| `medium` | 2 | 8 GiB | |
+| `large` | 4 | 8 GiB | elasticsearch |
+| `xlarge` | 4 | 16 GiB | core |
+
+Each provider owns the class → SKU/flavour mapping (Azure `Standard_D*`, Hetzner
+`cx*`, or explicit `cores`/`memory` for libvirt/proxmox). Disk sizes come from
+the provider's `disk_sizes_gb` keyed by role.
+
+### Subnets
+
+`mgmt` (management + Ansible/SSH), `db`, `kafka`, `sim` (SNMP simulation),
+`external` (DHCP bridge for the monitoring jump host). Interface order in
+`subnets` fixes NIC order on the VM.
+
+## Identifier scheme
+
+- **slug** — the human handle (kebab-case), equals the directory name; used as
+  hostname prefix, Terraform workspace, and Grafana label.
+- **canonical descriptor** — machine-derived from the spec, `<count><code>`
+  tokens in a fixed order joined by `-` (e.g. `3es-3mm-1pg-3sn-3kf-1on-2mn-nl6`).
+  Used as the reproducibility fingerprint on results. Generate with:
+
+  ```bash
+  make deployment DEPLOYMENT=mimir-ha        # or:
+  python3 deployments/bin/topology-descriptor.py deployments/mimir-ha/topology.yml
+  ```
+
+Descriptor component order: `es mm vm ch ak rr pg sn kf on mn nl6`.
+
+## Deployment index
+
+| slug | descriptor | notes |
+|---|---|---|
+| `baseline` | `1es-1pg-1kf-1on-1mn-nl6` | the current single-node lab (reference) |
+| `mimir-ha` (A) | `3es-3mm-1pg-3sn-3kf-1on-2mn-nl6` | full HA Mimir + Sentinel |
+| `rrd-minimal` (B) | `1rr-1pg-1kf-1on-1mn` | RRDTool on core, minimal |
+| `vm-cluster-es` (C) | `1es-3vm-1pg-1on` | VictoriaMetrics cluster + ES flows |
+| `es-nostore` (D) | `1es-1pg-1kf-1on-1mn` | ES flows, no metrics TSDB |
+| `vm-cluster-minion` (E) | `3vm-1pg-1kf-1on-1mn` | VictoriaMetrics cluster + minion |
+| `vm-single` (F) | `1vm-1pg-1on` | single VictoriaMetrics |
+| `mimir-single` (G) | `1mm-1pg-1on` | single Mimir |
+| `clickhouse-akvorado` (H) | `1ch-1ak` | standalone flow-engine (no OpenNMS) |
+
+**Interpretation notes:** B lists RRDTool without a Core, but RRD is a Core
+storage strategy, so `baseline`/B include `core` with the RRD strategy set at the
+Ansible layer. Components beyond the current lab (mimir, victoriametrics,
+clickhouse, akvorado, sentinel) are valid spec data now; their Ansible roles and
+provider translation arrive in Phase 3 (component breadth).

--- a/deployments/baseline/topology.yml
+++ b/deployments/baseline/topology.yml
@@ -1,0 +1,42 @@
+name: baseline
+description: >-
+  The current single-node lab (reference topology). One instance of each
+  component; TSDB strategy (RRD/ES) is set at the Ansible layer on core.
+roles:
+  elasticsearch:
+    count: 1
+    size: large
+    subnets: [mgmt, db]
+    groups: [elasticsearch, docker_engine]
+  database:
+    count: 1
+    size: small
+    subnets: [mgmt, db]
+    groups: [database]
+  core:
+    count: 1
+    size: xlarge
+    subnets: [mgmt, db, kafka]
+    groups: [core]
+  kafka:
+    count: 1
+    size: small
+    subnets: [mgmt, kafka]
+    groups: [message_broker, docker_engine, kafka_ui]
+  minion:
+    count: 1
+    size: small
+    subnets: [mgmt, kafka, sim]
+    routes: { sim: net_sim }
+    groups: [minion]
+  loadgen:
+    count: 1
+    size: small
+    subnets: [mgmt, sim]
+    groups: [net_sim, docker_engine]
+  monitoring:
+    count: 1
+    size: small
+    subnets: [mgmt, external]
+    public_ip: true
+    groups: [mon_servers, docker_engine, grafana]

--- a/deployments/bin/topology-descriptor.py
+++ b/deployments/bin/topology-descriptor.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Derive the canonical descriptor from a deployment topology.yml.
+
+The descriptor is a reproducibility fingerprint: <count><code> tokens in a fixed
+component order, joined by '-', e.g. 3es-3mm-1pg-3sn-3kf-1on-2mn-nl6.
+
+Usage:
+    topology-descriptor.py <path/to/topology.yml>
+    topology-descriptor.py --validate <path/to/topology.yml>   # exit non-zero on schema errors
+"""
+import sys
+import re
+
+# role -> descriptor code. monitoring is infra and intentionally excluded.
+ROLE_CODES = {
+    "core": "on",
+    "minion": "mn",
+    "sentinel": "sn",
+    "database": "pg",
+    "kafka": "kf",
+    "rrd": "rr",
+    "elasticsearch": "es",
+    "mimir": "mm",
+    "victoriametrics": "vm",
+    "clickhouse": "ch",
+    "akvorado": "ak",
+    "loadgen": "nl6",
+}
+# Fixed emit order for a stable, comparable descriptor.
+ORDER = ["es", "mm", "vm", "ch", "ak", "rr", "pg", "sn", "kf", "on", "mn", "nl6"]
+KNOWN_SIZES = {"small", "medium", "large", "xlarge"}
+KNOWN_SUBNETS = {"mgmt", "db", "kafka", "sim", "external"}
+
+
+def _load(path):
+    try:
+        import yaml
+    except ImportError:
+        sys.exit("PyYAML required: pip install pyyaml")
+    with open(path) as fh:
+        return yaml.safe_load(fh)
+
+
+def descriptor(spec):
+    counts = {}
+    for role, cfg in (spec.get("roles") or {}).items():
+        code = ROLE_CODES.get(role)
+        if code is None:  # monitoring / unknown -> not in descriptor
+            continue
+        n = int(cfg.get("count", 1))
+        if n > 0:
+            counts[code] = counts.get(code, 0) + n
+    # nl6 is a singleton presence flag — emit bare "nl6" (no count) when count == 1.
+    def tok(c):
+        return "nl6" if c == "nl6" and counts[c] == 1 else f"{counts[c]}{c}"
+
+    return "-".join(tok(c) for c in ORDER if c in counts)
+
+
+def validate(path, spec):
+    errors = []
+    slug = spec.get("name")
+    dir_slug = path.split("/")[-2] if "/" in path else None
+    if not slug:
+        errors.append("missing 'name'")
+    elif dir_slug and slug != dir_slug:
+        errors.append(f"name '{slug}' != directory '{dir_slug}'")
+    if slug and not re.fullmatch(r"[a-z0-9]([a-z0-9-]*[a-z0-9])?", slug):
+        errors.append(f"slug '{slug}' not a valid DNS-1123 label (lowercase, digits, hyphen)")
+    if len(slug or "") > 63:
+        errors.append("slug exceeds 63 chars")
+    roles = spec.get("roles") or {}
+    if not roles:
+        errors.append("no roles defined")
+    for role, cfg in roles.items():
+        where = f"role '{role}'"
+        if cfg.get("size") not in KNOWN_SIZES:
+            errors.append(f"{where}: size '{cfg.get('size')}' not in {sorted(KNOWN_SIZES)}")
+        for sn in cfg.get("subnets") or []:
+            if sn not in KNOWN_SUBNETS:
+                errors.append(f"{where}: unknown subnet '{sn}'")
+        if not cfg.get("groups") and role != "monitoring":
+            errors.append(f"{where}: no inventory groups")
+    return errors
+
+
+def main(argv):
+    args = [a for a in argv[1:] if not a.startswith("--")]
+    do_validate = "--validate" in argv
+    if len(args) != 1:
+        sys.exit(__doc__)
+    path = args[0]
+    spec = _load(path)
+    errs = validate(path, spec)
+    if do_validate:
+        if errs:
+            print(f"INVALID {path}:", file=sys.stderr)
+            for e in errs:
+                print(f"  - {e}", file=sys.stderr)
+            return 1
+        print(f"OK {spec['name']}: {descriptor(spec)}")
+        return 0
+    if errs:
+        print(f"warning: {path} has schema issues: {errs}", file=sys.stderr)
+    print(descriptor(spec))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/deployments/clickhouse-akvorado/topology.yml
+++ b/deployments/clickhouse-akvorado/topology.yml
@@ -1,0 +1,17 @@
+name: clickhouse-akvorado
+description: >-
+  Deployment H — standalone flow-engine comparison: 1 ClickHouse, 1 Akvorado.
+  No OpenNMS components; Akvorado ships its own console/UI, so no separate
+  monitoring VM.
+roles:
+  clickhouse:
+    count: 1
+    size: large
+    subnets: [mgmt, sim]
+    groups: [clickhouse, docker_engine]
+  akvorado:
+    count: 1
+    size: medium
+    subnets: [mgmt, sim]
+    public_ip: true
+    groups: [akvorado, docker_engine]

--- a/deployments/es-nostore/topology.yml
+++ b/deployments/es-nostore/topology.yml
@@ -1,0 +1,37 @@
+name: es-nostore
+description: >-
+  Deployment D — Elasticsearch for flows, no metrics TSDB persistence, 1
+  PostgreSQL, 1 Core, 1 Kafka, 1 Minion.
+roles:
+  elasticsearch:
+    count: 1
+    size: large
+    subnets: [mgmt, db]
+    groups: [elasticsearch, docker_engine]
+  database:
+    count: 1
+    size: small
+    subnets: [mgmt, db]
+    groups: [database]
+  core:
+    count: 1
+    size: xlarge
+    subnets: [mgmt, db, kafka]
+    groups: [core]
+  kafka:
+    count: 1
+    size: small
+    subnets: [mgmt, kafka]
+    groups: [message_broker, docker_engine, kafka_ui]
+  minion:
+    count: 1
+    size: small
+    subnets: [mgmt, kafka, sim]
+    routes: { sim: net_sim }
+    groups: [minion]
+  monitoring:
+    count: 1
+    size: small
+    subnets: [mgmt, external]
+    public_ip: true
+    groups: [mon_servers, docker_engine, grafana]

--- a/deployments/mimir-ha/topology.yml
+++ b/deployments/mimir-ha/topology.yml
@@ -1,0 +1,52 @@
+name: mimir-ha
+description: >-
+  Deployment A — full HA stack: 3 Elasticsearch, 3 Mimir, 3 Sentinel, 3 Kafka,
+  1 PostgreSQL, 1 Core, 2 Minion, nl6 load generator.
+roles:
+  elasticsearch:
+    count: 3
+    size: large
+    subnets: [mgmt, db]
+    groups: [elasticsearch, docker_engine]
+  mimir:
+    count: 3
+    size: large
+    subnets: [mgmt, db]
+    groups: [mimir, docker_engine]
+  database:
+    count: 1
+    size: small
+    subnets: [mgmt, db]
+    groups: [database]
+  sentinel:
+    count: 3
+    size: medium
+    subnets: [mgmt, db, kafka]
+    groups: [sentinel]
+  kafka:
+    count: 3
+    size: medium
+    subnets: [mgmt, kafka]
+    groups: [message_broker, docker_engine, kafka_ui]
+  core:
+    count: 1
+    size: xlarge
+    subnets: [mgmt, db, kafka]
+    groups: [core]
+  minion:
+    count: 2
+    size: small
+    subnets: [mgmt, kafka, sim]
+    routes: { sim: net_sim }
+    groups: [minion]
+  loadgen:
+    count: 1
+    size: small
+    subnets: [mgmt, sim]
+    groups: [net_sim, docker_engine]
+  monitoring:
+    count: 1
+    size: small
+    subnets: [mgmt, external]
+    public_ip: true
+    groups: [mon_servers, docker_engine, grafana]

--- a/deployments/mimir-single/topology.yml
+++ b/deployments/mimir-single/topology.yml
@@ -1,0 +1,24 @@
+name: mimir-single
+description: Deployment G — single Mimir, 1 PostgreSQL, 1 Core.
+roles:
+  mimir:
+    count: 1
+    size: large
+    subnets: [mgmt, db]
+    groups: [mimir, docker_engine]
+  database:
+    count: 1
+    size: small
+    subnets: [mgmt, db]
+    groups: [database]
+  core:
+    count: 1
+    size: xlarge
+    subnets: [mgmt, db, kafka]
+    groups: [core]
+  monitoring:
+    count: 1
+    size: small
+    subnets: [mgmt, external]
+    public_ip: true
+    groups: [mon_servers, docker_engine, grafana]

--- a/deployments/rrd-minimal/topology.yml
+++ b/deployments/rrd-minimal/topology.yml
@@ -1,0 +1,38 @@
+name: rrd-minimal
+description: >-
+  Deployment B — RRDTool storage on Core, minimal: 1 PostgreSQL, 1 Kafka,
+  1 Minion. RRD is a Core storage strategy, so Core is included with the RRD
+  strategy set at the Ansible layer.
+roles:
+  rrd:
+    count: 1
+    size: small
+    subnets: [mgmt]
+    groups: [rrd]
+  database:
+    count: 1
+    size: small
+    subnets: [mgmt, db]
+    groups: [database]
+  core:
+    count: 1
+    size: xlarge
+    subnets: [mgmt, db, kafka]
+    groups: [core]
+  kafka:
+    count: 1
+    size: small
+    subnets: [mgmt, kafka]
+    groups: [message_broker, docker_engine, kafka_ui]
+  minion:
+    count: 1
+    size: small
+    subnets: [mgmt, kafka, sim]
+    routes: { sim: net_sim }
+    groups: [minion]
+  monitoring:
+    count: 1
+    size: small
+    subnets: [mgmt, external]
+    public_ip: true
+    groups: [mon_servers, docker_engine, grafana]

--- a/deployments/vm-cluster-es/topology.yml
+++ b/deployments/vm-cluster-es/topology.yml
@@ -1,0 +1,31 @@
+name: vm-cluster-es
+description: >-
+  Deployment C — VictoriaMetrics cluster (3 nodes) for metrics + 1 Elasticsearch
+  for flows, 1 PostgreSQL, 1 Core.
+roles:
+  elasticsearch:
+    count: 1
+    size: large
+    subnets: [mgmt, db]
+    groups: [elasticsearch, docker_engine]
+  victoriametrics:
+    count: 3
+    size: medium
+    subnets: [mgmt, db]
+    groups: [victoriametrics, docker_engine]
+  database:
+    count: 1
+    size: small
+    subnets: [mgmt, db]
+    groups: [database]
+  core:
+    count: 1
+    size: xlarge
+    subnets: [mgmt, db, kafka]
+    groups: [core]
+  monitoring:
+    count: 1
+    size: small
+    subnets: [mgmt, external]
+    public_ip: true
+    groups: [mon_servers, docker_engine, grafana]

--- a/deployments/vm-cluster-minion/topology.yml
+++ b/deployments/vm-cluster-minion/topology.yml
@@ -1,0 +1,37 @@
+name: vm-cluster-minion
+description: >-
+  Deployment E — VictoriaMetrics cluster (3 nodes), 1 PostgreSQL, 1 Core,
+  1 Kafka, 1 Minion.
+roles:
+  victoriametrics:
+    count: 3
+    size: medium
+    subnets: [mgmt, db]
+    groups: [victoriametrics, docker_engine]
+  database:
+    count: 1
+    size: small
+    subnets: [mgmt, db]
+    groups: [database]
+  core:
+    count: 1
+    size: xlarge
+    subnets: [mgmt, db, kafka]
+    groups: [core]
+  kafka:
+    count: 1
+    size: small
+    subnets: [mgmt, kafka]
+    groups: [message_broker, docker_engine, kafka_ui]
+  minion:
+    count: 1
+    size: small
+    subnets: [mgmt, kafka, sim]
+    routes: { sim: net_sim }
+    groups: [minion]
+  monitoring:
+    count: 1
+    size: small
+    subnets: [mgmt, external]
+    public_ip: true
+    groups: [mon_servers, docker_engine, grafana]

--- a/deployments/vm-single/topology.yml
+++ b/deployments/vm-single/topology.yml
@@ -1,0 +1,24 @@
+name: vm-single
+description: Deployment F — single VictoriaMetrics, 1 PostgreSQL, 1 Core.
+roles:
+  victoriametrics:
+    count: 1
+    size: large
+    subnets: [mgmt, db]
+    groups: [victoriametrics, docker_engine]
+  database:
+    count: 1
+    size: small
+    subnets: [mgmt, db]
+    groups: [database]
+  core:
+    count: 1
+    size: xlarge
+    subnets: [mgmt, db, kafka]
+    groups: [core]
+  monitoring:
+    count: 1
+    size: small
+    subnets: [mgmt, external]
+    public_ip: true
+    groups: [mon_servers, docker_engine, grafana]


### PR DESCRIPTION
## Summary

Phase 2 scaffolding: a **deployment library** — `deployments/<slug>/topology.yml` as the provider-agnostic source of truth for each "topology under test" (which components, node counts, sizes, subnets, inventory groups). This is the structure the whole restructure was aiming at: pick a deployment + a provider, provision it, run experiments against it.

Safe and self-contained — **touches no Terraform provider roots and no live state.**

## What's in this PR

- **`deployments/README.md`** — the spec schema: role→component-code map, size classes, subnets, the slug + canonical-descriptor identifier scheme, and the A–H index.
- **9 spec files** — `baseline` (the current lab, reference) + the eight A–H target deployments (`mimir-ha`, `rrd-minimal`, `vm-cluster-es`, `es-nostore`, `vm-cluster-minion`, `vm-single`, `mimir-single`, `clickhouse-akvorado`).
- **`deployments/bin/topology-descriptor.py`** — derives the reproducibility fingerprint (e.g. `3es-3mm-1pg-3sn-3kf-1on-2mn-nl6`) and validates specs against the schema.
- **Makefile**: `make deployments` (list + descriptors), `make deployment DEPLOYMENT=<slug>` (show + validate one), `make validate-deployments` (all).

## Verified

- `make validate-deployments` → all 9 specs valid.
- `make deployments` descriptors match the README index exactly for all 9.

## Deferred to Phase 2b (not in this PR)

Terraform consumption of a spec — translating agnostic `topology.yml` → a provider's `local.topology` so `make deploy DEPLOYMENT=… PROVIDER=…` provisions it. That edits the provider roots, so it waits until the Phase 1 `for_each` refactor merges per provider (PR #127 for KVM), to avoid disturbing the live-state plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
