### PR TITLE
feat(deployments): adopt the clickhouse and akvorado roles

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -46,8 +46,12 @@ jobs:
       - name: Install OpenNMS deployment collections
         run: ansible-galaxy collection install -r requirements.yml -p ~/.ansible/collections --force-with-deps
 
-      - name: Set Ansible roles path
-        run: echo "ANSIBLE_ROLES_PATH=$GITHUB_WORKSPACE/bootstrap/roles" >> "$GITHUB_ENV"
+      # No ANSIBLE_ROLES_PATH here: the env var overrides ansible.cfg's
+      # roles_path, so duplicating it in CI let the two drift apart — CI kept
+      # resolving only bootstrap/roles after deployments/roles was added, and
+      # failed on a role that resolves fine locally. ansible.cfg is the single
+      # source of truth; `make lint-ansible` runs from the repo root and picks
+      # it up.
 
       # ansible-lint parses vault-encrypted group_vars but never decrypts them;
       # a throwaway password file lets them load without a real secret in CI.

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
     paths:
       - "bootstrap/**"
+      - "deployments/**"
       - "experiments/**"
       - "opennms-playbook.yml"
       - "opennms-lab-vars.yml"

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,5 +1,5 @@
 [defaults]
-roles_path         = bootstrap/roles
+roles_path         = bootstrap/roles:deployments/roles
 host_key_checking  = False
 pipelining         = True
 forks              = 20

--- a/bootstrap/roles/apt_update/defaults/main.yml
+++ b/bootstrap/roles/apt_update/defaults/main.yml
@@ -8,6 +8,7 @@
 #
 #   grafana        -> grafana_version in opennms-lab-vars.yml (exact, e.g. 12.4.6)
 #   opennms-*      -> opennms_pkg_version, "36.0.2*" (patch level)
+#   clickhouse-*   -> clickhouse_version in deployments/roles/clickhouse (exact)
 #
 # jrrd2, rrdtool and iplike are deliberately absent: they pin a major version
 # ("1.*"), so an upgrade still satisfies the pin.
@@ -20,3 +21,6 @@ apt_update_pinned_packages:
   - opennms-server
   - opennms-webapp-jetty
   - opennms-webapp-hawtio
+  - clickhouse-common-static
+  - clickhouse-server
+  - clickhouse-client

--- a/deploy.sh
+++ b/deploy.sh
@@ -241,12 +241,28 @@ ansible-galaxy collection install \
   -r "$REPO_ROOT/requirements.yml" \
   --force-with-deps
 
-step "[4/4] Deploying OpenNMS Horizon..."
+# A deployment may ship its own playbook when it stands up a different stack.
+# Deployment H (clickhouse-akvorado) deploys no OpenNMS at all, so bolting its
+# plays into opennms-playbook.yml would hide a second stack inside a playbook
+# named for the first. Every OpenNMS deployment ships no playbook.yml and gets
+# the shared one, which keeps its play order — the stack's dependency graph —
+# in exactly one place.
+# Gated on kvm for the same reason as the vars overlay above: only kvm is
+# spec-driven, so on other providers --deployment does not shape the infra and
+# a per-deployment playbook would target hosts that were never provisioned.
+DEPLOYMENT_PLAYBOOK="$REPO_ROOT/opennms-playbook.yml"
+STACK_LABEL="OpenNMS Horizon"
+if [[ -n "$DEPLOYMENT" && "$PROVIDER" == "kvm" && -f "$REPO_ROOT/deployments/$DEPLOYMENT/playbook.yml" ]]; then
+  DEPLOYMENT_PLAYBOOK="$REPO_ROOT/deployments/$DEPLOYMENT/playbook.yml"
+  STACK_LABEL="$DEPLOYMENT stack"
+fi
+
+step "[4/4] Deploying $STACK_LABEL..."
 # shellcheck disable=SC2086
 ansible-playbook \
   --become \
   -i "$REPO_ROOT/ansible-inventory.yml" \
   $ANSIBLE_VERBOSITY \
