### PR TITLE
feat(kvm): spec-driven topology from the deployment library (Phase 2b)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,13 @@ DESCRIPTOR := python3 $(DEPLOYMENTS_DIR)/bin/topology-descriptor.py
 V ?=
 # Extra args forwarded verbatim to terraform via deploy.sh (e.g. TF_ARGS="-var foo=bar").
 TF_ARGS ?=
+# Deployment slug from the library (deployments/<slug>/). Consumed by kvm today.
+DEPLOYMENT ?= baseline
+
+# The deployment var is declared only on providers wired for spec-driven topology
+# (kvm in Phase 2b); never pass it to the others. Combined with any TF_ARGS.
+_dep_tfarg = $(if $(filter kvm,$(PROVIDER)),-var deployment=$(DEPLOYMENT))
+_tfargs    = $(strip $(_dep_tfarg) $(TF_ARGS))
 
 # ── guards ────────────────────────────────────────────────────────────────────
 
@@ -54,12 +61,21 @@ endif
 # ── lifecycle (delegates to deploy.sh) ──────────────────────────────────────────
 
 .PHONY: deploy
-deploy: check-provider ## Provision + configure the lab for PROVIDER
-	./deploy.sh --provider $(PROVIDER) $(if $(TF_ARGS),--tf-args "$(TF_ARGS)") $(V)
+deploy: check-provider ## Provision + configure the lab (PROVIDER=…, kvm: DEPLOYMENT=<slug>)
+	./deploy.sh --provider $(PROVIDER) $(if $(_tfargs),--tf-args "$(_tfargs)") $(V)
 
 .PHONY: destroy
 destroy: check-provider confirm ## Tear down all lab resources for PROVIDER
-	./deploy.sh --provider $(PROVIDER) --destroy $(if $(TF_ARGS),--tf-args "$(TF_ARGS)") $(V)
+	./deploy.sh --provider $(PROVIDER) --destroy $(if $(_tfargs),--tf-args "$(_tfargs)") $(V)
+
+.PHONY: plan
+plan: check-provider ## terraform plan for PROVIDER (kvm: DEPLOYMENT=<slug>)
+	terraform -chdir=terraform/$(PROVIDER) init -input=false $(if $(filter kvm,$(PROVIDER)),-upgrade) >/dev/null
+	terraform -chdir=terraform/$(PROVIDER) plan -input=false \
+	  -var-file=../lab.tfvars \
+	  $(if $(filter kvm proxmox vmware,$(PROVIDER)),-var-file=../disk-sizes.tfvars) \
+	  -var-file=$(PROVIDER).tfvars \
+	  $(_dep_tfarg)
 
 # ── lint (mirrors .github/workflows) ────────────────────────────────────────────
 

