### PR TITLE
feat: per-deployment OpenNMS config overlay (Phase 3a plumbing)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,10 +28,11 @@ TF_ARGS ?=
 # Deployment slug from the library (deployments/<slug>/). Consumed by kvm today.
 DEPLOYMENT ?= baseline
 
-# The deployment var is declared only on providers wired for spec-driven topology
-# (kvm in Phase 2b); never pass it to the others. Combined with any TF_ARGS.
+# The deployment is passed to deploy.sh only for spec-driven providers (kvm),
+# which selects both the Terraform topology and the Ansible config overlay.
+_dep_flag  = $(if $(filter kvm,$(PROVIDER)),--deployment $(DEPLOYMENT))
+# `make plan` still passes the Terraform var directly (it bypasses deploy.sh).
 _dep_tfarg = $(if $(filter kvm,$(PROVIDER)),-var deployment=$(DEPLOYMENT))
-_tfargs    = $(strip $(_dep_tfarg) $(TF_ARGS))
 
 # ── guards ────────────────────────────────────────────────────────────────────
 
@@ -62,11 +63,11 @@ endif
 
 .PHONY: deploy
 deploy: check-provider ## Provision + configure the lab (PROVIDER=…, kvm: DEPLOYMENT=<slug>)
-	./deploy.sh --provider $(PROVIDER) $(if $(_tfargs),--tf-args "$(_tfargs)") $(V)
+	./deploy.sh --provider $(PROVIDER) $(_dep_flag) $(if $(TF_ARGS),--tf-args "$(TF_ARGS)") $(V)
 
 .PHONY: destroy
 destroy: check-provider confirm ## Tear down all lab resources for PROVIDER
-	./deploy.sh --provider $(PROVIDER) --destroy $(if $(_tfargs),--tf-args "$(_tfargs)") $(V)
+	./deploy.sh --provider $(PROVIDER) $(_dep_flag) --destroy $(if $(TF_ARGS),--tf-args "$(TF_ARGS)") $(V)
 
 .PHONY: plan
 plan: check-provider ## terraform plan for PROVIDER (kvm: DEPLOYMENT=<slug>)

--- a/deploy.sh
+++ b/deploy.sh
@@ -58,7 +58,7 @@ DEPLOYMENT=""
 while [[ $# -gt 0 ]]; do
   case $1 in
     --provider)   PROVIDER="$2"; shift 2 ;;
-    --deployment) DEPLOYMENT="$2"; shift 2 ;;
+    --deployment) DEPLOYMENT="${2:?--deployment requires a value}"; shift 2 ;;
     --destroy)    DESTROY=true; shift ;;
     --tf-args)    read -ra TF_EXTRA_ARGS <<< "$2"; shift 2 ;;
     -v|-vv|-vvv|-vvvv) ANSIBLE_VERBOSITY="$1"; shift ;;
@@ -98,7 +98,7 @@ if [[ -n "$DEPLOYMENT" && "$PROVIDER" == "kvm" ]]; then
   DEPLOYMENT_VARS=(-var "deployment=$DEPLOYMENT")
 fi
 DEPLOYMENT_VARS_FILE=""
-if [[ -n "$DEPLOYMENT" && -f "$REPO_ROOT/deployments/$DEPLOYMENT/opennms-lab-vars.yml" ]]; then
+if [[ -n "$DEPLOYMENT" && "$PROVIDER" == "kvm" && -f "$REPO_ROOT/deployments/$DEPLOYMENT/opennms-lab-vars.yml" ]]; then
   DEPLOYMENT_VARS_FILE="--extra-vars=@$REPO_ROOT/deployments/$DEPLOYMENT/opennms-lab-vars.yml"
 fi
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -20,15 +20,17 @@ usage() {
 Usage: $0 --provider <azure|kvm|proxmox|vmware> [OPTIONS]
 
 Options:
-  --provider  <azure|kvm|proxmox|vmware>   Target infrastructure provider (required)
+  --provider   <azure|kvm|proxmox|vmware>  Target infrastructure provider (required)
+  --deployment <slug>               Deployment topology from deployments/<slug>/ (kvm; default baseline)
   --destroy                         Tear down all lab resources
-  --tf-args   "<args>"              Extra arguments passed verbatim to terraform
+  --tf-args    "<args>"             Extra arguments passed verbatim to terraform
   -v|-vv|-vvv|-vvvv                 Ansible verbosity
   -h|--help                         Show this message
 
 Examples:
   $0 --provider azure
   $0 --provider kvm
+  $0 --provider kvm --deployment mimir-single
   $0 --provider proxmox
   $0 --provider vmware
   $0 --provider azure --destroy
@@ -51,14 +53,16 @@ PROVIDER=""
 DESTROY=false
 TF_EXTRA_ARGS=()
 ANSIBLE_VERBOSITY=""
+DEPLOYMENT=""
 
 while [[ $# -gt 0 ]]; do
   case $1 in
-    --provider) PROVIDER="$2"; shift 2 ;;
-    --destroy)  DESTROY=true; shift ;;
-    --tf-args)  read -ra TF_EXTRA_ARGS <<< "$2"; shift 2 ;;
+    --provider)   PROVIDER="$2"; shift 2 ;;
+    --deployment) DEPLOYMENT="$2"; shift 2 ;;
+    --destroy)    DESTROY=true; shift ;;
+    --tf-args)    read -ra TF_EXTRA_ARGS <<< "$2"; shift 2 ;;
     -v|-vv|-vvv|-vvvv) ANSIBLE_VERBOSITY="$1"; shift ;;
