### PR TITLE
fix: pin ClickHouse packages against the bootstrap dist upgrade

### DIFF
--- a/bootstrap/roles/apt_update/defaults/main.yml
+++ b/bootstrap/roles/apt_update/defaults/main.yml
@@ -8,6 +8,7 @@
 #
 #   grafana        -> grafana_version in opennms-lab-vars.yml (exact, e.g. 12.4.6)
 #   opennms-*      -> opennms_pkg_version, "36.0.2*" (patch level)
+#   clickhouse-*   -> clickhouse_version in the stub_clickhouse role (exact)
 #
 # jrrd2, rrdtool and iplike are deliberately absent: they pin a major version
 # ("1.*"), so an upgrade still satisfies the pin.
@@ -20,3 +21,6 @@ apt_update_pinned_packages:
   - opennms-server
   - opennms-webapp-jetty
   - opennms-webapp-hawtio
+  - clickhouse-common-static
+  - clickhouse-server
+  - clickhouse-client


### PR DESCRIPTION
Adds the three ClickHouse packages to `apt_update_pinned_packages`.

## Why

The `stub_clickhouse` role added in Phase 3b ([ansible-opennms#125](https://github.com/opennms-forge/ansible-opennms/pull/125)) pins `clickhouse-common-static`, `clickhouse-server` and `clickhouse-client` to an exact `clickhouse_version` — but they were absent from the hold list, while `apt_update` runs `upgrade: dist` on `hosts: all`, which includes Deployment H's `ch-benchmark-01`.

So the first deploy of H would install the pinned version and the **second would abort**: `dist-upgrade` moves ClickHouse past the pin, the pinned install reads as a downgrade, and apt refuses. Exactly #141, on a new host.

## Note for the reviewer

This is the hand-maintained list from #142 meeting its first new pinned package, and it went stale immediately — worth weighing when reviewing that design. It does fail loudly rather than silently (an apt abort, not corrupt data), which is what that file's comment predicted, but it would have failed on the first repeat deploy of H rather than at some distant point.

The alternative — deriving the list from the pinned versions rather than enumerating it — would need the benchmark to introspect collection role defaults, which is why #142 enumerated in the first place. Still enumerated here; flagging the tradeoff rather than silently re-paying it.

## Verification

`make lint-ansible` passes (`0 failure(s), 168 files processed`, profile `production`).

Not exercised live — Deployment H has not been deployed yet, which is the next Phase 3b step. When it is, the check is that a *second* `make deploy PROVIDER=kvm DEPLOYMENT=clickhouse-akvorado` completes, with `clickhouse-server` held and released in the play output and `dpkg-query` still reporting the pinned version.
