### PR TITLE
fix: bump Grafana pin to 12.4.6, the head of the 12.x line

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -7,6 +7,7 @@ on:
       - "bootstrap/**"
       - "experiments/**"
       - "opennms-playbook.yml"
+      - "opennms-lab-vars.yml"
       - "requirements.yml"
       - ".ansible-lint"
       - "Makefile"

--- a/opennms-lab-vars.yml
+++ b/opennms-lab-vars.yml
@@ -27,11 +27,13 @@ opennms_es_port: 9200
 # Pinned to a Grafana 12.x release so the stock grafana.grafana 6.1.0 collection
 # works as-is. Grafana 13 needs a grafana-cli --homepath fix for plugin installs
 # that only exists in a non-Galaxy hotfix build (see requirements.yml).
-# NOTE: this is the apt package version. Grafana's download pages call this
-# release "12.4.3+security-02", but apt.grafana.com encodes it as "12.4.3-02" —
-# the "+security" form matches nothing and apt fails with
-# "no available installation candidate".
-grafana_version: "12.4.3-02"
+# NOTE: this is the apt package version. Security releases are encoded with a
+# "-NN" suffix (Grafana's download pages call them "+security-NN", which matches
+# nothing in apt); plain releases carry no suffix. Keep this at the head of the
+# 12.x line — a pin below it is a downgrade on hosts that already have a newer
+# Grafana, and apt then refuses with "Packages were downgraded and -y was used
+# without --allow-downgrades" (see #137).
+grafana_version: "12.4.6"
 # Datasources are provisioned by bootstrap/roles/grafana via files.
 # Empty list overrides the submodule's group_vars (which the collection
 # would otherwise use to call its datasource module — rejecting plugin types).


### PR DESCRIPTION
Closes #137.

Bumps `grafana_version` from `12.4.3-02` to `12.4.6`, the current head of the 12.x line on `apt.grafana.com stable`.

## Why

`12.4.3-02` sorts *below* `12.4.4`/`12.4.5`/`12.4.6` in dpkg ordering, so on a host that already carries a newer Grafana the pinned install is a downgrade and apt refuses:

```
E: Packages were downgraded and -y was used without --allow-downgrades
```

The *Manage Grafana* play is ordered before *Manage OpenNMS Horizon Core* in `opennms-playbook.yml`, so this aborts a full `make deploy` before Core is ever configured. Hit during the Phase 3a `mimir-single` verification on `mon-benchmark-01`; worked around at the time with `--limit core-benchmark-01`.

## Constraint kept

Still on 12.x — Grafana 13 needs the `grafana-cli --homepath` fix for plugin installs that only exists in a non-Galaxy hotfix build of `grafana.grafana` (see `requirements.yml`).

The stale comment about the `+security` naming is rewritten to describe the encoding rule generally (`-NN` for security releases, no suffix otherwise) rather than one specific release, and now records the downgrade trap so the next bump doesn't re-introduce it.

## Not fixed here

A host already on **13.x** still can't be reached by this pin. The upstream role installs via `ansible.builtin.package` with no `allow_downgrade` option ([`roles/grafana/tasks/install.yml`](https://github.com/grafana/grafana-ansible-collection/blob/main/roles/grafana/tasks/install.yml)), so such a host has to be rebuilt. That is the same VM-reuse problem tracked in #138.

## Verification

`make lint-ansible` — `Passed: 0 failure(s), 0 warning(s) in 164 files processed`, profile `production`.

Version availability confirmed against the live repo index:

```
$ curl -s https://apt.grafana.com/dists/stable/main/binary-amd64/Packages.gz \
  | gunzip -c | awk '/^Package: grafana$/{p=1} p&&/^Version:/{print $2; p=0}' | sort -V | tail -8
12.4.3
12.4.3-02
12.4.4
12.4.5
12.4.6
13.0.1
...
13.1.1
```

Not yet exercised on a live deploy — the lab was torn down after the Phase 3a verification.

## Also in this PR

`ci: lint on opennms-lab-vars.yml changes` — the Ansible Lint path filter didn't list `opennms-lab-vars.yml`, so this PR originally got no Lint run at all despite changing an ansible-lint-covered file. Adding it to the filter makes the gate self-verifying here: Lint now runs and passes on this branch. Per-experiment overrides under `experiments/<name>/opennms-lab-vars.yml` were already covered by `experiments/**`.
