### PR TITLE
fix: expose the host CPU to guests, and make Akvorado's compose actually start

### DIFF
--- a/deployments/roles/akvorado/defaults/main.yml
+++ b/deployments/roles/akvorado/defaults/main.yml
@@ -6,21 +6,23 @@ akvorado_version: "2.4.1"
 akvorado_src_url: "https://github.com/akvorado/akvorado/archive/refs/tags/v{{ akvorado_version }}.tar.gz"
 akvorado_install_dir: /opt/akvorado
 
-# Upstream keeps its compose files under docker/ and chains them through
-# COMPOSE_FILE in the shipped .env. The docker CLI reads that; the Ansible
-# module does not — it looks for a compose file directly in project_src and
-# fails before invoking docker — so the chain is listed explicitly here.
-# Mirrors the active (uncommented) COMPOSE_FILE entries in .env for the pinned
-# akvorado_version; re-check it when bumping the version. Order matters:
-# later files override earlier ones, so the local override must stay last.
+# Upstream chains its compose files through COMPOSE_FILE in the root .env. The
+# docker CLI reads that; the Ansible module does not — it looks for a compose
+# file directly in its project directory — so the chain is listed explicitly.
+# Paths are relative to docker/, which is the compose project directory here;
+# see vars/main.yml for why.
+#
+# Mirrors the active (uncommented) COMPOSE_FILE entries in the root .env for
+# the pinned akvorado_version; re-check when bumping it. Order matters: later
+# files override earlier ones, so the local override must stay last.
 akvorado_compose_files:
-  - docker/docker-compose.yml
-  - docker/docker-compose-ipinfo.yml
-  - docker/docker-compose-prometheus.yml
-  - docker/docker-compose-loki.yml
-  - docker/docker-compose-grafana.yml
-  - docker/docker-compose-demo.yml
-  - docker/docker-compose-local.yml
+  - docker-compose.yml
+  - docker-compose-ipinfo.yml
+  - docker-compose-prometheus.yml
+  - docker-compose-loki.yml
+  - docker-compose-grafana.yml
+  - docker-compose-demo.yml
+  - docker-compose-local.yml
 
 # Where the flow schema lives. Required — the bundled ClickHouse container is
 # disabled (see templates/docker-compose-local.yml.j2) so that a dedicated

--- a/deployments/roles/akvorado/defaults/main.yml
+++ b/deployments/roles/akvorado/defaults/main.yml
@@ -6,6 +6,22 @@ akvorado_version: "2.4.1"
 akvorado_src_url: "https://github.com/akvorado/akvorado/archive/refs/tags/v{{ akvorado_version }}.tar.gz"
 akvorado_install_dir: /opt/akvorado
 
+# Upstream keeps its compose files under docker/ and chains them through
+# COMPOSE_FILE in the shipped .env. The docker CLI reads that; the Ansible
+# module does not — it looks for a compose file directly in project_src and
+# fails before invoking docker — so the chain is listed explicitly here.
+# Mirrors the active (uncommented) COMPOSE_FILE entries in .env for the pinned
+# akvorado_version; re-check it when bumping the version. Order matters:
+# later files override earlier ones, so the local override must stay last.
+akvorado_compose_files:
+  - docker/docker-compose.yml
+  - docker/docker-compose-ipinfo.yml
+  - docker/docker-compose-prometheus.yml
+  - docker/docker-compose-loki.yml
+  - docker/docker-compose-grafana.yml
+  - docker/docker-compose-demo.yml
+  - docker/docker-compose-local.yml
+
 # Where the flow schema lives. Required — the bundled ClickHouse container is
 # disabled (see templates/docker-compose-local.yml.j2) so that a dedicated
 # ClickHouse node (clickhouse) can be measured on its own.

--- a/deployments/roles/akvorado/handlers/main.yml
+++ b/deployments/roles/akvorado/handlers/main.yml
@@ -3,7 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 - name: Restart akvorado
   community.docker.docker_compose_v2:
