### PR TITLE
fix: hold lab-pinned packages across the bootstrap dist upgrade

### DIFF
--- a/bootstrap/roles/apt_update/defaults/main.yml
+++ b/bootstrap/roles/apt_update/defaults/main.yml
@@ -1,0 +1,22 @@
+---
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: Apache-2.0
+#
+# Packages this lab installs at an exact or patch-level version. `upgrade: dist`
+# would move them past that pin, making the next pinned install a downgrade that
+# apt refuses (#141).
+#
+#   grafana        -> grafana_version in opennms-lab-vars.yml (exact, e.g. 12.4.6)
+#   opennms-*      -> opennms_pkg_version, "36.0.2*" (patch level)
+#
+# jrrd2, rrdtool and iplike are deliberately absent: they pin a major version
+# ("1.*"), so an upgrade still satisfies the pin.
+#
+# Kept in sync by hand. A missing entry restores the old drift, which surfaces as
+# the "Packages were downgraded" abort in #141 rather than failing silently.
+apt_update_pinned_packages:
+  - grafana
+  - opennms-common
+  - opennms-server
+  - opennms-webapp-jetty
+  - opennms-webapp-hawtio

--- a/bootstrap/roles/apt_update/tasks/main.yml
+++ b/bootstrap/roles/apt_update/tasks/main.yml
@@ -3,8 +3,31 @@
   ansible.builtin.apt:
     update_cache: true
 
+# The lab pins some package versions, and a dist upgrade would move them past
+# that pin — the next pinned install then reads as a downgrade, apt refuses it,
+# and the deploy dies before OpenNMS Core (#141). Hold those packages for the
+# duration of the upgrade only; releasing afterwards keeps deliberate version
+# bumps working normally.
+- name: Gather installed packages
+  ansible.builtin.package_facts:
+    manager: apt
+
+- name: Hold lab-pinned packages across the distribution upgrade
+  ansible.builtin.dpkg_selections:
+    name: "{{ item }}"
+    selection: hold
+  loop: "{{ apt_update_pinned_packages }}"
+  when: item in ansible_facts.packages
+
 - name: Update all packages to the latest version
   ansible.builtin.apt:
     upgrade: dist
     autoclean: true
     autoremove: true
+
+- name: Release the hold on lab-pinned packages
+  ansible.builtin.dpkg_selections:
+    name: "{{ item }}"
+    selection: install
+  loop: "{{ apt_update_pinned_packages }}"
+  when: item in ansible_facts.packages


### PR DESCRIPTION
Closes #141.

`bootstrap/roles/apt_update` runs `upgrade: dist` on every host on every run. On a host that already has a pinned package installed, that moves it past the pin, so the next pinned install reads as a downgrade and apt refuses it. The *Manage Grafana* play precedes *Manage OpenNMS Horizon Core*, so the abort takes OpenNMS Core with it — **only a first deploy onto a fresh VM ever succeeded**.

Bumping the pin was never the fix: the upgrade outruns any value, which is why #139 didn't help.

## Change

Hold the pinned packages for the duration of the upgrade, release them straight after. The pin can't drift, and deliberate version bumps still apply normally because the hold never outlives the task that needs it.

Covers `grafana` (exact pin) and the `opennms-*` packages (patch-level `36.0.2*`). `jrrd2`/`rrdtool`/`iplike` pin a *major* version (`1.*`), which an upgrade still satisfies, so they're deliberately left out — noted in `defaults/main.yml`.

`package_facts` guards both tasks, so a package that isn't installed is skipped rather than erroring on a fresh host.

## Verification — two sequential live deploys on KVM

This is the exact sequence that failed before: `vm-single`, then a swap to `mimir-single` where `mon-benchmark-01` survives.

**Deploy 1** (fresh VMs) — every hold item skips, nothing installed yet; `failed=0` on all 4 hosts. Grafana lands at the pin:

```
$ dpkg-query -W grafana  ->  12.4.6
```

**Deploy 2** (the swap that previously aborted) — `failed=0` on all 4 hosts, **including `mon-benchmark-01`**:

```
core-benchmark-01   : ok=70  changed=3   failed=0
db-benchmark-01     : ok=28  changed=2   failed=0
mimir-benchmark-01  : ok=9   changed=5   failed=0
mon-benchmark-01    : ok=25  changed=0   failed=0
```

Exactly the installed pinned packages were held, and all of them released:

```
hold     -> changed: [mon-benchmark-01]  => (item=grafana)
            changed: [core-benchmark-01] => (item=opennms-common)
            changed: [core-benchmark-01] => (item=opennms-server)
            changed: [core-benchmark-01] => (item=opennms-webapp-jetty)
            changed: [core-benchmark-01] => (item=opennms-webapp-hawtio)
release  -> same five, all changed
```

`Install Grafana` is now a no-op `ok` instead of fatal, and the whole deploy contains **zero** `Packages were downgraded` errors.

The decisive artifact is apt's own history on `mon-benchmark-01`. Previously it read:

```
Install: grafana:amd64 (12.4.6)
Upgrade: grafana:amd64 (12.4.6, 13.1.1)      <- the drift
```

After this change, across both deploys, the upgrade line is simply absent:

```
Install: grafana:amd64 (12.4.6)
```

`dpkg-query` confirms `12.4.6`, and `apt-mark showhold` confirms the hold was released rather than left behind.

**Stack health** — this deploy ran the OpenNMS play unattended, with no `--limit` workaround: OpenNMS `active`, Mimir ingesting **549 series** (climbing from 270 over ~4 min), and 0 `UnknownHostException`.

`make lint-ansible` passes (`0 failure(s), 168 files processed`, profile `production`).
