### PR TITLE
feat(deployments): add the es-cluster-min component test bed

### DIFF
--- a/deployments/README.md
+++ b/deployments/README.md
@@ -111,6 +111,7 @@ Descriptor component order: `es mm vm ch ak rr pg sn kf on mn nl6`.
 | `vm-single` (F) | `1vm-1pg-1on` | single VictoriaMetrics |
 | `mimir-single` (G) | `1mm-1pg-1on` | single Mimir |
 | `clickhouse-akvorado` (H) | `1ch-1ak` | standalone flow-engine (no OpenNMS) |
+| `es-cluster-min` | `3es` | **component test bed**, not A–H — verifies Elasticsearch cluster formation on a footprint that fits the lab (28 GB) |
 
 **Interpretation notes:** B lists RRDTool without a Core, but RRD is a Core
 storage strategy, so `baseline`/B include `core` with the RRD strategy set at the

--- a/deployments/es-cluster-min/topology.yml
+++ b/deployments/es-cluster-min/topology.yml
@@ -1,0 +1,22 @@
+name: es-cluster-min
+description: >-
+  Component test bed — Elasticsearch cluster formation only. Not an A–H
+  benchmark topology: it exists to verify stub_elasticsearch's derived
+  discovery on a footprint that fits the lab hypervisor (28 GB), because
+  Deployment A needs 132 GB and cannot run there.
+roles:
+  elasticsearch:
+    count: 3
+    size: large
+    subnets: [mgmt, db]
+    groups: [elasticsearch]
+  # Jump host only. Every kvm deployment needs a public_ip node or there is no
+  # ProxyCommand and Ansible cannot reach the 192.0.2.x hosts at all. Kept out
+  # of mon_servers so the bootstrap monitoring stack (Grafana, Prometheus,
+  # Traefik...) is not dragged in for a test bed that does not need it.
+  monitoring:
+    count: 1
+    size: small
+    subnets: [mgmt, external]
+    public_ip: true
+    groups: []


### PR DESCRIPTION
Phase 3c verifies multi-node roles **component by component**, because Deployment A needs **132 GB / 50 vCPU** against a hypervisor with **62 GB / 16 cores** and cannot run there at all. This is the Elasticsearch bed: 3 nodes plus a jump host, **28 GB**.

Listed in the deployment index as a *component test bed* rather than an A–H benchmark topology, so the curated library stays readable.

The jump host is not decoration: every kvm deployment needs a `public_ip` node or there is no `ProxyCommand` and Ansible cannot reach the `192.0.2.x` hosts at all. It is deliberately kept out of `mon_servers` so the bootstrap monitoring stack (Grafana, Prometheus, Traefik) is not dragged into a test bed with no use for it.

## What it found

Used to verify [ansible-opennms#130](https://github.com/opennms-forge/ansible-opennms/pull/130) live — and it earned its keep immediately, finding **two defects that rendering the role's own defaults could not**:

1. **`discovery.type` was never actually removed.** `combine()` only adds keys, and this repo overrides `es_configuration` wholesale via extra-vars — including `discovery.type: single-node`. All three nodes rendered seed hosts, initial master nodes *and* single-node, and refused to boot. #130 had claimed the two forms were mutually exclusive by construction; they were not, for exactly the configuration this lab uses.
2. **`bootstrap.memory_lock` had always been inert.** Single-node Elasticsearch skips bootstrap checks. A cluster runs them, and the nodes died on `memory locking requested ... but memory is not locked`.

## Verified

```
LimitMEMLOCK=infinity
status: green,  number_of_nodes: 3,  number_of_data_nodes: 3
es-benchmark-02 elected master

index        shard prirep state   node
clustercheck 0     p      STARTED es-benchmark-02
clustercheck 0     r      STARTED es-benchmark-03
clustercheck 1     p      STARTED es-benchmark-03
clustercheck 1     r      STARTED es-benchmark-01
clustercheck 2     r      STARTED es-benchmark-02
clustercheck 2     p      STARTED es-benchmark-01
```

Primaries and replicas on distinct nodes — a functional cluster, not merely a formed one.

`make validate-deployments` passes; descriptor is `3es`. `terraform plan` renders 25 resources with `ip_jump_host = 192.0.2.200` and all three nodes in the `elasticsearch` group.

The collection changes were exercised through the documented `type: dir` local-dev override, which has been reverted — `requirements.yml` still pins `583efae # v0.6.0`.