### PR TITLE
fix(akvorado): unbreak the H stack — ports, container DNS, config lookup

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -11,6 +11,8 @@ on:
       - "opennms-lab-vars.yml"
       - "requirements.yml"
       - ".ansible-lint"
+      # Owns roles_path, so it governs whether roles resolve at all.
+      - "ansible.cfg"
       - "Makefile"
 
 # CI invokes the `make lint-ansible` target, never ansible-lint directly, so local

--- a/deploy.sh
+++ b/deploy.sh
@@ -74,6 +74,13 @@ case "$PROVIDER" in
 esac
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ansible.cfg is the single source of truth for roles_path, and Ansible only
+# picks it up from the current directory. Every path below is absolute, so the
+# caller's cwd is otherwise irrelevant — but without this, invoking the script
+# from anywhere other than the repo root loses deployments/roles and fails with
+# "the role 'clickhouse' was not found".
+export ANSIBLE_CONFIG="$REPO_ROOT/ansible.cfg"
 TF_DIR="$REPO_ROOT/terraform/$PROVIDER"
 TFVARS_FILE="$TF_DIR/${PROVIDER}.tfvars"
 

--- a/deployments/clickhouse-akvorado/opennms-lab-vars.yml
+++ b/deployments/clickhouse-akvorado/opennms-lab-vars.yml
@@ -9,10 +9,16 @@
 # tracked separately.
 
 # Akvorado writes to the dedicated ClickHouse node rather than the container
-# bundled in its own compose stack, which the role disables. Host name comes
-# from the topology (role key `clickhouse` -> vm_name `ch-benchmark-01`).
+# bundled in its own compose stack, which the role disables.
+#
+# By IP, not by name. Akvorado runs in containers, and Docker's embedded
+# resolver does not consult the host's /etc/hosts — so `ch-benchmark-01`, which
+# the etc_hosts role writes on the Akvorado VM, resolves for the host but
+# NXDOMAINs inside the containers. The address is the mgmt NIC of the
+# `clickhouse` topology role (vm_name ch-benchmark-01); it shifts if that role's
+# position in the topology changes.
 akvorado_clickhouse_servers:
-  - "ch-benchmark-01:9000"
+  - "192.0.2.232:9000"
 
 # Populates Src/DstNetName and Role in the console. The lab's mgmt subnet.
 akvorado_networks:

--- a/deployments/roles/akvorado/README.md
+++ b/deployments/roles/akvorado/README.md
@@ -45,7 +45,6 @@ rather than merged, otherwise Compose pulls the disabled service back in.
 | `akvorado_version` | `2.4.1` | Upstream tag to vendor |
 | `akvorado_clickhouse_servers` | `[]` | **Required.** External ClickHouse, e.g. `["ch-benchmark-01:9000"]` |
 | `akvorado_kafka_brokers` | `[kafka:9092]` | In-stack Kafka, Akvorado's own inlet → outlet buffer |
-| `akvorado_http_port` | `8080` | Host port for the console, published from Traefik |
 | `akvorado_networks` | `{}` | Populates `Src/DstNetName/Role` in the console; omitted from the config when empty |
 | `akvorado_demo_exporters` | `false` | Enable upstream's synthetic flow exporters |
 
@@ -56,7 +55,8 @@ generator — it is how the flow path gets exercised end to end.
 
 | Port | Purpose |
 |---|---|
-| `8080/tcp` | Console (configurable) |
+| `8081/tcp` | Console, as published by upstream's Traefik |
+| `127.0.0.1:8080/tcp` | Private entrypoint — unauthenticated services, loopback only |
 | `2055/udp` | NetFlow |
 | `4739/udp` | IPFIX |
 | `6343/udp` | sFlow |

--- a/deployments/roles/akvorado/defaults/main.yml
+++ b/deployments/roles/akvorado/defaults/main.yml
@@ -9,7 +9,12 @@ akvorado_install_dir: /opt/akvorado
 # Where the flow schema lives. Required — the bundled ClickHouse container is
 # disabled (see templates/docker-compose-local.yml.j2) so that a dedicated
 # ClickHouse node (clickhouse) can be measured on its own.
-# Example: ["ch-benchmark-01:9000"]
+#
+# Give an IP, not a hostname: these entries are resolved inside the Akvorado
+# containers, and Docker's embedded resolver does not read the host's
+# /etc/hosts. A lab hostname that resolves fine on the VM NXDOMAINs in the
+# container.
+# Example: ["192.0.2.232:9000"]
 akvorado_clickhouse_servers: []
 
 # Kafka stays inside the compose stack: Akvorado uses it as its own inlet ->
@@ -20,10 +25,11 @@ akvorado_kafka_topic: flows
 akvorado_kafka_partitions: 8
 akvorado_kafka_replication_factor: 1
 