--- a/terraform/kvm/main.tf
+++ b/terraform/kvm/main.tf
@@ -13,74 +13,80 @@ locals {
   # The monitoring VM is the exception: it routes out via its DHCP external NIC.
   gateway_mgmt = cidrhost(var.subnet_mgmt, 1)
 
-  # Topology spec (keyed by role): the deployment-under-test as data. Node count
-  # is 1 per role today; interface addresses/gateways/sizes are the current
-  # values, so this refactor is byte-for-byte identical in plan. One interfaces
-  # list per role drives both cloud-init network-config and the domain NICs.
+  # ── deployment spec → kvm topology translation ────────────────────────────
+  # Read the provider-agnostic spec (roles/count/size/subnets/groups/routes) and
+  # translate it into the provider-specific topology the compute module consumes.
+  spec = yamldecode(file("${path.root}/../../deployments/${var.deployment}/topology.yml"))
+
+  # t-shirt size class → libvirt memory (MiB) / vCPU (see deployments/README.md).
+  size_map = {
+    small  = { memory = 4096, vcpu = 2 }
+    medium = { memory = 8192, vcpu = 2 }
+    large  = { memory = 8192, vcpu = 4 }
+    xlarge = { memory = 16384, vcpu = 4 }
+  }
+
+  # Spec role → provider role key (identity unless remapped). nl6 runs on netsim.
+  provider_role = {
+    loadgen = "netsim"
+  }
+
+  # Provider role → VM-name prefix ("<prefix>-benchmark-NN").
+  role_shortname = {
+    database   = "db", core = "core", kafka = "kafka", minion = "minion"
+    netsim     = "netsim", monitoring = "mon", elasticsearch = "es"
+    sentinel   = "sentinel", mimir = "mimir", victoriametrics = "vm"
+    clickhouse = "ch", akvorado = "akvorado", rrd = "rrd"
+  }
+
+  subnet_cidr = {
+    mgmt  = var.subnet_mgmt
+    db    = var.subnet_db
+    kafka = var.subnet_kafka
+    sim   = var.subnet_sim
+  }
+
+  # Per-subnet base IP offset per provider role; node i gets offset + i.
+  # Baseline offsets reproduce the current lab.tfvars addresses exactly.
+  ip_offset = {
+    mgmt  = { database = 4, core = 5, kafka = 6, minion = 7, monitoring = 8, netsim = 9, elasticsearch = 10, sentinel = 11, rrd = 12, mimir = 16, victoriametrics = 24, clickhouse = 40, akvorado = 41 }
+    db    = { database = 4, core = 5, elasticsearch = 6, sentinel = 8, mimir = 16, victoriametrics = 24, clickhouse = 40 }
+    kafka = { kafka = 4, core = 5, minion = 6, sentinel = 8 }
+    sim   = { minion = 5, netsim = 6, clickhouse = 10, akvorado = 11 }
+  }
+
+  named_routes = {
+    net_sim = { to = var.net_sim_cidr, via = var.net_sim_gateway }
+  }
+
+  # Expand each spec role into `count` nodes, keyed by provider role (+ -N when >1).
+  nodes = merge([
+    for srole, cfg in local.spec.roles : {
+      for i in range(try(cfg.count, 1)) :
+      "${lookup(local.provider_role, srole, srole)}${try(cfg.count, 1) > 1 ? "-${i}" : ""}" => {
+        prole = lookup(local.provider_role, srole, srole)
+        index = i
+        cfg   = cfg
+      }
+    }
+  ]...)
+
   topology = {
-    elasticsearch = {
-      vm_name = "es-benchmark-01"
-      memory  = 8192
-      vcpu    = 4
+    for key, n in local.nodes :
+    key => {
+      vm_name = "${local.role_shortname[n.prole]}-benchmark-${format("%02d", n.index + 1)}"
+      memory  = local.size_map[n.cfg.size].memory
+      vcpu    = local.size_map[n.cfg.size].vcpu
+      disk_gb = lookup(var.disk_sizes_gb, n.prole, 30)
       interfaces = [
-        { subnet = "mgmt", iface_name = "enp1s0", address = var.ip_elasticsearch, prefix = 26, gateway = local.gateway_mgmt },
-        { subnet = "db", iface_name = "enp2s0", address = var.ip_es_core, prefix = 26, gateway = null },
-      ]
-    }
-    database = {
-      vm_name = "db-benchmark-01"
-      memory  = 4096
-      vcpu    = 2
-      interfaces = [
-        { subnet = "mgmt", iface_name = "enp1s0", address = var.ip_database, prefix = 26, gateway = local.gateway_mgmt },
-        { subnet = "db", iface_name = "enp2s0", address = var.ip_database_db, prefix = 26, gateway = null },
-      ]
-    }
-    core = {
-      vm_name = "core-benchmark-01"
-      memory  = 16384
-      vcpu    = 4
-      interfaces = [
-        { subnet = "mgmt", iface_name = "enp1s0", address = var.ip_core, prefix = 26, gateway = local.gateway_mgmt },
-        { subnet = "db", iface_name = "enp2s0", address = var.ip_core_db, prefix = 26, gateway = null },
-        { subnet = "kafka", iface_name = "enp3s0", address = var.ip_core_kafka, prefix = 26, gateway = null },
-      ]
-    }
-    kafka = {
-      vm_name = "kafka-benchmark-01"
-      memory  = 4096
-      vcpu    = 2
-      interfaces = [
-        { subnet = "mgmt", iface_name = "enp1s0", address = var.ip_kafka, prefix = 26, gateway = local.gateway_mgmt },
-        { subnet = "kafka", iface_name = "enp2s0", address = var.ip_kafka_kafka, prefix = 26, gateway = null },
-      ]
-    }
-    minion = {
-      vm_name = "minion-benchmark-01"
-      memory  = 4096
-      vcpu    = 2
-      interfaces = [
-        { subnet = "mgmt", iface_name = "enp1s0", address = var.ip_minion, prefix = 26, gateway = local.gateway_mgmt },
-        { subnet = "kafka", iface_name = "enp2s0", address = var.ip_minion_kafka, prefix = 26, gateway = null },
-        { subnet = "sim", iface_name = "enp3s0", address = var.ip_minion_sim, prefix = 26, gateway = null, routes = [{ to = var.net_sim_cidr, via = var.net_sim_gateway }] },
-      ]
-    }
-    netsim = {
-      vm_name = "netsim-benchmark-01"
-      memory  = 4096
-      vcpu    = 2
-      interfaces = [
-        { subnet = "mgmt", iface_name = "enp1s0", address = var.ip_netsim, prefix = 26, gateway = local.gateway_mgmt },
-        { subnet = "sim", iface_name = "enp2s0", address = var.ip_netsim_sim, prefix = 26, gateway = null },
-      ]
-    }
-    monitoring = {
-      vm_name = "mon-benchmark-01"
-      memory  = 4096
-      vcpu    = 2
-      interfaces = [
-        { subnet = "mgmt", iface_name = "enp1s0", address = var.ip_monitoring, prefix = 26, gateway = null },
-        { subnet = "external", iface_name = "enp2s0", address = null, prefix = null, gateway = null },
+        for si, subnet in n.cfg.subnets : {
+          subnet     = subnet
+          iface_name = "enp${si + 1}s0"
+          address    = subnet == "external" ? null : cidrhost(local.subnet_cidr[subnet], local.ip_offset[subnet][n.prole] + n.index)
+          prefix     = subnet == "external" ? null : 26
+          gateway    = (subnet == "mgmt" && !try(n.cfg.public_ip, false)) ? local.gateway_mgmt : null
+          routes     = try(n.cfg.routes[subnet], null) != null ? [local.named_routes[n.cfg.routes[subnet]]] : []
+        }
       ]
     }
   }
@@ -109,7 +115,6 @@ module "compute" {
   network_sim_id      = module.network.network_sim_id
   network_mgmt_id     = module.network.network_mgmt_id
   network_external_id = module.network.network_external_id
-  disk_sizes_gb       = var.disk_sizes_gb
   topology            = local.topology
 }
 

--- a/terraform/kvm/modules/compute/main.tf
+++ b/terraform/kvm/modules/compute/main.tf
@@ -16,37 +16,6 @@ locals {
     sim      = var.network_sim_id
     external = var.network_external_id
   }
-
-  cloud_init_meta_data = {
-    database      = <<-EOF
-      instance-id: db-benchmark-01
-      local-hostname: db-benchmark-01
-    EOF
-    core          = <<-EOF
-      instance-id: core-benchmark-01
-      local-hostname: core-benchmark-01
-    EOF
-    kafka         = <<-EOF
-      instance-id: kafka-benchmark-01
-      local-hostname: kafka-benchmark-01
-    EOF
-    minion        = <<-EOF
-      instance-id: minion-benchmark-01
-      local-hostname: minion-benchmark-01
-    EOF
-    netsim        = <<-EOF
-      instance-id: netsim-benchmark-01
-      local-hostname: netsim-benchmark-01
-    EOF
-    monitoring    = <<-EOF
-      instance-id: mon-benchmark-01
-      local-hostname: mon-benchmark-01
-    EOF
-    elasticsearch = <<-EOF
-      instance-id: es-benchmark-01
-      local-hostname: es-benchmark-01
-    EOF
-  }
 }
 
 # Ubuntu 24.04 LTS cloud image — must be the cloud image (qcow2), NOT the server installer ISO.
@@ -91,7 +60,7 @@ resource "libvirt_volume" "os" {
     format = { type = "qcow2" }
   }
 
-  capacity      = var.disk_sizes_gb[each.key]
+  capacity      = each.value.disk_gb
   capacity_unit = "GiB"
 }
 