-  "$REPO_ROOT/opennms-playbook.yml" \
+  "$DEPLOYMENT_PLAYBOOK" \
   --extra-vars="@$REPO_ROOT/opennms-lab-vars.yml" \
   $DEPLOYMENT_VARS_FILE

--- a/deployments/clickhouse-akvorado/opennms-lab-vars.yml
+++ b/deployments/clickhouse-akvorado/opennms-lab-vars.yml
@@ -1,0 +1,25 @@
+---
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: Apache-2.0
+#
+# Deployment H overlay — layered onto the play as extra-vars by deploy.sh.
+#
+# The file name is inherited from the OpenNMS deployments and is a poor fit
+# here: H deploys no OpenNMS. Renaming the overlay across all deployments is
+# tracked separately.
+
+# Akvorado writes to the dedicated ClickHouse node rather than the container
+# bundled in its own compose stack, which the role disables. Host name comes
+# from the topology (role key `clickhouse` -> vm_name `ch-benchmark-01`).
+akvorado_clickhouse_servers:
+  - "ch-benchmark-01:9000"
+
+# Populates Src/DstNetName and Role in the console. The lab's mgmt subnet.
+akvorado_networks:
+  192.0.2.0/24:
+    name: lab
+    role: customers
+
+# H has no load generator, so upstream's synthetic exporters are how the flow
+# path gets exercised end to end.
+akvorado_demo_exporters: true

--- a/deployments/clickhouse-akvorado/playbook.yml
+++ b/deployments/clickhouse-akvorado/playbook.yml
@@ -1,0 +1,25 @@
+---
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: Apache-2.0
+#
+# Deployment H — standalone flow-engine stack. No OpenNMS.
+#
+# deploy.sh runs deployments/<slug>/playbook.yml when it exists, otherwise the
+# shared opennms-playbook.yml. H is the only deployment that shares no plays
+# with the OpenNMS stack, so it gets its own rather than being bolted into a
+# playbook named for a product it does not deploy.
+#
+# ClickHouse first: Akvorado's outlet needs somewhere to write, and its
+# orchestrator migrates the schema on startup.
+
+- name: Manage ClickHouse
+  hosts: clickhouse
+  become: true
+  roles:
+    - clickhouse
+
+- name: Manage Akvorado
+  hosts: akvorado
+  become: true
+  roles:
+    - akvorado

--- a/deployments/clickhouse-akvorado/topology.yml
+++ b/deployments/clickhouse-akvorado/topology.yml
@@ -8,7 +8,9 @@ roles:
     count: 1
     size: large
     subnets: [mgmt, sim]
-    groups: [clickhouse, docker_engine]
+    # No docker_engine: the clickhouse role installs native .deb packages, so
+    # Docker would be installed on a host that never uses it.
+    groups: [clickhouse]
   akvorado:
     count: 1
     size: medium