-    project_src: "{{ _akvorado_project_dir }}"
+    project_src: "{{ _akvorado_compose_dir }}"
+    project_name: "{{ _akvorado_project_name }}"
     files: "{{ akvorado_compose_files }}"
     profiles: "{{ ['demo'] if akvorado_demo_exporters else omit }}"
     state: restarted

--- a/deployments/roles/akvorado/handlers/main.yml
+++ b/deployments/roles/akvorado/handlers/main.yml
@@ -4,6 +4,7 @@
 - name: Restart akvorado
   community.docker.docker_compose_v2:
     project_src: "{{ _akvorado_project_dir }}"
+    files: "{{ akvorado_compose_files }}"
     profiles: "{{ ['demo'] if akvorado_demo_exporters else omit }}"
     state: restarted
     wait: true

--- a/deployments/roles/akvorado/tasks/main.yml
+++ b/deployments/roles/akvorado/tasks/main.yml
@@ -75,7 +75,8 @@
 
 - name: Start the Akvorado stack
   community.docker.docker_compose_v2:
-    project_src: "{{ _akvorado_project_dir }}"
+    project_src: "{{ _akvorado_compose_dir }}"
+    project_name: "{{ _akvorado_project_name }}"
     files: "{{ akvorado_compose_files }}"
     profiles: "{{ ['demo'] if akvorado_demo_exporters else omit }}"
     state: present

--- a/deployments/roles/akvorado/tasks/main.yml
+++ b/deployments/roles/akvorado/tasks/main.yml
@@ -76,6 +76,7 @@
 - name: Start the Akvorado stack
   community.docker.docker_compose_v2:
     project_src: "{{ _akvorado_project_dir }}"
+    files: "{{ akvorado_compose_files }}"
     profiles: "{{ ['demo'] if akvorado_demo_exporters else omit }}"
     state: present
     wait: true

--- a/deployments/roles/akvorado/vars/main.yml
+++ b/deployments/roles/akvorado/vars/main.yml
@@ -3,3 +3,17 @@
 # SPDX-License-Identifier: Apache-2.0
 # The release tarball unpacks to a version-named directory.
 _akvorado_project_dir: "{{ akvorado_install_dir }}/akvorado-{{ akvorado_version }}"
+
+# Compose runs with its project directory set to docker/, not the tree root.
+# docker_compose_v2 always passes --project-directory, and pointing it at the
+# root breaks the relative paths upstream's compose files are written against:
+# `extends: file: versions.yml` and the `../config` bind both resolve from the
+# compose file's own directory. Rooted, they became
+# <root>/versions.yml (missing) and <root>/../config (outside the tree).
+#
+# Upstream ships docker/.env purely as a guard against humans running compose
+# from there — it only sets an invalid COMPOSE_FILE, which the explicit --file
+# list overrides. That also means the root .env is not read, so the project
+# name is set explicitly rather than inherited from COMPOSE_PROJECT_NAME.
+_akvorado_compose_dir: "{{ _akvorado_project_dir }}/docker"
+_akvorado_project_name: akvorado

