### PR TITLE
fix: derive the jump host from the topology, publish the orchestrator

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -144,7 +144,7 @@ discover_jump_host() {
       -o ConnectTimeout=5 \
       -o ProxyJump="$hypervisor" \
       "${admin_user}@${mgmt_ip}" \
-      'ip -4 addr | grep inet | grep -oE "([0-9]{1,3}\.){3}[0-9]{1,3}" | grep -v "^192\.0\.2\.\|^127\."' \
+      'ip -4 addr | grep inet | grep -oE "([0-9]{1,3}\.){3}[0-9]{1,3}" | grep -vE "^192\.0\.2\.|^127\.|^172\.(1[6-9]|2[0-9]|3[01])\.|^169\.254\."' \
       2>/dev/null | head -1 || true)
     [[ -n "$jump_host" ]] && break
     info "waiting for external IP on jump host... ($i/24)" >&2
@@ -214,8 +214,14 @@ if [[ "$PROVIDER" == "kvm" || "$PROVIDER" == "proxmox" || "$PROVIDER" == "vmware
   # leaves the inventory without a ProxyCommand. Only the spec-driven kvm root
   # exposes ip_jump_host; the others still have a fixed layout where the
   # monitoring VM is always the jump host.
+  # On kvm the value is authoritative even when empty: empty means the spec
+  # marks no node public_ip, i.e. there is no jump host, and falling back to
+  # the static ip_monitoring would reintroduce the very timeout this replaced.
+  # The other providers do not expose the output at all, hence the fallback.
   IP_JUMP_HOST=$(tf_output ip_jump_host)
-  [[ -z "$IP_JUMP_HOST" ]] && IP_JUMP_HOST=$(tf_output ip_monitoring)
+  if [[ "$PROVIDER" != "kvm" && -z "$IP_JUMP_HOST" ]]; then
+    IP_JUMP_HOST=$(tf_output ip_monitoring)
+  fi
   ADMIN_USER=$(tf_output admin_user)
 
   if [[ "$PROVIDER" == "kvm" ]]; then

--- a/deploy.sh
+++ b/deploy.sh
@@ -147,7 +147,7 @@ discover_jump_host() {
       'ip -4 addr | grep inet | grep -oE "([0-9]{1,3}\.){3}[0-9]{1,3}" | grep -v "^192\.0\.2\.\|^127\."' \
       2>/dev/null | head -1 || true)
     [[ -n "$jump_host" ]] && break
-    info "waiting for external IP on monitoring VM... ($i/24)" >&2
+    info "waiting for external IP on jump host... ($i/24)" >&2
     sleep 5
   done
   echo "$jump_host"
@@ -208,7 +208,14 @@ tf_apply "${PROVIDER_VARS[@]+"${PROVIDER_VARS[@]}"}"
 # after boot and cannot be known at plan time.  Discover it via SSH through the
 # hypervisor, then re-apply to regenerate the Ansible inventory with ProxyJump.
 if [[ "$PROVIDER" == "kvm" || "$PROVIDER" == "proxmox" || "$PROVIDER" == "vmware" ]]; then
-  IP_MONITORING=$(tf_output ip_monitoring)
+  # Prefer the topology-derived jump host. ip_monitoring is a static tfvars
+  # value and reports the monitoring VM's address even for a deployment that
+  # provisions none — probing it there just times out for two minutes and
+  # leaves the inventory without a ProxyCommand. Only the spec-driven kvm root
+  # exposes ip_jump_host; the others still have a fixed layout where the
+  # monitoring VM is always the jump host.
+  IP_JUMP_HOST=$(tf_output ip_jump_host)
+  [[ -z "$IP_JUMP_HOST" ]] && IP_JUMP_HOST=$(tf_output ip_monitoring)
   ADMIN_USER=$(tf_output admin_user)
 
   if [[ "$PROVIDER" == "kvm" ]]; then
@@ -222,9 +229,9 @@ if [[ "$PROVIDER" == "kvm" || "$PROVIDER" == "proxmox" || "$PROVIDER" == "vmware
     HYPERVISOR=$(tf_output vsphere_server)
   fi
 
-  if [[ -n "$HYPERVISOR" && -n "$IP_MONITORING" ]]; then
-    step "Discovering monitoring VM external IP (via $HYPERVISOR → $IP_MONITORING)..."
-    JUMP_HOST=$(discover_jump_host "$HYPERVISOR" "$IP_MONITORING" "$ADMIN_USER")
+  if [[ -n "$HYPERVISOR" && -n "$IP_JUMP_HOST" ]]; then
+    step "Discovering jump host external IP (via $HYPERVISOR → $IP_JUMP_HOST)..."
+    JUMP_HOST=$(discover_jump_host "$HYPERVISOR" "$IP_JUMP_HOST" "$ADMIN_USER")
 
     if [[ -n "$JUMP_HOST" ]]; then
       info "found: $JUMP_HOST — regenerating inventory with jump host..."

--- a/deployments/clickhouse-akvorado/topology.yml
+++ b/deployments/clickhouse-akvorado/topology.yml
@@ -14,6 +14,12 @@ roles:
   akvorado:
     count: 1
     size: medium
-    subnets: [mgmt, sim]
+    # external is required alongside public_ip, as in every other deployment:
+    # the mgmt default route is suppressed for public_ip nodes on the
+    # assumption an external NIC carries it, and cloud-init only emits
+    # nameservers for an interface that has a gateway. Without it this node
+    # boots with no default route and no DNS — no tarball fetch, no docker
+    # pull — and the jump-host probe finds no external address to discover.
+    subnets: [mgmt, sim, external]
     public_ip: true
     groups: [akvorado, docker_engine]

--- a/deployments/roles/akvorado/defaults/main.yml
+++ b/deployments/roles/akvorado/defaults/main.yml
@@ -26,8 +26,10 @@ akvorado_clickhouse_servers: []
 #
 # Defaults to the inventory's lab_mgmt_ip: management, never the jump host's
 # external DHCP address, so the unauthenticated orchestrator API stays off the
-# public interface. Left empty, the role falls back to upstream's in-compose
-# URL — correct only when ClickHouse also runs in the stack.
+# public interface. Required — the role asserts it, because ClickHouse is
+# always external here and a compose-internal URL it cannot resolve would only
+# surface later as dictionaries that silently never load. Only the spec-driven
+# topology-inventory module emits lab_mgmt_ip; elsewhere, set this explicitly.
 akvorado_orchestrator_host: "{{ lab_mgmt_ip | default('') }}"
 akvorado_orchestrator_port: 8090
 

--- a/deployments/roles/akvorado/defaults/main.yml
+++ b/deployments/roles/akvorado/defaults/main.yml
@@ -17,6 +17,20 @@ akvorado_install_dir: /opt/akvorado
 # Example: ["192.0.2.232:9000"]
 akvorado_clickhouse_servers: []
 
+# ClickHouse fetches Akvorado's dictionaries (asns, networks, protocols, ports)
+# over HTTP, from CREATE DICTIONARY ... SOURCE(HTTP(...)) pointed at the
+# orchestrator. Upstream addresses it as http://akvorado-orchestrator:8080,
+# which only resolves inside the compose network — an external ClickHouse
+# cannot reach it, and Traefik's :8080 entrypoint is loopback-bound. So the
+# orchestrator is published on the host's management address instead.
+#
+# Defaults to the inventory's lab_mgmt_ip: management, never the jump host's
+# external DHCP address, so the unauthenticated orchestrator API stays off the
+# public interface. Left empty, the role falls back to upstream's in-compose
+# URL — correct only when ClickHouse also runs in the stack.
+akvorado_orchestrator_host: "{{ lab_mgmt_ip | default('') }}"
+akvorado_orchestrator_port: 8090
+
 # Kafka stays inside the compose stack: Akvorado uses it as its own inlet ->
 # outlet buffer, not as a shared lab broker.
 akvorado_kafka_brokers:

--- a/deployments/roles/akvorado/tasks/main.yml
+++ b/deployments/roles/akvorado/tasks/main.yml
@@ -1,14 +1,21 @@
 ---
 # Copyright 2026 Ronny Trommer <ronny@no42.org>
 # SPDX-License-Identifier: Apache-2.0
-- name: Assert an external ClickHouse is configured
+- name: Assert the external ClickHouse and orchestrator address are configured
   ansible.builtin.assert:
     that:
       - akvorado_clickhouse_servers | length > 0
+      - akvorado_orchestrator_host | length > 0
     fail_msg: >-
-      akvorado_clickhouse_servers is empty. The bundled ClickHouse container is
-      disabled, so Akvorado has nowhere to write flows. Set it to the
-      clickhouse host, e.g. ["ch-benchmark-01:9000"].
+      akvorado_clickhouse_servers and akvorado_orchestrator_host must both be
+      set. This role always disables the bundled ClickHouse container, so
+      ClickHouse is always external: it needs somewhere to write flows
+      (by IP, e.g. ["192.0.2.232:9000"] — container DNS cannot see the host's
+      /etc/hosts) and an orchestrator address it can reach to load its
+      dictionaries. akvorado_orchestrator_host defaults to the inventory's
+      lab_mgmt_ip, which only the spec-driven topology-inventory module emits;
+      on an inventory without it, set it explicitly rather than silently
+      rendering a compose-internal URL that ClickHouse cannot resolve.
   # always, not the role tag: a --tags docker or --tags configuration run would
   # otherwise skip the guard and still template the config and start the stack,
   # which is exactly the confusing failure this assert exists to prevent.

--- a/deployments/roles/akvorado/templates/akvorado.yaml.j2
+++ b/deployments/roles/akvorado/templates/akvorado.yaml.j2
@@ -38,11 +38,7 @@ clickhouse:
 {# Keep these tags at column 0: Ansible templates with trim_blocks but not     #}
 {# lstrip_blocks, so leading whitespace on a comment line survives into the    #}
 {# output and would corrupt the indentation of the block below.                #}
-{% if akvorado_orchestrator_host %}
   orchestrator-url: http://{{ akvorado_orchestrator_host }}:{{ akvorado_orchestrator_port }}
-{% else %}
-  orchestrator-url: http://akvorado-orchestrator:8080
-{% endif %}
   prometheus-endpoint: /metrics
 {% if akvorado_networks %}
   networks:

--- a/deployments/roles/akvorado/templates/akvorado.yaml.j2
+++ b/deployments/roles/akvorado/templates/akvorado.yaml.j2
@@ -33,7 +33,16 @@ clickhousedb:
 {% endfor %}
 
 clickhouse:
+{# ClickHouse dereferences orchestrator-url itself to load dictionaries, so it #}
+{# must be reachable from the ClickHouse host, not a compose-internal name.    #}
+{# Keep these tags at column 0: Ansible templates with trim_blocks but not     #}
+{# lstrip_blocks, so leading whitespace on a comment line survives into the    #}
+{# output and would corrupt the indentation of the block below.                #}
+{% if akvorado_orchestrator_host %}
+  orchestrator-url: http://{{ akvorado_orchestrator_host }}:{{ akvorado_orchestrator_port }}
+{% else %}
   orchestrator-url: http://akvorado-orchestrator:8080
+{% endif %}
   prometheus-endpoint: /metrics
 {% if akvorado_networks %}
   networks:

--- a/deployments/roles/akvorado/templates/docker-compose-local.yml.j2
+++ b/deployments/roles/akvorado/templates/docker-compose-local.yml.j2
@@ -13,6 +13,15 @@ services:
   clickhouse:
     profiles: [disabled]
 
+{% if akvorado_orchestrator_host %}
+  # Published so the external ClickHouse can fetch dictionaries from it.
+  # Bound to the management address rather than 0.0.0.0: this node is the
+  # deployment's jump host, and the orchestrator API is unauthenticated.
+  akvorado-orchestrator:
+    ports:
+      - {{ akvorado_orchestrator_host }}:{{ akvorado_orchestrator_port }}:8080/tcp
+
+{% endif %}
   akvorado-console:
     depends_on: !override
       akvorado-orchestrator:

--- a/deployments/roles/akvorado/templates/docker-compose-local.yml.j2
+++ b/deployments/roles/akvorado/templates/docker-compose-local.yml.j2
@@ -13,7 +13,6 @@ services:
   clickhouse:
     profiles: [disabled]
 
-{% if akvorado_orchestrator_host %}
   # Published so the external ClickHouse can fetch dictionaries from it.
   # Bound to the management address rather than 0.0.0.0: this node is the
   # deployment's jump host, and the orchestrator API is unauthenticated.
@@ -21,7 +20,6 @@ services:
     ports:
       - {{ akvorado_orchestrator_host }}:{{ akvorado_orchestrator_port }}:8080/tcp
 
-{% endif %}
   akvorado-console:
     depends_on: !override
       akvorado-orchestrator:

--- a/terraform/kvm/outputs.tf
+++ b/terraform/kvm/outputs.tf
@@ -8,6 +8,17 @@ output "ip_monitoring" {
   description = "Management IP of the monitoring VM (reachable from the KVM host via NAT)"
 }
 
+# ip_monitoring is a static tfvars value, so it reports 192.0.2.200 even for a
+# deployment that provisions no monitoring VM. The jump host is whichever node
+# the spec marks public_ip, which for clickhouse-akvorado is the Akvorado node —
+# probing ip_monitoring there just times out. Derive it from the topology
+# instead. For every OpenNMS deployment the jump node IS monitoring, so this
+# resolves to the same address ip_monitoring already returned.
+output "ip_jump_host" {
+  value       = local.jump_host_name != "" ? local.inv_hosts[local.jump_host_name].ansible_host : ""
+  description = "Management IP of the deployment's jump host (the public_ip node), derived from the topology spec"
+}
+
 output "admin_user" {
   value       = var.admin_user
   description = "Admin user on the VMs"


### PR DESCRIPTION
The last two blockers from the review of #144 (2b.2 and 2b.4). With these, all eight review findings are closed except the two lows.

## Jump host derived from the topology (2b.4)

`deploy.sh` probed `tf_output ip_monitoring` — but that output is a **static tfvars value**, not derived from the spec:

```hcl
output "ip_monitoring" { value = var.ip_monitoring }
```

So it reports `192.0.2.200` even for a deployment that provisions no monitoring VM. Deployment H's `public_ip` node is `akvorado`, so the probe spun for two minutes against an address nothing answers on, then regenerated an inventory with no `ProxyCommand` and failed the bootstrap play as unreachable — meaning the playbook selection added in #144 was never even reached.

The kvm root already computes `local.jump_node_key` from `public_ip: true`, so this just exposes it. New `ip_jump_host` output resolves that node's mgmt address out of `local.inv_hosts`; `deploy.sh` prefers it and falls back to `ip_monitoring` for azure/proxmox/vmware, which are still on the fixed layout where monitoring is always the jump host.

Verified by plan:

```
clickhouse-akvorado:   ip_jump_host  = "192.0.2.233"   ← the Akvorado node
                       ip_monitoring = "192.0.2.200"   ← a VM this deployment has no

baseline:              ip_jump_host  = "192.0.2.200"
                       ip_monitoring = "192.0.2.200"   ← identical, 37 to add / 0 destroy
```

The `discover_jump_host` function itself needed no change — it was always generic; only its input and log wording were monitoring-specific.

## Orchestrator reachable from the external ClickHouse (2b.2)

ClickHouse dereferences `clickhouse.orchestrator-url` **itself**, inside `CREATE DICTIONARY ... SOURCE(HTTP(...))`, to load the asns/networks/protocols/ports dictionaries. Upstream addresses the orchestrator as `http://akvorado-orchestrator:8080`, which only resolves inside the compose network. Once ClickHouse moved to its own node that silently broke every dictionary — and Traefik's `:8080` entrypoint is loopback-bound, so there was no route in at all.

The orchestrator is now published on the host, bound to the **management address** (`lab_mgmt_ip` from the inventory) rather than `0.0.0.0`. That matters: this node is the deployment's jump host with an external DHCP address, and the orchestrator API is unauthenticated — it has no business on the public interface.

With `lab_mgmt_ip` unset the role falls back to upstream's in-compose URL and publishes nothing, which is the correct behaviour for an all-in-one stack.

Verified against the real upstream v2.4.1 tree with `docker compose config`:

```
akvorado-orchestrator:  192.0.2.233:8090 -> 8080     ← management address only
traefik:                127.0.0.1:8080  -> 8080
traefik:                0.0.0.0:8081    -> 8081
clickhouse disabled:    True
orchestrator-url:       http://192.0.2.233:8090
clickhousedb.servers:   ['192.0.2.232:9000']
```

and the fallback path publishes no orchestrator port and keeps `http://akvorado-orchestrator:8080`.

## A bug the verification caught

My first version put explanatory `{# ... #}` comments *inside* the templated block, indented to match. Ansible templates with `trim_blocks` but **not** `lstrip_blocks`, so each comment line's leading whitespace survives into the output — it pushed `orchestrator-url` to six spaces against `prometheus-endpoint`'s two and made the config unparseable:

```
ParserError: while parsing a block mapping
```

Comments moved to column 0. The rendered config now parses, with `clickhouse` keys `['orchestrator-url', 'prometheus-endpoint', 'networks']`.

## Verification summary

`make fmt`, `make validate-kvm`, `make lint-ansible` (`0 failure(s), 182 files`, production), `bash -n deploy.sh` — all clean. Plans run for both `clickhouse-akvorado` and `baseline`.

**Still not deployed.** What remains untested on real infrastructure is whether ClickHouse can actually fetch the dictionaries over the published port, and whether the migrations succeed against ClickHouse 26.7 when Akvorado pins 26.3 LTS (finding 2b.7). Those need the lab.