-    -h|--help)  usage; exit 0 ;;
+    -h|--help)    usage; exit 0 ;;
     *) echo "Error: unknown option: $1" >&2; error_usage ;;
   esac
 done
@@ -84,6 +88,18 @@ if [[ ! -f "$TFVARS_FILE" ]]; then
   echo "Error: $TFVARS_FILE not found." >&2
   echo "       Copy ${TFVARS_FILE}.example → $TFVARS_FILE and fill in your values." >&2
   exit 1
+fi
+
+# Deployment selection: the `deployment` Terraform variable is declared only on
+# spec-driven providers (kvm today). The matching Ansible config overlay
+# (deployments/<slug>/opennms-lab-vars.yml) is layered onto the OpenNMS play.
+DEPLOYMENT_VARS=()
+if [[ -n "$DEPLOYMENT" && "$PROVIDER" == "kvm" ]]; then
+  DEPLOYMENT_VARS=(-var "deployment=$DEPLOYMENT")
+fi
+DEPLOYMENT_VARS_FILE=""
+if [[ -n "$DEPLOYMENT" && -f "$REPO_ROOT/deployments/$DEPLOYMENT/opennms-lab-vars.yml" ]]; then
+  DEPLOYMENT_VARS_FILE="--extra-vars=@$REPO_ROOT/deployments/$DEPLOYMENT/opennms-lab-vars.yml"
 fi
 
 # ── provider-specific extra vars ──────────────────────────────────────────────