--- a/terraform/kvm/modules/compute/main.tf
+++ b/terraform/kvm/modules/compute/main.tf
@@ -117,6 +117,25 @@ resource "libvirt_domain" "vm" {
   memory_unit = "MiB"
   vcpu        = each.value.vcpu
 
+  # Without this libvirt defaults to the qemu64 model: an x86-64 baseline CPU
+  # with no SSE4.2, AVX or AVX2. Two consequences, both bad for this lab.
+  #
+  # ClickHouse requires SSE4.2 and dies at package configuration time with
+  # "Illegal instruction (core dumped)" — Deployment H cannot install at all.
+  #
+  # More quietly, every number this lab has ever produced was measured on a
+  # CPU without vector instructions. JVM intrinsics, Kafka and Elasticsearch
+  # compression and checksums, and the TSDB engines all lean on SSE4.2/AVX2,
+  # so results were systematically unrepresentative of the hardware anyone
+  # actually runs on — the opposite of what a benchmark lab is for.
+  #
+  # host-passthrough rather than host-model: this is a single-hypervisor lab
+  # with no live migration to preserve, so exposing the host CPU exactly is
+  # both the fastest and the most faithful option.
+  cpu = {
+    mode = "host-passthrough"
+  }
+
   os = {
     type         = "hvm"
     type_arch    = "x86_64"


### PR DESCRIPTION
Deployment H now deploys end to end. Three defects, found by actually running it.

## 1. Guests ran on an emulated baseline CPU

libvirt defaulted to the **qemu64** model — x86-64 baseline, no SSE4.2, AVX or AVX2 — while the hypervisor has all three:

```
guest:  <cpu mode='custom'><model fallback='forbid'>qemu64</model>
        "QEMU Virtual CPU version 2.5+",  x86-64-v2 capable: NO
host:   avx  avx2  sse4_2
```

ClickHouse requires SSE4.2, so H could not install at all — `clickhouse-server` died in post-install with `Illegal instruction (core dumped)`, dpkg exit 132.

**The quieter problem matters more.** Every measurement this lab has produced was taken on a CPU without vector instructions. JVM intrinsics, Kafka and Elasticsearch compression and checksums, and the Mimir/VictoriaMetrics engines all use SSE4.2/AVX2 — so the numbers were systematically unrepresentative of the hardware these stacks actually run on, which is the opposite of what a benchmark lab is for. **Earlier Phase 3a figures should be read with that caveat.**

`host-passthrough` rather than `host-model`: single hypervisor, no live migration to preserve. Note libvirt only honours a CPU model change at next boot, so an existing lab must be recreated rather than re-applied.

## 2. The compose file chain was never passed

`community.docker.docker_compose_v2` looks for a compose file directly in its project directory and errors before invoking docker. Upstream keeps its files under `docker/` and chains them via `COMPOSE_FILE` in the root `.env` — the CLI reads that, the module does not. Listed explicitly; verified an explicit `-f` list and the `.env`-driven run resolve to the same nine services.

## 3. Compose could not resolve upstream's relative paths

```
open /opt/akvorado/akvorado-2.4.1/versions.yml: no such file
```

The module always passes `--project-directory`. Pointed at the tree root, `extends: file: versions.yml` and the `../config` bind — both relative to the compose file's own directory — resolved outside the tree. The CLI never showed this because without `--project-directory` it infers the project directory from the first `-f` file.

`project_src` now points at `docker/`, matching what the CLI would infer. Upstream's `docker/.env` guard only sets an invalid `COMPOSE_FILE`, which the explicit `--file` list overrides; the root `.env` is therefore not read, so the project name is set explicitly.

**Both 2 and 3 are the same lesson**: the pre-deploy `docker compose config` check used the CLI, while the role drives the Ansible module. It validated the templates but not the invocation.

## Verified live

```
13 containers healthy — console, inlet, orchestrator, outlet, 4 demo exporters,
                        kafka, kafka-ui, redis, traefik, geoip
no clickhouse container                    ← profiles:[disabled] + !override works
console :8081                       -> 200
orchestrator :8090 dictionary CSV   -> 200
ClickHouse dictionaries: networks LOADED 3,463,881 | asns LOADED 103,861 | protocols LOADED 129
default.flows: 39,949 -> 46,171 in 60s     (~104 flows/sec)
```

The dictionary loads are the direct proof of the orchestrator-URL fix from #146: ClickHouse fetched them over HTTP from `192.0.2.233:8090`. Akvorado's migrations also succeeded against ClickHouse 26.7, so finding 2b.7's compatibility concern did not materialise — the comparability question about running a different branch from Akvorado's pinned 26.3 LTS stands on its own.

Also corrected along the way: my earlier teardown checks ran `virsh` as an unprivileged user, hitting `qemu:///session` rather than the `qemu:///system` namespace Terraform uses — they were reading an empty namespace and proved nothing. The `terraform destroy` output was always the authoritative signal.