--- a/deployments/roles/akvorado/README.md
+++ b/deployments/roles/akvorado/README.md
@@ -1,0 +1,77 @@
+# akvorado
+
+Deployment-under-test role: deploys the [Akvorado](https://github.com/akvorado/akvorado)
+flow collector via Docker Compose, writing to an **external** ClickHouse rather
+than the one bundled in upstream's compose stack.
+
+Lives here rather than in the `indigo423.opennms` collection because Akvorado is
+a competing flow engine — OpenNMS has no wire to it. It exists to be measured
+*against* OpenNMS. Not a production-grade Akvorado deployment.
+
+## Approach
+
+Upstream's compose stack is vendored at a pinned tag rather than reimplemented.
+That stack is more than a list of containers: the orchestrator acts as a config
+service that inlet, outlet and console fetch from at boot, tied together by a
+healthcheck dependency graph, and Traefik injects the `Remote-User` header the
+console authenticates with. Re-deriving that is more work and more risk than
+tracking it.
+
+The role therefore:
+
+1. Unpacks the release tarball to `/opt/akvorado/akvorado-<version>/`.
+2. Writes `docker/docker-compose-local.yml` — upstream's documented override
+   slot, already in the `COMPOSE_FILE` chain of the shipped `.env`, so `.env`
+   itself is left untouched.
+3. Replaces `config/akvorado.yaml` to point `clickhousedb.servers` at the
+   external node. `inlet.yaml`, `outlet.yaml` and `console.yaml` stay as
+   upstream ships them via `!include`.
+4. Brings the stack up with `community.docker.docker_compose_v2`.
+
+The bundled `clickhouse` service is parked in an unused profile — upstream's
+documented way to disable a service. Because console and outlet declare a
+healthcheck dependency on it, their `depends_on` is *replaced* (`!override`)
+rather than merged, otherwise Compose pulls the disabled service back in.
+
+## Requirements
+
+- Docker Engine with the Compose v2 plugin on the target host.
+- A reachable ClickHouse (see `clickhouse`).
+
+## Variables
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `akvorado_version` | `2.4.1` | Upstream tag to vendor |
+| `akvorado_clickhouse_servers` | `[]` | **Required.** External ClickHouse, e.g. `["ch-benchmark-01:9000"]` |
+| `akvorado_kafka_brokers` | `[kafka:9092]` | In-stack Kafka, Akvorado's own inlet → outlet buffer |
+| `akvorado_http_port` | `8080` | Host port for the console, published from Traefik |
+| `akvorado_networks` | `{}` | Populates `Src/DstNetName/Role` in the console; omitted from the config when empty |
+| `akvorado_demo_exporters` | `false` | Enable upstream's synthetic flow exporters |
+
+`akvorado_demo_exporters` exists because the lab's Deployment H has no load
+generator — it is how the flow path gets exercised end to end.
+
+## Ports
+
+| Port | Purpose |
+|---|---|
+| `8080/tcp` | Console (configurable) |
+| `2055/udp` | NetFlow |
+| `4739/udp` | IPFIX |
+| `6343/udp` | sFlow |
+
+## Example
+
+```yaml
+- name: Manage Akvorado
+  hosts: akvorado
+  become: true
+  roles:
+    - common
+    - role: akvorado
+      vars:
+        akvorado_clickhouse_servers:
+          - "ch-benchmark-01:9000"
+        akvorado_demo_exporters: true
+```

--- a/deployments/roles/akvorado/defaults/main.yml
+++ b/deployments/roles/akvorado/defaults/main.yml
@@ -1,0 +1,40 @@
+---
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: Apache-2.0
+# renovate: datasource=github-tags depName=akvorado/akvorado
+akvorado_version: "2.4.1"
+akvorado_src_url: "https://github.com/akvorado/akvorado/archive/refs/tags/v{{ akvorado_version }}.tar.gz"
+akvorado_install_dir: /opt/akvorado
+
+# Where the flow schema lives. Required — the bundled ClickHouse container is
+# disabled (see templates/docker-compose-local.yml.j2) so that a dedicated
+# ClickHouse node (clickhouse) can be measured on its own.
+# Example: ["ch-benchmark-01:9000"]
+akvorado_clickhouse_servers: []
+
+# Kafka stays inside the compose stack: Akvorado uses it as its own inlet ->
+# outlet buffer, not as a shared lab broker.
+akvorado_kafka_brokers:
+  - kafka:9092
+akvorado_kafka_topic: flows
+akvorado_kafka_partitions: 8
+akvorado_kafka_replication_factor: 1
+
+# Host port for the Akvorado console, published from Traefik's public
+# entrypoint. Traefik also injects the Remote-User header the console
+# authenticates with, which is why it is kept rather than bypassed.
+akvorado_http_port: 8080
+
+# Networks reported as Src/DstNetName/Role in the console. Site-specific, so
+# there is no sensible default — left empty, the section is omitted entirely
+# and Akvorado simply reports no network names.
+# Example:
+#   akvorado_networks:
+#     198.51.100.0/24:
+#       name: customers
+#       role: customers
+akvorado_networks: {}
+
+# Synthetic flow exporters shipped by upstream. The lab's Deployment H has no
+# load generator, so this is how the flow path is exercised end to end.
+akvorado_demo_exporters: false

--- a/deployments/roles/akvorado/handlers/main.yml
+++ b/deployments/roles/akvorado/handlers/main.yml
@@ -1,0 +1,12 @@
+---
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: Apache-2.0
+- name: Restart akvorado
+  community.docker.docker_compose_v2:
+    project_src: "{{ _akvorado_project_dir }}"
+    profiles: "{{ ['demo'] if akvorado_demo_exporters else omit }}"
+    state: restarted
+    wait: true
+  tags:
+    - akvorado
+    - docker

--- a/deployments/roles/akvorado/tasks/main.yml
+++ b/deployments/roles/akvorado/tasks/main.yml
@@ -1,0 +1,77 @@
+---
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: Apache-2.0
+- name: Assert an external ClickHouse is configured
+  ansible.builtin.assert:
+    that:
+      - akvorado_clickhouse_servers | length > 0
+    fail_msg: >-
+      akvorado_clickhouse_servers is empty. The bundled ClickHouse container is
+      disabled, so Akvorado has nowhere to write flows. Set it to the
+      clickhouse host, e.g. ["ch-benchmark-01:9000"].
+  # always, not the role tag: a --tags docker or --tags configuration run would
+  # otherwise skip the guard and still template the config and start the stack,
+  # which is exactly the confusing failure this assert exists to prevent.
+  tags:
+    - always
+
+- name: Create the Akvorado install directory
+  ansible.builtin.file:
+    path: "{{ akvorado_install_dir }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+  tags:
+    - akvorado
+
+# Unpacked per version so that bumping akvorado_version fetches the new tree
+# rather than being skipped by a version-independent creates: guard.
+- name: Unpack the Akvorado source tree for version {{ akvorado_version }}
+  ansible.builtin.unarchive:
+    src: "{{ akvorado_src_url }}"
+    dest: "{{ akvorado_install_dir }}"
+    remote_src: true
+    creates: "{{ _akvorado_project_dir }}/docker/docker-compose.yml"
+    owner: root
+    group: root
+  tags:
+    - akvorado
+
+# Upstream already lists docker-compose-local.yml in the COMPOSE_FILE chain in
+# its shipped .env, so the override applies without touching .env.
+- name: Configure the Akvorado compose override
+  ansible.builtin.template:
+    src: docker-compose-local.yml.j2
+    dest: "{{ _akvorado_project_dir }}/docker/docker-compose-local.yml"
+    owner: root
+    group: root
+    mode: "0644"
+  notify:
+    - Restart akvorado
+  tags:
+    - akvorado
+    - configuration
+
+- name: Configure the Akvorado orchestrator
+  ansible.builtin.template:
+    src: akvorado.yaml.j2
+    dest: "{{ _akvorado_project_dir }}/config/akvorado.yaml"
+    owner: root
+    group: root
+    mode: "0644"
+  notify:
+    - Restart akvorado
+  tags:
+    - akvorado
+    - configuration
+
+- name: Start the Akvorado stack
+  community.docker.docker_compose_v2:
+    project_src: "{{ _akvorado_project_dir }}"
+    profiles: "{{ ['demo'] if akvorado_demo_exporters else omit }}"
+    state: present
+    wait: true
+  tags:
+    - akvorado
+    - docker

--- a/deployments/roles/akvorado/templates/akvorado.yaml.j2
+++ b/deployments/roles/akvorado/templates/akvorado.yaml.j2
@@ -1,0 +1,50 @@
+{# Copyright 2026 Ronny Trommer <ronny@no42.org> #}
+{# SPDX-License-Identifier: Apache-2.0 #}
+{# Managed by the akvorado Ansible role — local changes are overwritten. #}
+{# Replaces upstream config/akvorado.yaml. inlet/outlet/console keep their #}
+{# upstream !include files; only the parts the lab varies live here.       #}
+---
+kafka:
+  topic: {{ akvorado_kafka_topic }}
+  brokers:
+{% for broker in akvorado_kafka_brokers %}
+    - {{ broker }}
+{% endfor %}
+  topic-configuration:
+    num-partitions: {{ akvorado_kafka_partitions }}
+    replication-factor: {{ akvorado_kafka_replication_factor }}
+    config-entries:
+      segment.bytes: 1073741824
+      retention.ms: 86400000
+      cleanup.policy: delete
+      compression.type: producer
+
+geoip:
+  optional: true
+  asn-database:
+    - /usr/share/GeoIP/asn.mmdb
+  geo-database:
+    - /usr/share/GeoIP/country.mmdb
+
+clickhousedb:
+  servers:
+{% for server in akvorado_clickhouse_servers %}
+    - {{ server }}
+{% endfor %}
+
+clickhouse:
+  orchestrator-url: http://akvorado-orchestrator:8080
+  prometheus-endpoint: /metrics
+{% if akvorado_networks %}
+  networks:
+{% for prefix, attrs in akvorado_networks.items() %}
+    {{ prefix }}:
+{% for key, value in attrs.items() %}
+      {{ key }}: {{ value }}
+{% endfor %}
+{% endfor %}
+{% endif %}
+
+inlet: !include "inlet.yaml"
+outlet: !include "outlet.yaml"
+console: !include "console.yaml"

--- a/deployments/roles/akvorado/templates/docker-compose-local.yml.j2
+++ b/deployments/roles/akvorado/templates/docker-compose-local.yml.j2
@@ -1,0 +1,34 @@
+{# Copyright 2026 Ronny Trommer <ronny@no42.org> #}
+{# SPDX-License-Identifier: Apache-2.0 #}
+{# Managed by the akvorado Ansible role — local changes are overwritten. #}
+{# docker-compose-local.yml is upstream's documented override slot and is #}
+{# already part of the COMPOSE_FILE chain in the shipped .env.            #}
+---
+services:
+  # The lab measures a dedicated ClickHouse node (clickhouse), so the
+  # bundled one is parked in an unused profile — upstream's documented way to
+  # disable a service. Because console and outlet declare a healthcheck
+  # dependency on it, their depends_on is replaced rather than merged, or
+  # Compose would pull the disabled service back in.
+  clickhouse:
+    profiles: [disabled]
+
+  akvorado-console:
+    depends_on: !override
+      akvorado-orchestrator:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+
+  akvorado-outlet:
+    depends_on: !override
+      akvorado-orchestrator:
+        condition: service_healthy
+      kafka:
+        condition: service_healthy
+
+  # Publish the console on the host. Traefik is kept because it injects the
+  # Remote-User header the console authenticates with.
+  traefik:
+    ports:
+      - {{ akvorado_http_port }}:8081/tcp

--- a/deployments/roles/akvorado/vars/main.yml
+++ b/deployments/roles/akvorado/vars/main.yml
@@ -1,0 +1,5 @@
+---
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: Apache-2.0
+# The release tarball unpacks to a version-named directory.
+_akvorado_project_dir: "{{ akvorado_install_dir }}/akvorado-{{ akvorado_version }}"

--- a/deployments/roles/clickhouse/README.md
+++ b/deployments/roles/clickhouse/README.md
@@ -1,0 +1,51 @@
+# clickhouse
+
+Deployment-under-test role: installs a single-node ClickHouse from the upstream
+apt repository and runs it as a systemd service on `:8123` (HTTP) and `:9000`
+(native). It is the flow-storage backend for `akvorado`, which creates and
+migrates its own schema, so this role deliberately does no schema work.
+
+Lives here rather than in the `indigo423.opennms` collection because OpenNMS has
+no wire to ClickHouse — nothing in OpenNMS reads from or writes to it. It exists
+to stand up an engine OpenNMS is measured *against*. Not a production-grade
+ClickHouse deployment.
+
+## What it does
+
+- Adds the ClickHouse apt repository (`packages.clickhouse.com/deb stable`).
+- Installs `clickhouse-common-static`, `clickhouse-server` and `clickhouse-client`,
+  all pinned to the same `clickhouse_version` — the server refuses to start
+  against a mismatched `clickhouse-common-static`.
+- Drops `/etc/clickhouse-server/config.d/10-lab-listen.xml` to set the listen
+  address, ports and data path. Using `config.d` rather than editing `config.xml`
+  means a package upgrade cannot silently revert the listen address.
+
+## Not production
+
+- Listens on `0.0.0.0` so a separate Akvorado host can reach it. Acceptable only
+  because the lab sits on a private subnet.
+- Keeps the packaged `default` user with no password and applies no resource
+  limits, quotas or TLS.
+
+## Variables
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `clickhouse_version` | `26.7.1.1315` | Exact package version, applied to all three packages |
+| `clickhouse_http_port` | `8123` | HTTP interface |
+| `clickhouse_tcp_port` | `9000` | Native protocol |
+| `clickhouse_data_dir` | `/var/lib/clickhouse` | Storage path |
+| `clickhouse_listen_host` | `0.0.0.0` | Listen address |
+| `clickhouse_arch` | `amd64` | Repository architecture |
+| `clickhouse_apt_key_url` | ClickHouse `repomd.xml.key` | Repository signing key (served from the `rpm/lts` path, not `deb`) |
+
+## Example
+
+```yaml
+- name: Manage ClickHouse
+  hosts: clickhouse
+  become: true
+  roles:
+    - common
+    - clickhouse
+```

--- a/deployments/roles/clickhouse/defaults/main.yml
+++ b/deployments/roles/clickhouse/defaults/main.yml
@@ -1,0 +1,20 @@
+---
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: Apache-2.0
+# renovate: datasource=deb depName=clickhouse-server
+clickhouse_version: "26.7.1.1315"
+
+clickhouse_arch: amd64
+clickhouse_apt_key_url: "https://packages.clickhouse.com/rpm/lts/repodata/repomd.xml.key"
+clickhouse_apt_repo_uri: "https://packages.clickhouse.com/deb"
+clickhouse_apt_suite: stable
+
+clickhouse_http_port: 8123
+clickhouse_tcp_port: 9000
+clickhouse_data_dir: /var/lib/clickhouse
+
+# ClickHouse binds loopback only out of the box. Akvorado runs on a separate
+# host in this lab, so the stub listens on all interfaces — acceptable because
+# the lab sits on a private subnet, and the reason this is a stub, not a
+# production deployment.
+clickhouse_listen_host: "0.0.0.0"

--- a/deployments/roles/clickhouse/handlers/main.yml
+++ b/deployments/roles/clickhouse/handlers/main.yml
@@ -1,0 +1,10 @@
+---
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: Apache-2.0
+- name: Restart clickhouse
+  ansible.builtin.service:
+    name: clickhouse-server.service
+    state: restarted
+  tags:
+    - clickhouse
+    - systemd

--- a/deployments/roles/clickhouse/tasks/main.yml
+++ b/deployments/roles/clickhouse/tasks/main.yml
@@ -1,0 +1,65 @@
+---
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: Apache-2.0
+- name: Add the ClickHouse apt repository
+  ansible.builtin.deb822_repository:
+    name: clickhouse
+    types: deb
+    uris: "{{ clickhouse_apt_repo_uri }}"
+    suites: "{{ clickhouse_apt_suite }}"
+    components:
+      - main
+    architectures:
+      - "{{ clickhouse_arch }}"
+    signed_by: "{{ clickhouse_apt_key_url }}"
+  tags:
+    - clickhouse
+    - repositories
+
+# Pinned to one version across all three packages: clickhouse-server refuses to
+# start against a mismatched clickhouse-common-static.
+- name: Install ClickHouse {{ clickhouse_version }}
+  ansible.builtin.apt:
+    update_cache: true
+    name:
+      - "clickhouse-common-static={{ clickhouse_version }}"
+      - "clickhouse-server={{ clickhouse_version }}"
+      - "clickhouse-client={{ clickhouse_version }}"
+    install_recommends: false
+  tags:
+    - clickhouse
+
+- name: Ensure the ClickHouse data directory exists
+  ansible.builtin.file:
+    path: "{{ clickhouse_data_dir }}"
+    state: directory
+    owner: clickhouse
+    group: clickhouse
+    mode: "0750"
+  tags:
+    - clickhouse
+    - configuration
+
+# config.d drops in beside the packaged config.xml rather than replacing it, so
+# a package upgrade cannot silently revert the listen address.
+- name: Configure ClickHouse listen address and ports
+  ansible.builtin.template:
+    src: listen.xml.j2
+    dest: /etc/clickhouse-server/config.d/10-lab-listen.xml
+    owner: clickhouse
+    group: clickhouse
+    mode: "0640"
+  notify:
+    - Restart clickhouse
+  tags:
+    - clickhouse
+    - configuration
+
+- name: Enable and start systemd unit for ClickHouse
+  ansible.builtin.service:
+    name: clickhouse-server.service
+    enabled: true
+    state: started
+  tags:
+    - clickhouse
+    - systemd

--- a/deployments/roles/clickhouse/templates/listen.xml.j2
+++ b/deployments/roles/clickhouse/templates/listen.xml.j2
@@ -1,0 +1,9 @@
+{# Copyright 2026 Ronny Trommer <ronny@no42.org> #}
+{# SPDX-License-Identifier: Apache-2.0 #}
+{# Managed by the clickhouse Ansible role — local changes are overwritten. #}
+<clickhouse>
+    <listen_host>{{ clickhouse_listen_host }}</listen_host>
+    <http_port>{{ clickhouse_http_port }}</http_port>
+    <tcp_port>{{ clickhouse_tcp_port }}</tcp_port>
+    <path>{{ clickhouse_data_dir }}/</path>
+</clickhouse>

--- a/requirements.yml
+++ b/requirements.yml
@@ -23,3 +23,9 @@ collections:
   # non-Galaxy 6.1.1-hotfix.1 build is not needed at that Grafana version.
   - name: grafana.grafana
     version: "6.1.0"
+
+  # Used by the repo-local deployments/roles/akvorado role, which drives
+  # Akvorado's Docker Compose stack via community.docker.docker_compose_v2.
+  # Not a dependency of the OpenNMS deployment roles.
+  - name: community.docker
+    version: "4.5.0"


### PR DESCRIPTION
Companion to [ansible-opennms#129](https://github.com/opennms-forge/ansible-opennms/pull/129), which withdrew `akvorado` and `stub_clickhouse` from the collection. They deploy a competing flow engine and its store so OpenNMS can be measured against them — OpenNMS has no wire to either — so they belong here.

Supersedes #143, whose ClickHouse apt pins are folded in (see below).

## New: `deployments/roles/`

A home for **components of a deployment under test**, distinct from `bootstrap/roles/`, which prepares VMs. Both roles are recovered from collection commits `cfe8e22` and `a2aa218` and shed `meta/main.yml` — `galaxy_info` describes a publishable artifact and means nothing for a repo-local role; no existing benchmark role carries one.

`stub_clickhouse` becomes **`clickhouse`**. The `stub_` prefix meant "POC stand-in rather than the production role", a distinction that only exists in the collection where production OpenNMS roles sit alongside. Dropping it gives one name across three layers:

```
topology.yml role key:   clickhouse      akvorado
inventory group:         clickhouse      akvorado
deployments/roles/:      clickhouse      akvorado
```

## Deployment H gets its own playbook

Eight of the nine deployments are the *same* OpenNMS stack with different backends. H is the only one that shares **zero** plays with it — so putting its plays into `opennms-playbook.yml` would hide a second stack inside a playbook named for the first.

`deploy.sh` selects `deployments/<slug>/playbook.yml` when present, else the shared one. The eight OpenNMS deployments ship no `playbook.yml` and are untouched, which keeps the shared play order — the stack's dependency graph, database before core, broker before minion — in exactly one place. Rejected alternatives: per-deployment playbooks (duplicates that graph eight ways) and renaming `opennms-playbook.yml` (~10 files, and unnecessary once selection is per-stack).

Selection is **kvm-gated**, matching the existing vars overlay at `deploy.sh:101`. Only kvm is spec-driven, so `--deployment clickhouse-akvorado --provider azure` would otherwise build the fixed 7-host OpenNMS layout and then run H's playbook against hosts that were never provisioned.

## Also in here

- **`roles_path` appends** rather than replaces: `bootstrap/roles:deployments/roles`.
- **`community.docker`** moves from the collection's `galaxy.yml` to this repo's `requirements.yml`, where its only consumer lives. The `indigo423.opennms` pin stays at `583efae # v0.6.0` — unchanged, and no collection release is needed.
- **ClickHouse apt pins folded in from #143.** That PR's comment pointed at a `stub_clickhouse` role which, after #129, existed nowhere. Landing the pins alongside the role makes the reference resolve — which is also what the review of #143 recommended. Without the hold, the second deploy of H aborts exactly as #141 did.
- **ClickHouse node drops `docker_engine`** — the role installs native `.deb` packages, so Docker would be installed on a host that never uses it. Akvorado keeps it; its whole stack is Compose.
- **CI now lints `deployments/**`.** Without it, a PR touching only these roles would get **no Lint run at all** — the same gap fixed for `opennms-lab-vars.yml` in #139, about to repeat.

## Licensing — worth a look

The collection is **GPL-3.0-or-later**; this repo is **Apache-2.0**. The moved files carry this repo's Apache-2.0 SPDX headers. The basis: the roles were authored for this lab, you hold the copyright on both repos, and they were merged to collection `main` but **never appeared in a tagged release**, so they were never distributed under GPL-3.0. If you'd rather they retain GPL headers, say so and I'll switch them.

## Verification

- `make lint-ansible` — `0 failure(s), 182 files processed` (was 168), profile `production`. The rise confirms the new roles are actually being linted.
- `bash -n deploy.sh` clean; the selection branch exercised directly across five cases:

```
  clickhouse-akvorado    kvm    -> deployments/clickhouse-akvorado/playbook.yml
  vm-single              kvm    -> opennms-playbook.yml
  baseline               kvm    -> opennms-playbook.yml
  clickhouse-akvorado    azure  -> opennms-playbook.yml     (kvm gate)
  <none>                 kvm    -> opennms-playbook.yml
```

- `ansible-playbook --syntax-check` passes on all three playbooks — H's (proving `clickhouse`/`akvorado` resolve via the new `roles_path`), plus `opennms-playbook.yml` and `bootstrap/site.yml` as regressions proving `bootstrap/roles` still resolves.
- `akvorado.yaml.j2` re-rendered after adding SPDX headers: output byte-identical (`changed=0`), still parses with `!include` handled, `clickhousedb.servers` → `["ch-benchmark-01:9000"]`.

**Not deployed yet.** Deployment H has never been stood up; that's the next step, and the `profiles: [disabled]` + `!override depends_on` interaction on Akvorado's bundled ClickHouse remains the least-proven part.
