### PR TITLE
feat(deployments): enable Phase 3a remote_write backends (collection v0.6.0)

### DIFF
--- a/deployments/mimir-single/opennms-lab-vars.yml
+++ b/deployments/mimir-single/opennms-lab-vars.yml
@@ -13,10 +13,12 @@ opennms_properties_timeseries:
   org.opennms.timeseries.strategy: integration
 
 # Prometheus remote_write plugin target (Mimir single-binary, default :8080).
-# Mimir runs with multitenancy enabled by default, so it requires an
-# X-Scope-OrgID header — organization_id sets it (writes/reads/Grafana must match).
+# The stub_mimir role runs Mimir with multitenancy_enabled: false, so it ignores
+# the X-Scope-OrgID header and writes/reads land in the single anonymous tenant.
+# organization_id is left empty to match; Grafana must query without an org-id
+# header too.
 opennms_remotewrite:
   enabled: true
   write_url: "http://mimir-benchmark-01:8080/api/v1/push"
   read_url: "http://mimir-benchmark-01:8080/prometheus/api/v1"
-  organization_id: "opennms"
+  organization_id: ""

--- a/opennms-playbook.yml
+++ b/opennms-playbook.yml
@@ -27,6 +27,13 @@
     - indigo423.opennms.common
     - indigo423.opennms.stub_mimir
 
+- name: Manage VictoriaMetrics
+  hosts: victoriametrics
+  become: true
+  roles:
+    - indigo423.opennms.common
+    - indigo423.opennms.stub_victoriametrics
+
 - name: Manage Grafana
   hosts: grafana
   become: true

--- a/requirements.yml
+++ b/requirements.yml
@@ -9,7 +9,7 @@ collections:
   # update only via a deliberate PR, never automatically.
   - name: https://github.com/opennms-forge/ansible-opennms.git
     type: git
-    version: e4c19a0af99bccf632069d224b4ba09d5d21e8db  # v0.5.0
+    version: 583efaea23c71db2baa372bc5a8fcd44b68cbb3c  # v0.6.0
 
   # Transitive collections used by the OpenNMS deployment roles. Pinned by
   # Galaxy version string (weaker than SHA pinning, matches the prior


### PR DESCRIPTION
Wires the Phase 3a metrics backends into the benchmark now that **ansible-opennms v0.6.0** is released (remote_write plugin support + `stub_victoriametrics` + `stub_mimir` single-node config, incl. the post-merge hardening from #121).

## Changes
- **`requirements.yml`** — bump `indigo423.opennms` git SHA to v0.6.0 (`583efaea23c71db2baa372bc5a8fcd44b68cbb3c`), kept SHA-pinned per convention.
- **`opennms-playbook.yml`** — add a **VictoriaMetrics play** (`common` + `stub_victoriametrics`) targeting the topology-derived `victoriametrics` group, mirroring the existing Mimir play. Unblocks `vm-single` (Deployment F).
- **`deployments/mimir-single` overlay** — `stub_mimir` now runs `multitenancy_enabled: false`, so Mimir ignores `X-Scope-OrgID`. Set `organization_id: ""` and corrected the stale comment (single anonymous tenant; Grafana must query without an org-id header). `vm-single` overlay already correct.

## Verification
- Collection installs from the pinned SHA; both `stub_victoriametrics` and `stub_mimir` roles present.
- `ansible-playbook --syntax-check opennms-playbook.yml` — the new play resolves against v0.6.0.
- `ansible-lint` (production profile) — 0 failures on the changed files.

## Not in this PR (next, needs live infra)
End-to-end re-verify of `vm-single` + `mimir-single` on kvm/mad-monkey — now with the startup-race fix, the backends, un-throttled Mimir limits, and single-tenant querying. That's a heavy deploy; I'll confirm before running.