@@ -140,6 +156,7 @@ tf_apply() {
   terraform -chdir="$TF_DIR" apply \
     "${COMMON_VAR_FILES[@]}" \
     -var-file="${PROVIDER}.tfvars" \
+    "${DEPLOYMENT_VARS[@]+"${DEPLOYMENT_VARS[@]}"}" \
     "$@" \
     "${TF_EXTRA_ARGS[@]+"${TF_EXTRA_ARGS[@]}"}" \
     -input=false \
@@ -150,6 +167,7 @@ tf_destroy() {
   terraform -chdir="$TF_DIR" destroy \
     "${COMMON_VAR_FILES[@]}" \
     -var-file="${PROVIDER}.tfvars" \
+    "${DEPLOYMENT_VARS[@]+"${DEPLOYMENT_VARS[@]}"}" \
     "$@" \
     "${TF_EXTRA_ARGS[@]+"${TF_EXTRA_ARGS[@]}"}" \
     -input=false \
@@ -230,4 +248,5 @@ ansible-playbook \
   -i "$REPO_ROOT/ansible-inventory.yml" \
   $ANSIBLE_VERBOSITY \
   "$REPO_ROOT/opennms-playbook.yml" \
-  --extra-vars="@$REPO_ROOT/opennms-lab-vars.yml"
+  --extra-vars="@$REPO_ROOT/opennms-lab-vars.yml" \
+  $DEPLOYMENT_VARS_FILE

--- a/deployments/mimir-single/opennms-lab-vars.yml
+++ b/deployments/mimir-single/opennms-lab-vars.yml
@@ -1,0 +1,20 @@
+---
+# OpenNMS config overlay for the mimir-single deployment. Layered by
+# `make deploy DEPLOYMENT=mimir-single PROVIDER=kvm` as extra-vars over the base
+# opennms-lab-vars.yml.
+#
+# Sends OpenNMS metrics to Grafana Mimir through the Prometheus remote_write
+# plugin (opennms-prometheus-remotewrite-plugin). The backend host resolves via
+# /etc/hosts (topology-derived). Requires the opennms_core remote_write support
+# added in Phase 3a (collection).
+
+# Switch the time-series layer from RRD to the OSGi integration layer.
+opennms_properties_timeseries:
+  org.opennms.timeseries.strategy: integration
+
+# Prometheus remote_write plugin target (Mimir single-binary, default :8080).
+opennms_remotewrite:
+  enabled: true
+  write_url: "http://mimir-benchmark-01:8080/api/v1/push"
+  read_url: "http://mimir-benchmark-01:8080/prometheus/api/v1"
+  organization_id: ""

--- a/deployments/vm-single/opennms-lab-vars.yml
+++ b/deployments/vm-single/opennms-lab-vars.yml
@@ -1,0 +1,20 @@
+---
+# OpenNMS config overlay for the vm-single deployment. Layered by
+# `make deploy DEPLOYMENT=vm-single PROVIDER=kvm` as extra-vars over the base
+# opennms-lab-vars.yml.
+#
+# Sends OpenNMS metrics to VictoriaMetrics through the SAME Prometheus
+# remote_write plugin used for Mimir — only the URL differs. The backend host
+# resolves via /etc/hosts (topology-derived). Requires the opennms_core
+# remote_write support added in Phase 3a (collection).
+
+# Switch the time-series layer from RRD to the OSGi integration layer.
+opennms_properties_timeseries:
+  org.opennms.timeseries.strategy: integration
+
+# Prometheus remote_write plugin target (VictoriaMetrics single-node, :8428).
+opennms_remotewrite:
+  enabled: true
+  write_url: "http://vm-benchmark-01:8428/api/v1/write"
+  read_url: "http://vm-benchmark-01:8428/prometheus/api/v1"
+  organization_id: ""


### PR DESCRIPTION
## Summary

Phase 3a, part 1 — the **in-repo config-overlay plumbing**. Each deployment can now carry a `deployments/<slug>/opennms-lab-vars.yml` that `make`/`deploy.sh` layer onto the OpenNMS play as extra-vars (over the base, so it wins). This completes the "deployment = data" model on the Ansible side.

## What changed

- **`deploy.sh`**: new `--deployment <slug>` flag. It selects the Terraform topology (`-var deployment=` for kvm) **and** layers `deployments/<slug>/opennms-lab-vars.yml` onto the OpenNMS playbook when present.
- **Makefile**: `make deploy/destroy PROVIDER=kvm DEPLOYMENT=<slug>` passes `--deployment` through (kvm only; `make plan` keeps passing the tf var directly).
- **Overlays for the two 3a targets**:
  - `mimir-single` → `timeseries.strategy=integration`, remote_write `writeUrl` → `mimir-benchmark-01:8080/api/v1/push`.
  - `vm-single` → same, `writeUrl` → `vm-benchmark-01:8428/api/v1/write` (same plugin, different URL — the key lever).

## Verified

- `bash -n deploy.sh`; both overlays parse as YAML.
- `make -n deploy PROVIDER=kvm DEPLOYMENT=mimir-single` → `deploy.sh … --deployment mimir-single`; `PROVIDER=azure` → no `--deployment` (never leaks to non-spec-driven providers).
- Deployment specs still validate; descriptors unchanged.

## Not in this PR (Phase 3a, part 2 — the collection + live deploy)

The overlays take effect only once the `indigo423.opennms` collection provides:
- `opennms_core`: install the `opennms-plugins-prometheus-remotewrite` Karaf feature + template the `org.opennms.plugins.tss.prometheus` PID from `opennms_remotewrite`.
- `stub_victoriametrics` role (mirrors `stub_mimir`).
- `grafana_provisioning`: VictoriaMetrics datasource.

That lands via an upstream `ansible-opennms` PR + a `requirements.yml` SHA bump + the `opennms-playbook.yml` `victoriametrics` play (kept out of this PR so CI doesn't fail on a not-yet-published role), and is verified by a real `make deploy PROVIDER=kvm DEPLOYMENT=mimir-single` on the libvirt host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