-# Host port for the Akvorado console, published from Traefik's public
-# entrypoint. Traefik also injects the Remote-User header the console
-# authenticates with, which is why it is kept rather than bypassed.
-akvorado_http_port: 8080
+# No console-port variable: upstream publishes the console on 8081 and the
+# private entrypoint on 127.0.0.1:8080, and Compose appends port lists, so any
+# override here adds a binding rather than replacing one. Changing the console
+# port means overriding traefik's published ports with a host port that is not
+# already taken — see upstream's docker-compose-local.yml comments.
 
 # Networks reported as Src/DstNetName/Role in the console. Site-specific, so
 # there is no sensible default — left empty, the section is omitted entirely

--- a/deployments/roles/akvorado/templates/docker-compose-local.yml.j2
+++ b/deployments/roles/akvorado/templates/docker-compose-local.yml.j2
@@ -27,8 +27,9 @@ services:
       kafka:
         condition: service_healthy
 
-  # Publish the console on the host. Traefik is kept because it injects the
-  # Remote-User header the console authenticates with.
-  traefik:
-    ports:
-      - {{ akvorado_http_port }}:8081/tcp
+  # No traefik ports override. Upstream already publishes 127.0.0.1:8080:8080
+  # (private — unauthenticated services) and 8081:8081 (the console), and
+  # Compose *appends* port lists rather than replacing them, so republishing
+  # 8081 on host port 8080 claimed 8080 twice and the stack failed to start.
+  # The console is reachable on 8081 as shipped. Traefik itself is kept: it
+  # injects the Remote-User header the console authenticates with.


### PR DESCRIPTION
Fixes four of the blockers found reviewing #144. All predate the move — the roles had never been deployed — but Deployment H could not have come up with any of them present.

Leaves 2b.2 (`clickhouse.orchestrator-url` unreachable from an external ClickHouse) and 2b.4 (jump-host probe hardcoded to `ip_monitoring`) open; both need design decisions rather than a patch.

## Traefik port conflict (high)

The override republished the console on `{{ akvorado_http_port }}:8081`, but upstream already publishes `127.0.0.1:8080:8080/tcp` and `8081:8081/tcp`, and Compose **appends** port lists rather than replacing them. Host port 8080 was claimed twice, so the stack failed to start.

Dropped entirely. The console is already reachable on **8081**, which is the port upstream intends for users — its own comment explains 8080 stays on loopback precisely *because* it exposes unauthenticated services. So the override was both broken and aimed at the wrong port. `akvorado_http_port` goes with it: it implied a knob the role does not provide.

## Containers cannot resolve lab hostnames (high)

`akvorado_clickhouse_servers` pointed at `ch-benchmark-01`, which the `etc_hosts` role writes into the Akvorado VM's `/etc/hosts`. But Docker's embedded resolver does not consult the host's `/etc/hosts` — it forwards to the daemon's upstream nameservers — so every Akvorado container would have NXDOMAINed on it.

Now uses the mgmt IP, with the reason recorded in both the overlay and the role defaults so the next person doesn't reach for a hostname. Worth noting the irony: the `etc_hosts` role fixes host-level resolution across topology swaps and is simply not in play for containerised workloads.

## deploy.sh depended on the caller's cwd (medium)

Ansible only picks up `ansible.cfg` from the current directory, and `deploy.sh` uses absolute paths without ever `cd`-ing to the repo root. Making `ansible.cfg` the sole owner of `roles_path` (in #144) turned that latent quirk into a real failure: run the script from anywhere else and `deployments/roles` vanishes.

Exports `ANSIBLE_CONFIG` explicitly rather than `cd`-ing, so relative-path semantics elsewhere in the script are untouched.

## ansible.cfg missing from the CI lint filter (nit)

It now governs whether roles resolve at all, but a change to it alone triggered no lint.

## Verification

Rendered both templates into the **real upstream v2.4.1 tree** and ran `docker compose config` — a check that would have caught the port bug before it was ever committed, and which now covers the part of this stack I'd flagged as least proven:

```
published host ports
  akvorado-inlet:   0.0.0.0:2055 -> 2055/udp
  akvorado-inlet:   0.0.0.0:4739 -> 4739/udp
  akvorado-inlet:   0.0.0.0:6343 -> 6343/udp
  akvorado-outlet:  0.0.0.0:10179 -> 10179/tcp
  traefik:          127.0.0.1:8080 -> 8080/tcp
  traefik:          0.0.0.0:8081  -> 8081/tcp
```

No duplicate 8080. And the override behaves as designed:

```
clickhouse in services:        False
akvorado-console.depends_on:   ['akvorado-orchestrator', 'redis']
akvorado-outlet.depends_on:    ['akvorado-orchestrator', 'kafka']
demo profile services:         + akvorado-exporter-1..4
clickhousedb.servers:          192.0.2.232:9000
```

That settles task 3.3 — `profiles: [disabled]` plus `!override depends_on` drops the bundled ClickHouse cleanly while keeping the other dependency edges — without needing a lab.

The cwd fix is reproduced both ways from `/tmp`: `--syntax-check` on H's playbook fails without `ANSIBLE_CONFIG` and passes with it.

`make lint-ansible` — `0 failure(s), 182 files processed`, profile `production`. `bash -n deploy.sh` clean. No stale `akvorado_http_port` references remain.