@@ -120,7 +89,7 @@ resource "libvirt_cloudinit_disk" "ci" {
 
   name           = "${each.value.vm_name}-cloudinit"
   user_data      = module.cloud_init[each.key].user_data
-  meta_data      = local.cloud_init_meta_data[each.key]
+  meta_data      = "instance-id: ${each.value.vm_name}\nlocal-hostname: ${each.value.vm_name}\n"
   network_config = module.cloud_init[each.key].network_config
 }
 

--- a/terraform/kvm/modules/compute/variables.tf
+++ b/terraform/kvm/modules/compute/variables.tf
@@ -17,28 +17,15 @@ variable "network_sim_id" { type = string }
 variable "network_mgmt_id" { type = string }
 variable "network_external_id" { type = string }
 
-variable "disk_sizes_gb" {
-  type        = map(number)
-  description = "Disk size in GB per role (keyed by topology role name)"
-  default = {
-    database      = 50
-    core          = 100
-    kafka         = 50
-    minion        = 20
-    netsim        = 20
-    monitoring    = 30
-    elasticsearch = 50
-  }
-}
-
-# Topology spec (keyed by role); see terraform/kvm/main.tf for the schema. One
-# interfaces list per role drives both the cloud-init network-config and the
-# libvirt_domain network interfaces (in the same order).
+# Topology (keyed by node); see terraform/kvm/main.tf for how it is derived from
+# the deployment spec. One interfaces list per node drives both the cloud-init
+# network-config and the libvirt_domain network interfaces (in the same order).
 variable "topology" {
   type = map(object({
     vm_name = string
     memory  = number
     vcpu    = number
+    disk_gb = number
     interfaces = list(object({
       subnet     = string
       iface_name = string

--- a/terraform/kvm/variables.tf
+++ b/terraform/kvm/variables.tf
@@ -26,6 +26,13 @@ variable "vm_names" {
 variable "ip_elasticsearch" { type = string }
 variable "ip_es_core" { type = string }
 
+# Deployment selector — resolves deployments/<deployment>/topology.yml.
+variable "deployment" {
+  type        = string
+  default     = "baseline"
+  description = "Deployment slug under deployments/; selects the topology spec to provision."
+}
+
 # KVM-specific (from kvm.tfvars)
 variable "libvirt_uri" { type = string }
 variable "storage_pool" { type = string }


### PR DESCRIPTION
## Summary

Phase 2b — the payoff step: the KVM provider root now **consumes the deployment library**. It reads `deployments/<slug>/topology.yml` and translates the provider-agnostic spec into its `local.topology`, replacing the hardcoded per-role block. `make deploy PROVIDER=kvm DEPLOYMENT=<slug>` (and `make plan …`) now select a topology.

## What changed (kvm only + Makefile)

- **`deployment` variable** (default `baseline`) on the kvm root; resolves `deployments/<deployment>/topology.yml`.
- **Spec → topology translation** in `terraform/kvm/main.tf`: size class → memory/vcpu; per-subnet IP offsets (baseline offsets reproduce the current `lab.tfvars` addresses exactly); `enpNs0` interface names; mgmt gateway except `public_ip` roles; named routes (`net_sim`); `count` expansion into nodes keyed by provider role (`loadgen`→`netsim`).
- **Disk size** moves into the topology (per node) and **`meta_data`** is derived from `vm_name`, so the compute module handles arbitrary nodes/counts (no per-role hardcoding).
- **Makefile**: `make plan PROVIDER=kvm DEPLOYMENT=<slug>`; `deploy`/`destroy` inject `-var deployment=` for kvm only (never leaks to other providers).

## Verified with live `terraform plan` (against the libvirt host)

| Deployment | Plan | Notes |
|---|---|---|
| `baseline` | **37 to add, 0 to change, 0 to destroy** | Identical to merged #127 — same `for_each` keys, IPs (es .202, minion-sim .133, netsim-sim .134, core-kafka .69, db .196, core .197), memory (core 16384 / es 8192 / rest 4096), disk. |
| `mimir-single` | 25 to add, 0 destroy | Distinct topology: `mimir`/`database`/`core`/`monitoring`, `mimir-benchmark-01` at derived `.208`. Proves selection works. |

0 destroy/replace in both. (State is currently empty — the lab isn't deployed — so these are clean fresh-create plans.)

## Limitation → Phase 2c

The `inventory` and `diagram` modules still consume the flat `lab.tfvars` `ip_*` vars, so **only `baseline` is fully deployable end-to-end today**. Non-baseline specs provision the correct compute but need a **topology-driven inventory** before Ansible can configure them. That's Phase 2c (make the inventory module render from `local.topology`), plus adding Ansible/component roles for the new components (mimir, victoriametrics, clickhouse, sentinel, akvorado) in Phase 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
