### PR TITLE
feat(kvm): topology-driven Ansible inventory (Phase 2c)

### DIFF
--- a/terraform/kvm/main.tf
+++ b/terraform/kvm/main.tf
@@ -1,13 +1,7 @@
 locals {
-  hosts = {
-    "db-benchmark-01"     = var.ip_database
-    "core-benchmark-01"   = var.ip_core
-    "kafka-benchmark-01"  = var.ip_kafka
-    "minion-benchmark-01" = var.ip_minion
-    "netsim-benchmark-01" = var.ip_netsim
-    "mon-benchmark-01"    = var.ip_monitoring
-    "es-benchmark-01"     = var.ip_elasticsearch
-  }
+  # /etc/hosts map (hostname -> mgmt IP) for cloud-init, derived from the topology
+  # below so it matches whatever deployment is selected.
+  hosts = { for h, v in local.inv_hosts : h => v.ansible_host }
 
   # Default route for lab VMs is the mgmt network gateway (.1 of subnet_mgmt).
   # The monitoring VM is the exception: it routes out via its DHCP external NIC.
@@ -90,6 +84,27 @@ locals {
       ]
     }
   }
+
+  # ── inventory data derived from the topology ──────────────────────────────
+  # hostname -> ansible_host (mgmt IP), inventory groups, and host vars.
+  inv_hosts = {
+    for key, n in local.nodes :
+    local.topology[key].vm_name => {
+      ansible_host = [for i in local.topology[key].interfaces : i.address if i.subnet == "mgmt"][0]
+      groups       = try(n.cfg.groups, [])
+      # nl6 runs on the netsim host; expose its sim NIC name for the generator.
+      host_vars = n.prole == "netsim" ? {
+        nl6_net_interface = try([for i in local.topology[key].interfaces : i.iface_name if i.subnet == "sim"][0], "")
+      } : {}
+    }
+  }
+
+  # The jump host is the public_ip node (its external DHCP IP is var.jump_host).
+  jump_node_keys = [for key, n in local.nodes : key if try(n.cfg.public_ip, false)]
+  jump_host_name = length(local.jump_node_keys) > 0 ? local.topology[local.jump_node_keys[0]].vm_name : ""
+
+  # Composed parent group; children absent from the deployment are dropped.
+  onms_stack_children = ["database", "core", "message_broker", "elasticsearch", "minion", "sentinel", "grafana"]
 }
 
 module "network" {
@@ -147,17 +162,12 @@ module "diagram" {
 }
 
 module "inventory" {
-  source = "../modules/inventory"
+  source = "../modules/topology-inventory"
 
-  ip_database          = var.ip_database
-  ip_core              = var.ip_core
-  ip_kafka             = var.ip_kafka
-  ip_minion            = var.ip_minion
-  ip_netsim            = var.ip_netsim
-  ip_monitoring        = var.ip_monitoring
-  ip_elasticsearch     = var.ip_elasticsearch
-  admin_user           = var.admin_user
-  ssh_key_path         = var.ssh_key_path
-  jump_host            = var.jump_host
-  netsim_sim_interface = "enp2s0"
+  hosts          = local.inv_hosts
+  admin_user     = var.admin_user
+  ssh_key_path   = var.ssh_key_path
+  jump_host      = var.jump_host
+  jump_host_name = local.jump_host_name
+  parent_groups  = { opennms_stack = local.onms_stack_children }
 }

--- a/terraform/kvm/main.tf
+++ b/terraform/kvm/main.tf
@@ -90,7 +90,9 @@ locals {
   inv_hosts = {
     for key, n in local.nodes :
     local.topology[key].vm_name => {
-      ansible_host = [for i in local.topology[key].interfaces : i.address if i.subnet == "mgmt"][0]
+      # mgmt NIC address; "" if a role has no mgmt subnet (caught by the inventory
+      # module precondition with a clear message rather than a cryptic index error).
+      ansible_host = try([for i in local.topology[key].interfaces : i.address if i.subnet == "mgmt"][0], "")
       groups       = try(n.cfg.groups, [])
       # nl6 runs on the netsim host; expose its sim NIC name for the generator.
       host_vars = n.prole == "netsim" ? {
@@ -100,10 +102,14 @@ locals {
   }
 
   # The jump host is the public_ip node (its external DHCP IP is var.jump_host).
-  jump_node_keys = [for key, n in local.nodes : key if try(n.cfg.public_ip, false)]
-  jump_host_name = length(local.jump_node_keys) > 0 ? local.topology[local.jump_node_keys[0]].vm_name : ""
+  # one() errors if a spec marks more than one node public_ip; null if none.
+  jump_node_key  = one([for key, n in local.nodes : key if try(n.cfg.public_ip, false)])
+  jump_host_name = local.jump_node_key != null ? local.topology[local.jump_node_key].vm_name : ""
 
-  # Composed parent group; children absent from the deployment are dropped.
+  # Canonical opennms_stack membership. TSDB/flow backends (mimir, victoriametrics,
+  # clickhouse, akvorado) are intentionally excluded — OpenNMS writes to them; they
+  # are not orchestrated as part of the stack group. Children absent from the
+  # selected deployment are dropped by the inventory module.
   onms_stack_children = ["database", "core", "message_broker", "elasticsearch", "minion", "sentinel", "grafana"]
 }
 

--- a/terraform/modules/topology-inventory/main.tf
+++ b/terraform/modules/topology-inventory/main.tf
@@ -28,6 +28,17 @@ locals {
 
 resource "local_file" "ansible_inventory" {
   filename = "${path.root}/../../ansible-inventory.yml"
+
+  # NOTE: the template intentionally mirrors the legacy modules/inventory template
+  # while azure/proxmox/vmware still use it. When they migrate to this module the
+  # legacy one is removed and this becomes the single source.
+  lifecycle {
+    precondition {
+      condition     = alltrue([for h, n in var.hosts : try(n.ansible_host, "") != ""])
+      error_message = "Every host needs a management IP (ansible_host); a role in the deployment is missing a 'mgmt' subnet in its topology.yml interfaces."
+    }
+  }
+
   content = templatefile("${path.module}/templates/inventory.yml.tftpl", {
     hosts          = var.hosts
     admin_user     = var.admin_user

--- a/terraform/modules/topology-inventory/main.tf
+++ b/terraform/modules/topology-inventory/main.tf
@@ -1,0 +1,40 @@
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    local = {
+      source  = "hashicorp/local"
+      version = "~> 2.0"
+    }
+  }
+}
+
+locals {
+  # Union of all group names across hosts.
+  all_groups = sort(distinct(flatten([for h, n in var.hosts : n.groups])))
+
+  # group -> sorted member hostnames.
+  group_members = {
+    for g in local.all_groups :
+    g => sort([for h, n in var.hosts : h if contains(n.groups, g)])
+  }
+
+  # Parent groups, with children filtered to those actually present.
+  parent_present = {
+    for p, children in var.parent_groups :
+    p => [for c in children : c if contains(local.all_groups, c)]
+    if length([for c in children : c if contains(local.all_groups, c)]) > 0
+  }
+}
+
+resource "local_file" "ansible_inventory" {
+  filename = "${path.root}/../../ansible-inventory.yml"
+  content = templatefile("${path.module}/templates/inventory.yml.tftpl", {
+    hosts          = var.hosts
+    admin_user     = var.admin_user
+    ssh_key_path   = var.ssh_key_path
+    jump_host      = var.jump_host
+    jump_host_name = var.jump_host_name
+    group_members  = local.group_members
+    parent_groups  = local.parent_present
+  })
+}

--- a/terraform/modules/topology-inventory/templates/inventory.yml.tftpl
+++ b/terraform/modules/topology-inventory/templates/inventory.yml.tftpl
@@ -1,0 +1,36 @@
+all:
+  vars:
+    ansible_user: ${admin_user}
+    ansible_ssh_private_key_file: ${ssh_key_path}
+    ansible_python_interpreter: /usr/bin/python3
+%{ if jump_host != "" ~}
+    ansible_ssh_common_args: '-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ProxyCommand="ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -W %h:%p ${admin_user}@${jump_host}"'
+%{ endif ~}
+  hosts:
+%{ for hostname in sort(keys(hosts)) ~}
+    ${hostname}:
+%{ if hostname == jump_host_name && jump_host != "" ~}
+      ansible_host: ${jump_host}
+      ansible_ssh_common_args: '-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
+%{ else ~}
+      ansible_host: ${hosts[hostname].ansible_host}
+%{ endif ~}
+%{ for k in sort(keys(hosts[hostname].host_vars)) ~}
+      ${k}: "${hosts[hostname].host_vars[k]}"
+%{ endfor ~}
+%{ endfor ~}
+  children:
+%{ for group in sort(keys(group_members)) ~}
+    ${group}:
+      hosts:
+%{ for hostname in group_members[group] ~}
+        ${hostname}:
+%{ endfor ~}
+%{ endfor ~}
+%{ for parent in sort(keys(parent_groups)) ~}
+    ${parent}:
+      children:
+%{ for child in parent_groups[parent] ~}
+        ${child}:
+%{ endfor ~}
+%{ endfor ~}

--- a/terraform/modules/topology-inventory/variables.tf
+++ b/terraform/modules/topology-inventory/variables.tf
@@ -1,0 +1,29 @@
+variable "hosts" {
+  description = "Hostname -> { ansible_host, groups, host_vars } derived from the topology."
+  type = map(object({
+    ansible_host = string
+    groups       = list(string)
+    host_vars    = optional(map(string), {})
+  }))
+}
+
+variable "parent_groups" {
+  description = "Parent group -> child group names. Children not present in `hosts` are dropped."
+  type        = map(list(string))
+  default     = {}
+}
+
+variable "admin_user" { type = string }
+variable "ssh_key_path" { type = string }
+
+variable "jump_host" {
+  type        = string
+  default     = ""
+  description = "External IP of the jump host; when set, the jump host is reached directly and others via ProxyCommand."
+}
+
+variable "jump_host_name" {
+  type        = string
+  default     = ""
+  description = "Hostname (in `hosts`) that is the jump host."
+}


### PR DESCRIPTION
## Summary

Phase 2c — make the Ansible inventory **topology-driven** so any deployment (not just `baseline`) gets a correct inventory. This is the last piece needed for full end-to-end deploys of an arbitrary topology on KVM.

## What changed

- **New module `terraform/modules/topology-inventory`** — renders `ansible-inventory.yml` from a generic `hosts` map (`hostname -> { ansible_host, groups, host_vars }`), inverting per-host groups into group membership, composing parent groups (children absent from the deployment are dropped), and handling the jump host.
- **kvm root** now builds that structure from `local.topology` + the spec's per-role `groups` and points `module.inventory` at the new module (was the flat `ip_*` `modules/inventory`). The `/etc/hosts` map (`local.hosts`) fed to cloud-init is derived from the topology too.
- The legacy `modules/inventory` is **unchanged** and still used by azure/proxmox/vmware until they go spec-driven.

## Verified (generated the real file via targeted `apply` of the `local_file`, no libvirt)

- **`baseline`** → semantically identical to the previous inventory: 7 hosts with correct mgmt IPs, `netsim` `nl6_net_interface: enp2s0`, `docker_engine` = {es,kafka,mon,netsim}, `opennms_stack` children = {database,core,message_broker,elasticsearch,minion,grafana}. (Keys are alphabetically ordered now; Ansible is order-insensitive.)
- **`mimir-single`** → correct 4-host inventory: `mimir-benchmark-01` at `.208`, `docker_engine` = {mimir,mon}, `opennms_stack` children reduced to {database,core,grafana}.
- `make plan PROVIDER=kvm DEPLOYMENT=baseline` still **37 to add, 0 change, 0 destroy**.

## Result

Any A–H topology is now both **provisioned and inventoried** end-to-end on KVM. Remaining: Ansible/component roles for the new components (Mimir, VictoriaMetrics, ClickHouse, Sentinel, Akvorado) — Phase 3 — and migrating azure/proxmox/vmware to the spec-driven + topology-inventory pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
