### PR TITLE
feat(deployments): add the kafka-cluster-min component test bed

### DIFF
--- a/deployments/README.md
+++ b/deployments/README.md
@@ -112,6 +112,7 @@ Descriptor component order: `es mm vm ch ak rr pg sn kf on mn nl6`.
 | `mimir-single` (G) | `1mm-1pg-1on` | single Mimir |
 | `clickhouse-akvorado` (H) | `1ch-1ak` | standalone flow-engine (no OpenNMS) |
 | `es-cluster-min` | `3es` | **component test bed**, not A–H — verifies Elasticsearch cluster formation on a footprint that fits the lab (28 GB) |
+| `kafka-cluster-min` | `3kf` | **component test bed**, not A–H — verifies KRaft cluster formation (shared cluster ID, quorum, RF 3) at 28 GB |
 
 **Interpretation notes:** B lists RRDTool without a Core, but RRD is a Core
 storage strategy, so `baseline`/B include `core` with the RRD strategy set at the

--- a/deployments/kafka-cluster-min/topology.yml
+++ b/deployments/kafka-cluster-min/topology.yml
@@ -1,0 +1,20 @@
+name: kafka-cluster-min
+description: >-
+  Component test bed — KRaft cluster formation only. Not an A–H benchmark
+  topology: it verifies stub_kafka's derived node ids, quorum voters and
+  shared cluster ID on a footprint that fits the lab hypervisor (28 GB),
+  because Deployment A needs 132 GB and cannot run there.
+roles:
+  kafka:
+    count: 3
+    size: medium
+    # Mirrors Deployment A's shape so the bed exercises the same NIC layout.
+    subnets: [mgmt, kafka]
+    groups: [message_broker]
+  # Jump host only — see es-cluster-min for why every kvm deployment needs one.
+  monitoring:
+    count: 1
+    size: small
+    subnets: [mgmt, external]
+    public_ip: true
+    groups: []


### PR DESCRIPTION
The Kafka counterpart to `es-cluster-min`: 3 brokers plus a jump host, **28 GB**. Subnets mirror Deployment A's shape so the bed exercises the same NIC layout rather than a simplified one.

Used to verify [ansible-opennms#131](https://github.com/opennms-forge/ansible-opennms/pull/131) on real infrastructure.

## What it proved

Unlike the Elasticsearch bed, this one found **no defects** — the role was correct as written.

```
cluster ID (all three brokers):  FOtgUUP8S62AB9-3XUyaNw
node.id:                         1 / 2 / 3, each advertising its own hostname

ClusterId:      FOtgUUP8S62AB9-3XUyaNw
LeaderId:       3
CurrentVoters:  [{"id":1,"endpoints":["CONTROLLER://kafka-benchmark-01:9093"]},
                 {"id":2,"endpoints":["CONTROLLER://kafka-benchmark-02:9093"]},
                 {"id":3,"endpoints":["CONTROLLER://kafka-benchmark-03:9093"]}]
MaxFollowerLag: 0

Topic: clustercheck  PartitionCount: 3  ReplicationFactor: 3
  Partition: 0  Leader: 1  Replicas: 1,2,3  Isr: 1,2,3
  Partition: 1  Leader: 2  Replicas: 2,3,1  Isr: 2,3,1
  Partition: 2  Leader: 3  Replicas: 3,1,2  Isr: 3,1,2
```

The shared cluster ID is the point. The role previously minted one **per host**, which would have left three brokers formatted as three separate clusters, unable to join each other with `INCONSISTENT_CLUSTER_ID`.

It also confirms the conditional-derivation decision in #131 was necessary: this repo sets `advertised.listeners` from a single hardcoded `kafka_bootstrap_servers: "192.0.2.68:9092"`, so without derived values winning for a cluster, all three brokers would have advertised the same address.

## One thing worth recording

The first deploy failed on the jump host with `Unable to acquire the dpkg frontend lock` — `unattended-upgrades` still held it on the freshly booted VM and the task's 60s `DPkg::Lock::Timeout` expired. Transient and unrelated to Kafka; it succeeded on retry. But it aborts the whole deploy at the bootstrap step, and it will recur on any fresh lab. Worth its own issue if it bites again.

`make validate-deployments` passes; descriptor `3kf`. The collection change was exercised via the documented `type: dir` override, since reverted — `requirements.yml` still pins `583efae # v0.6.0`.