### PR TITLE
fix: refresh /etc/hosts from the topology on every run

### DIFF
--- a/bootstrap/preparation-playbook.yml
+++ b/bootstrap/preparation-playbook.yml
@@ -21,6 +21,7 @@
   hosts: all
   become: true
   roles:
+    - etc_hosts
     - apt_update
     - common
     - prometheus.prometheus.node_exporter

--- a/bootstrap/roles/etc_hosts/tasks/main.yml
+++ b/bootstrap/roles/etc_hosts/tasks/main.yml
@@ -1,0 +1,21 @@
+---
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: Apache-2.0
+#
+# cloud-init writes /etc/hosts once, on first boot. A VM that keeps its
+# for_each key across a topology swap is not recreated, so it holds the host
+# table of the previous topology and cannot resolve the new hosts. Re-render
+# the file on every run so it converges like the rest of the config.
+#
+# lab_mgmt_ip is emitted by terraform/modules/topology-inventory. Providers
+# still on the legacy inventory module do not set it; they also have a fixed
+# topology and cannot hit the swap problem, so the task skips there.
+- name: Refresh /etc/hosts from the inventory topology
+  ansible.builtin.template:
+    src: hosts.j2
+    dest: /etc/hosts
+    owner: root
+    group: root
+    mode: "0644"
+  when: lab_mgmt_ip is defined
+  tags: ["etc-hosts"]

--- a/bootstrap/roles/etc_hosts/templates/hosts.j2
+++ b/bootstrap/roles/etc_hosts/templates/hosts.j2
@@ -1,0 +1,14 @@
+{# Copyright 2026 Ronny Trommer <ronny@no42.org> #}
+{# SPDX-License-Identifier: Apache-2.0 #}
+{# Mirrors the /etc/hosts written by                                        #}
+{# terraform/modules/cloud-init/templates/user-data.yaml.tftpl, which only  #}
+{# runs on first boot. Keep the two in sync.                                #}
+{# lab_mgmt_ip, not ansible_host: the inventory overrides ansible_host with #}
+{# the external DHCP address on the jump host.                              #}
+127.0.0.1 localhost
+127.0.1.1 {{ inventory_hostname }}
+{% for host in groups['all'] | sort %}
+{% if hostvars[host].lab_mgmt_ip is defined %}
+{{ hostvars[host].lab_mgmt_ip }} {{ host }} {{ host }}.lab.local
+{% endif %}
+{% endfor %}

--- a/terraform/modules/topology-inventory/templates/inventory.yml.tftpl
+++ b/terraform/modules/topology-inventory/templates/inventory.yml.tftpl
@@ -15,6 +15,7 @@ all:
 %{ else ~}
       ansible_host: ${hosts[hostname].ansible_host}
 %{ endif ~}
+      lab_mgmt_ip: ${hosts[hostname].ansible_host}
 %{ for k in sort(keys(hosts[hostname].host_vars)) ~}
       ${k}: "${hosts[hostname].host_vars[k]}"
 %{ endfor ~}


### PR DESCRIPTION
Closes #138.

`/etc/hosts` is written by cloud-init `write_files`, which only runs on **first boot**. A VM that keeps its `for_each` key across a topology swap isn't recreated, so it keeps the previous topology's host table — and nothing fails loudly. After `vm-single` → `mimir-single`, `core-benchmark-01` still listed `vm-benchmark-01`, had no `mimir-benchmark-01`, and the CortexTSS plugin dropped every sample with `UnknownHostException`.

## Change

A small `etc_hosts` bootstrap role re-renders `/etc/hosts` from the inventory on every run, mirroring `terraform/modules/cloud-init/templates/user-data.yaml.tftpl` byte for byte. It runs first in the *Basic configuration and tooling* play, so name resolution is correct before anything else is configured.

The address comes from a **new `lab_mgmt_ip` host var**, not `ansible_host` — both inventory modules override `ansible_host` with the *external DHCP* address on the jump host, which must not land in the lab host table. `topology-inventory` now emits `lab_mgmt_ip` for every host.

Full-file render rather than `blockinfile`: cloud-init's stale entries sit at the top of the file and would win first-match resolution against an appended block, so owning the file is what actually makes it converge.

## Scope

Providers still on the legacy `modules/inventory` don't get `lab_mgmt_ip`, so the task skips there. That's correct rather than a gap — their topology is fixed, so they can't hit the swap problem. When azure/proxmox/vmware move to spec-driven inventories they pick this up for free.

## Verification

**Rendered output**, from a fake inventory reproducing the failure (jump host `mon-benchmark-01` at external `192.168.11.93`, mgmt `192.0.2.200`):

```
127.0.0.1 localhost
127.0.1.1 core-benchmark-01
192.0.2.197 core-benchmark-01 core-benchmark-01.lab.local
192.0.2.196 db-benchmark-01 db-benchmark-01.lab.local
192.0.2.208 mimir-benchmark-01 mimir-benchmark-01.lab.local
192.0.2.200 mon-benchmark-01 mon-benchmark-01.lab.local
```

The `mimir-benchmark-01` entry that was missing is present, the jump host resolves to its **mgmt** IP, the external `192.168.11.93` appears nowhere, and the format matches cloud-init exactly (no stray blank lines from the Jinja loop).

**Legacy-inventory skip** — inventory without `lab_mgmt_ip`, role run in check mode:

```
TASK [etc_hosts : Refresh /etc/hosts from the inventory topology]
skipping: [core-benchmark-01]
skipping: [mon-benchmark-01]
```

**Terraform** — `make plan PROVIDER=kvm DEPLOYMENT=mimir-single` renders the new var for all four hosts and is infrastructure-neutral:

```
core-benchmark-01:
  ansible_host: 192.0.2.197
  lab_mgmt_ip: 192.0.2.197
...
Plan: 25 to add, 0 to change, 0 to destroy.
```

`25 to add / 0 destroy` matches the documented mimir-single baseline, so the inventory change introduces no infrastructure delta.

**Lint** — `make lint-ansible` passes (`0 failure(s), 167 files processed`, profile `production`); `make fmt` and `make validate-kvm` green.

Not yet exercised on a live deploy — the lab is down. The next `make deploy` will run it.
