### PR TITLE
chore(deps): bump indigo423.opennms to v0.5.0

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -9,7 +9,7 @@ collections:
   # update only via a deliberate PR, never automatically.
   - name: https://github.com/opennms-forge/ansible-opennms.git
     type: git
-    version: 286d031cdc5237b0d6c3f91b65ec3f0845b393ef  # v0.4.7
+    version: e4c19a0af99bccf632069d224b4ba09d5d21e8db  # v0.5.0
 
   # Transitive collections used by the OpenNMS deployment roles. Pinned by
   # Galaxy version string (weaker than SHA pinning, matches the prior


### PR DESCRIPTION
Bumps the `indigo423.opennms` git-SHA pin in `requirements.yml` from **v0.4.7** (`286d031`) to **v0.5.0** (`e4c19a0`). Per CLAUDE.md this collection is SHA-pinned and bumps are deliberate PRs.

## What v0.5.0 brings
The `opennms_core` **startup hardening** merged upstream (opennms-forge/ansible-opennms #114/#115/#116):
- fail the play when `install -dis` schema migration fails (was silently ignored)
- wait for Core readiness after start (no more success-on-a-dying-Core)
- clear a stale Liquibase changelog lock before startup (self-heals the ~5-min lock death)

This resolves the fresh-deploy startup flakiness hit during Phase 3a verification.

## Not included
v0.5.0 is v0.4.7 + the startup fixes only — it does **not** yet contain the Phase 3a backends (`stub_victoriametrics`, `stub_mimir` single-node config, `opennms_core` remote_write). Those still need upstreaming before `vm-single`/`mimir-single` are deployable end-to-end; this PR is just the startup-hardening bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)