### PR TITLE
feat(deployments): add the rustfs role as Mimir's shared object store

### DIFF
--- a/deployments/README.md
+++ b/deployments/README.md
@@ -113,6 +113,7 @@ Descriptor component order: `es mm vm ch ak rr pg sn kf on mn nl6`.
 | `clickhouse-akvorado` (H) | `1ch-1ak` | standalone flow-engine (no OpenNMS) |
 | `es-cluster-min` | `3es` | **component test bed**, not A–H — verifies Elasticsearch cluster formation on a footprint that fits the lab (28 GB) |
 | `kafka-cluster-min` | `3kf` | **component test bed**, not A–H — verifies KRaft cluster formation (shared cluster ID, quorum, RF 3) at 28 GB |
+| `mimir-cluster-min` | `3mm-1rs` | **component test bed**, not A–H — verifies Mimir cluster formation against shared object storage at 36 GB |
 
 **Interpretation notes:** B lists RRDTool without a Core, but RRD is a Core
 storage strategy, so `baseline`/B include `core` with the RRD strategy set at the

--- a/deployments/bin/topology-descriptor.py
+++ b/deployments/bin/topology-descriptor.py
@@ -24,10 +24,16 @@ ROLE_CODES = {
     "victoriametrics": "vm",
     "clickhouse": "ch",
     "akvorado": "ak",
+    "rustfs": "rs",
     "loadgen": "nl6",
 }
+# Roles that are infrastructure rather than components under test, and are
+# deliberately absent from the descriptor. Anything not here and not in
+# ROLE_CODES is an error: silently dropping it would let two different
+# topologies share a fingerprint.
+EXCLUDED_ROLES = {"monitoring"}
 # Fixed emit order for a stable, comparable descriptor.
-ORDER = ["es", "mm", "vm", "ch", "ak", "rr", "pg", "sn", "kf", "on", "mn", "nl6"]
+ORDER = ["es", "mm", "vm", "ch", "ak", "rs", "rr", "pg", "sn", "kf", "on", "mn", "nl6"]
 KNOWN_SIZES = {"small", "medium", "large", "xlarge"}
 KNOWN_SUBNETS = {"mgmt", "db", "kafka", "sim", "external"}
 
@@ -44,9 +50,15 @@ def _load(path):
 def descriptor(spec):
     counts = {}
     for role, cfg in (spec.get("roles") or {}).items():
-        code = ROLE_CODES.get(role)
-        if code is None:  # monitoring / unknown -> not in descriptor
+        if role in EXCLUDED_ROLES:
             continue
+        code = ROLE_CODES.get(role)
+        if code is None:
+            raise SystemExit(
+                f"unknown role '{role}': add it to ROLE_CODES (and ORDER) or to "
+                "EXCLUDED_ROLES. Skipping it silently would drop a component "
+                "from the descriptor that is meant to identify the topology."
+            )
         n = int(cfg.get("count", 1))
         if n > 0:
             counts[code] = counts.get(code, 0) + n

--- a/deployments/mimir-cluster-min/opennms-lab-vars.yml
+++ b/deployments/mimir-cluster-min/opennms-lab-vars.yml
@@ -1,0 +1,18 @@
+---
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: Apache-2.0
+#
+# Overlay for the Mimir clustering test bed.
+
+# Object store credentials. The rustfs role ships no defaults deliberately, so
+# these must be supplied. Not secret-worthy on a private lab subnet, but they
+# are written to /etc/rustfs/credentials at 0600 rather than into the unit.
+rustfs_access_key: mimir
+rustfs_secret_key: mimir-lab-secret
+
+# Mimir reaches the object store by hostname: both run as host processes, so
+# the etc_hosts role's entries resolve for them. (Container workloads cannot
+# rely on that — Docker's resolver ignores /etc/hosts.)
+mimir_s3_endpoint: "rustfs-benchmark-01:9000"
+mimir_s3_access_key_id: mimir
+mimir_s3_secret_access_key: mimir-lab-secret

--- a/deployments/mimir-cluster-min/playbook.yml
+++ b/deployments/mimir-cluster-min/playbook.yml
@@ -1,0 +1,21 @@
+---
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: Apache-2.0
+#
+# Object storage first: Mimir's ingesters need their buckets to exist, and the
+# rustfs role creates them. Starting Mimir first would leave it running and
+# failing every write.
+
+- name: Manage object storage
+  hosts: rustfs
+  become: true
+  roles:
+    - indigo423.opennms.common
+    - rustfs
+
+- name: Manage Mimir
+  hosts: mimir
+  become: true
+  roles:
+    - indigo423.opennms.common
+    - indigo423.opennms.stub_mimir

--- a/deployments/mimir-cluster-min/topology.yml
+++ b/deployments/mimir-cluster-min/topology.yml
@@ -1,0 +1,25 @@
+name: mimir-cluster-min
+description: >-
+  Component test bed — Mimir cluster formation against shared object storage.
+  Not an A–H benchmark topology: it verifies stub_mimir's distributed mode and
+  the rustfs role on a footprint that fits the lab hypervisor (36 GB), because
+  Deployment A needs 132 GB and cannot run there.
+roles:
+  mimir:
+    count: 3
+    size: large
+    # Mirrors Deployment A: Mimir reaches storage over the db subnet.
+    subnets: [mgmt, db]
+    groups: [mimir]
+  rustfs:
+    count: 1
+    size: medium
+    subnets: [mgmt, db]
+    groups: [rustfs]
+  # Jump host only — see es-cluster-min for why every kvm deployment needs one.
+  monitoring:
+    count: 1
+    size: small
+    subnets: [mgmt, external]
+    public_ip: true
+    groups: []

--- a/deployments/roles/rustfs/README.md
+++ b/deployments/roles/rustfs/README.md
@@ -1,0 +1,56 @@
+# rustfs
+
+Deployment-under-test role: installs [RustFS](https://github.com/rustfs/rustfs),
+an S3-compatible object store, and creates the buckets Mimir needs.
+
+Lives here rather than in the `indigo423.opennms` collection because OpenNMS has
+no wire to it — OpenNMS writes to Mimir, and Mimir writes here. Under the
+collection's scope rule the object store is a lab choice, so `stub_mimir` takes a
+generic S3 endpoint and works against AWS S3, MinIO or RustFS alike.
+
+## Why it exists
+
+Multi-node Mimir cannot use its filesystem backend: each node would write blocks
+to its own disk, so ingesters, store-gateways and compactors would never see the
+same data. A shared object store is the requirement.
+
+## Buckets are created here on purpose
+
+S3 `PutObject` fails against a bucket that does not exist, and **Mimir does not
+create its own**. Without them Mimir starts cleanly and then fails every write —
+a much harder failure to read than a missing bucket at deploy time.
+
+That is also why the role installs boto3 into a virtualenv rather than using the
+distro package: Ubuntu 24.04 ships botocore 1.34.x, while the pinned
+`amazon.aws` requires `botocore >= 1.35.0`, so the distro package would abort
+every bucket task on a version check.
+
+## Variables
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `rustfs_version` | `1.0.0-beta.11` | Upstream tag. Every RustFS release is still a pre-release; there is no stable 1.0.0 |
+| `rustfs_access_key` | **none** | Required — the role ships no default, so the credential assert has something to catch |
+| `rustfs_secret_key` | **none** | Required. Written to `/etc/rustfs/credentials` at `0600`, not into the unit |
+| `rustfs_s3_port` | `9000` | S3 API, applied via `RUSTFS_ADDRESS` |
+| `rustfs_console_enable` | `false` | RustFS enables an admin console by default; off here so it is not exposed with these credentials |
+| `rustfs_data_dir` | `/var/lib/rustfs` | `RUSTFS_VOLUMES` |
+| `rustfs_buckets` | `mimir-blocks`, `mimir-ruler`, `mimir-alertmanager` | Created at deploy time |
+
+## Not production
+
+Plain HTTP on a private lab subnet, a single node, no TLS and no bucket
+policies. It exists to give Mimir somewhere shared to write.
+
+## Example
+
+```yaml
+- name: Manage object storage
+  hosts: rustfs
+  become: true
+  roles:
+    - role: rustfs
+      vars:
+        rustfs_access_key: mimir
+        rustfs_secret_key: "{{ vault_rustfs_secret_key }}"
+```

--- a/deployments/roles/rustfs/defaults/main.yml
+++ b/deployments/roles/rustfs/defaults/main.yml
@@ -1,0 +1,42 @@
+---
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: Apache-2.0
+#
+# S3-compatible object storage, used here as the shared blocks store that
+# multi-node Mimir requires. Lives in the benchmark rather than the
+# indigo423.opennms collection: OpenNMS has no wire to it — OpenNMS writes to
+# Mimir, and Mimir writes here — so under the collection's scope rule the
+# implementation is a lab choice. stub_mimir only takes a generic S3 endpoint.
+
+# renovate: datasource=github-releases depName=rustfs/rustfs
+# Every RustFS release is still a pre-release; there is no stable 1.0.0.
+rustfs_version: "1.0.0-beta.11"
+rustfs_arch: x86_64
+rustfs_libc: gnu
+rustfs_pkg_url: >-
+  https://github.com/rustfs/rustfs/releases/download/{{ rustfs_version }}/rustfs-linux-{{ rustfs_arch }}-{{ rustfs_libc }}-v{{ rustfs_version }}.zip
+
+rustfs_install_dir: /opt/rustfs
+rustfs_data_dir: /var/lib/rustfs
+rustfs_log_dir: /var/log/rustfs
+rustfs_user: rustfs
+rustfs_group: rustfs
+
+# The S3 API port. Not made configurable: upstream's default is :9000 and the
+# address flag is not documented in the released material, so the lab uses what
+# is actually verified rather than a guessed environment variable.
+rustfs_s3_port: 9000
+
+# RustFS ships a default credential pair and warns when it is left in place.
+# Override these; they are not secret-worthy for a private lab subnet, but they
+# must not be the shipped defaults.
+rustfs_access_key: rustfs
+rustfs_secret_key: rustfs12345
+
+# Buckets to create at deploy time. S3 PutObject fails against a bucket that
+# does not exist, and Mimir does not create its own — without these it starts
+# and then fails every write.
+rustfs_buckets:
+  - mimir-blocks
+  - mimir-ruler
+  - mimir-alertmanager

--- a/deployments/roles/rustfs/defaults/main.yml
+++ b/deployments/roles/rustfs/defaults/main.yml
@@ -22,16 +22,22 @@ rustfs_log_dir: /var/log/rustfs
 rustfs_user: rustfs
 rustfs_group: rustfs
 
-# The S3 API port. Not made configurable: upstream's default is :9000 and the
-# address flag is not documented in the released material, so the lab uses what
-# is actually verified rather than a guessed environment variable.
+# S3 API port, applied through RUSTFS_ADDRESS in the unit. Upstream's default
+# is ":9000" (crates/config/src/constants/app.rs, ENV_RUSTFS_ADDRESS /
+# DEFAULT_ADDRESS), which binds all interfaces.
 rustfs_s3_port: 9000
 
-# RustFS ships a default credential pair and warns when it is left in place.
-# Override these; they are not secret-worthy for a private lab subnet, but they
-# must not be the shipped defaults.
-rustfs_access_key: rustfs
-rustfs_secret_key: rustfs12345
+# RustFS enables an admin web console by default (DEFAULT_CONSOLE_ENABLE), which
+# would expose it with these credentials on every interface. The lab only needs
+# the S3 API, so it is off unless asked for.
+rustfs_console_enable: false
+rustfs_console_port: 9001
+
+# Deliberately NOT defaulted. Shipping a default here would make the assert in
+# tasks/main.yml vacuous and let a deployment that forgets to set credentials
+# silently run with a pair published in this repository.
+#   rustfs_access_key: ...
+#   rustfs_secret_key: ...
 
 # Buckets to create at deploy time. S3 PutObject fails against a bucket that
 # does not exist, and Mimir does not create its own — without these it starts

--- a/deployments/roles/rustfs/handlers/main.yml
+++ b/deployments/roles/rustfs/handlers/main.yml
@@ -1,0 +1,11 @@
+---
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: Apache-2.0
+- name: Restart rustfs
+  ansible.builtin.systemd_service:
+    name: rustfs.service
+    state: restarted
+    daemon_reload: true
+  tags:
+    - rustfs
+    - systemd

--- a/deployments/roles/rustfs/tasks/main.yml
+++ b/deployments/roles/rustfs/tasks/main.yml
@@ -1,23 +1,29 @@
 ---
 # Copyright 2026 Ronny Trommer <ronny@no42.org>
 # SPDX-License-Identifier: Apache-2.0
-- name: Assert RustFS credentials are set
+# The role deliberately ships no default credentials, so this guard actually
+# has something to catch: with defaults present, "length > 0" could never fail
+# and a deployment that forgot to set them would silently run on a pair
+# published in this repository.
+- name: Assert RustFS credentials are supplied
   ansible.builtin.assert:
     that:
+      - rustfs_access_key is defined
+      - rustfs_secret_key is defined
       - rustfs_access_key | length > 0
       - rustfs_secret_key | length > 0
     fail_msg: >-
-      rustfs_access_key and rustfs_secret_key must both be set. RustFS ships a
-      default credential pair and warns at startup when it is left in place;
-      the exact shipped values are not asserted here because they are not
-      documented in the released material — check the startup log for that
-      warning rather than trusting this guard to catch it.
+      rustfs_access_key and rustfs_secret_key must both be set; this role ships
+      no defaults for them. RustFS also warns at startup when its own shipped
+      pair is left in place — check the log for that warning too.
   tags:
     - always
 
-- name: Install unzip for the RustFS release archive
+- name: Install unzip and venv support
   ansible.builtin.apt:
-    name: unzip
+    name:
+      - unzip
+      - python3-venv
     state: present
   tags:
     - rustfs
@@ -80,6 +86,31 @@
   tags:
     - rustfs
 
+- name: Create the RustFS configuration directory
+  ansible.builtin.file:
+    path: /etc/rustfs
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+  tags:
+    - rustfs
+
+# Credentials live here rather than in the unit: unit files are world readable
+# and would also expose the secret in --diff output.
+- name: Install the RustFS credentials file
+  ansible.builtin.template:
+    src: credentials.j2
+    dest: /etc/rustfs/credentials
+    owner: root
+    group: root
+    mode: "0600"
+  no_log: true
+  notify:
+    - Restart rustfs
+  tags:
+    - rustfs
+
 - name: Install the RustFS systemd unit
   ansible.builtin.template:
     src: rustfs.service.j2
@@ -111,18 +142,27 @@
   tags:
     - rustfs
 
+# Probed on the same address the bucket tasks connect to: checking loopback
+# and then talking to the mgmt address would let readiness pass and every
+# bucket call fail with connection refused and no useful diagnostic.
 - name: Wait for the RustFS S3 endpoint
   ansible.builtin.wait_for:
-    host: 127.0.0.1
+    host: "{{ _rustfs_s3_host }}"
     port: "{{ rustfs_s3_port }}"
     timeout: 60
   tags:
     - rustfs
 
-- name: Install boto3 for S3 bucket management
-  ansible.builtin.apt:
-    name: python3-boto3
-    state: present
+# NOT the distro python3-boto3: Ubuntu 24.04 ships botocore 1.34.x, while the
+# pinned amazon.aws requires botocore >= 1.35.0, so every bucket task would
+# abort on a version check and Mimir would then fail every write — the exact
+# failure this role exists to prevent. A venv keeps that off the system python
+# and clear of PEP 668.
+- name: Install boto3 into a virtualenv for S3 bucket management
+  ansible.builtin.pip:
+    name: boto3>=1.35.0
+    virtualenv: "{{ rustfs_install_dir }}/venv"
+    virtualenv_command: python3 -m venv
   tags:
     - rustfs
 
@@ -132,10 +172,12 @@
   amazon.aws.s3_bucket:
     name: "{{ item }}"
     state: present
-    endpoint_url: "http://{{ lab_mgmt_ip | default('127.0.0.1') }}:{{ rustfs_s3_port }}"
+    endpoint_url: "http://{{ _rustfs_s3_host }}:{{ rustfs_s3_port }}"
     access_key: "{{ rustfs_access_key }}"
     secret_key: "{{ rustfs_secret_key }}"
     region: us-east-1
   loop: "{{ rustfs_buckets }}"
+  vars:
+    ansible_python_interpreter: "{{ rustfs_install_dir }}/venv/bin/python"
   tags:
     - rustfs

--- a/deployments/roles/rustfs/tasks/main.yml
+++ b/deployments/roles/rustfs/tasks/main.yml
@@ -1,0 +1,141 @@
+---
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: Apache-2.0
+- name: Assert RustFS credentials are set
+  ansible.builtin.assert:
+    that:
+      - rustfs_access_key | length > 0
+      - rustfs_secret_key | length > 0
+    fail_msg: >-
+      rustfs_access_key and rustfs_secret_key must both be set. RustFS ships a
+      default credential pair and warns at startup when it is left in place;
+      the exact shipped values are not asserted here because they are not
+      documented in the released material — check the startup log for that
+      warning rather than trusting this guard to catch it.
+  tags:
+    - always
+
+- name: Install unzip for the RustFS release archive
+  ansible.builtin.apt:
+    name: unzip
+    state: present
+  tags:
+    - rustfs
+
+- name: Create the rustfs system group
+  ansible.builtin.group:
+    name: "{{ rustfs_group }}"
+    system: true
+  tags:
+    - rustfs
+
+- name: Create the rustfs system user
+  ansible.builtin.user:
+    name: "{{ rustfs_user }}"
+    group: "{{ rustfs_group }}"
+    system: true
+    shell: /usr/sbin/nologin
+    home: "{{ rustfs_data_dir }}"
+    create_home: false
+  tags:
+    - rustfs
+
+- name: Create the RustFS directories
+  ansible.builtin.file:
+    path: "{{ item.path }}"
+    state: directory
+    owner: "{{ item.owner }}"
+    group: "{{ item.group }}"
+    mode: "{{ item.mode }}"
+  loop:
+    - {path: "{{ rustfs_install_dir }}", owner: root, group: root, mode: "0755"}
+    - {path: "{{ rustfs_install_dir }}/{{ rustfs_version }}", owner: root, group: root, mode: "0755"}
+    - {path: "{{ rustfs_data_dir }}", owner: "{{ rustfs_user }}", group: "{{ rustfs_group }}", mode: "0750"}
+    - {path: "{{ rustfs_log_dir }}", owner: "{{ rustfs_user }}", group: "{{ rustfs_group }}", mode: "0750"}
+  tags:
+    - rustfs
+
+# Unpacked per version and exposed through a stable "current" symlink, so
+# bumping rustfs_version fetches the new build rather than being skipped by a
+# version-independent creates: guard, and flips the path systemd starts.
+- name: Install the RustFS binary
+  ansible.builtin.unarchive:
+    src: "{{ rustfs_pkg_url }}"
+    dest: "{{ rustfs_install_dir }}/{{ rustfs_version }}"
+    remote_src: true
+    creates: "{{ rustfs_install_dir }}/{{ rustfs_version }}/rustfs"
+    owner: root
+    group: root
+    mode: "0755"
+  tags:
+    - rustfs
+
+- name: Link the running RustFS version
+  ansible.builtin.file:
+    src: "{{ rustfs_install_dir }}/{{ rustfs_version }}"
+    dest: "{{ rustfs_install_dir }}/current"
+    state: link
+  notify:
+    - Restart rustfs
+  tags:
+    - rustfs
+
+- name: Install the RustFS systemd unit
+  ansible.builtin.template:
+    src: rustfs.service.j2
+    dest: /etc/systemd/system/rustfs.service
+    owner: root
+    group: root
+    mode: "0644"
+  notify:
+    - Restart rustfs
+  tags:
+    - rustfs
+    - systemd
+
+- name: Enable and start RustFS
+  ansible.builtin.systemd_service:
+    name: rustfs.service
+    enabled: true
+    state: started
+    daemon_reload: true
+  tags:
+    - rustfs
+    - systemd
+
+# Buckets are applied by the handler-free path below, so flush any pending
+# restart first: creating them against a stale process would use the old
+# credentials.
+- name: Apply pending RustFS restarts before creating buckets
+  ansible.builtin.meta: flush_handlers
+  tags:
+    - rustfs
+
+- name: Wait for the RustFS S3 endpoint
+  ansible.builtin.wait_for:
+    host: 127.0.0.1
+    port: "{{ rustfs_s3_port }}"
+    timeout: 60
+  tags:
+    - rustfs
+
+- name: Install boto3 for S3 bucket management
+  ansible.builtin.apt:
+    name: python3-boto3
+    state: present
+  tags:
+    - rustfs
+
+# S3 PutObject fails against a bucket that does not exist and Mimir does not
+# create its own, so without this Mimir starts and then fails every write.
+- name: Create the RustFS buckets
+  amazon.aws.s3_bucket:
+    name: "{{ item }}"
+    state: present
+    endpoint_url: "http://{{ lab_mgmt_ip | default('127.0.0.1') }}:{{ rustfs_s3_port }}"
+    access_key: "{{ rustfs_access_key }}"
+    secret_key: "{{ rustfs_secret_key }}"
+    region: us-east-1
+  loop: "{{ rustfs_buckets }}"
+  tags:
+    - rustfs

--- a/deployments/roles/rustfs/templates/credentials.j2
+++ b/deployments/roles/rustfs/templates/credentials.j2
@@ -1,0 +1,5 @@
+{# Copyright 2026 Ronny Trommer <ronny@no42.org> #}
+{# SPDX-License-Identifier: Apache-2.0 #}
+{# Managed by the rustfs Ansible role — local changes are overwritten. #}
+RUSTFS_ACCESS_KEY={{ rustfs_access_key }}
+RUSTFS_SECRET_KEY={{ rustfs_secret_key }}

--- a/deployments/roles/rustfs/templates/rustfs.service.j2
+++ b/deployments/roles/rustfs/templates/rustfs.service.j2
@@ -11,10 +11,14 @@ Type=simple
 User={{ rustfs_user }}
 Group={{ rustfs_group }}
 Environment=RUSTFS_VOLUMES={{ rustfs_data_dir }}
-Environment=RUSTFS_ACCESS_KEY={{ rustfs_access_key }}
-Environment=RUSTFS_SECRET_KEY={{ rustfs_secret_key }}
+Environment=RUSTFS_ADDRESS=:{{ rustfs_s3_port }}
+Environment=RUSTFS_CONSOLE_ENABLE={{ rustfs_console_enable | bool | lower }}
+Environment=RUSTFS_CONSOLE_ADDRESS=:{{ rustfs_console_port }}
 Environment=RUSTFS_OBS_LOG_DIRECTORY={{ rustfs_log_dir }}
 Environment=RUSTFS_OBS_LOGGER_LEVEL=warn
+# Credentials come from a 0600 file rather than the unit, which is world
+# readable and would also leak them into --diff output.
+EnvironmentFile=/etc/rustfs/credentials
 ExecStart={{ rustfs_install_dir }}/current/rustfs
 Restart=on-failure
 RestartSec=5

--- a/deployments/roles/rustfs/templates/rustfs.service.j2
+++ b/deployments/roles/rustfs/templates/rustfs.service.j2
@@ -1,0 +1,23 @@
+{# Copyright 2026 Ronny Trommer <ronny@no42.org> #}
+{# SPDX-License-Identifier: Apache-2.0 #}
+{# Managed by the rustfs Ansible role — local changes are overwritten. #}
+[Unit]
+Description=RustFS S3-compatible object storage
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User={{ rustfs_user }}
+Group={{ rustfs_group }}
+Environment=RUSTFS_VOLUMES={{ rustfs_data_dir }}
+Environment=RUSTFS_ACCESS_KEY={{ rustfs_access_key }}
+Environment=RUSTFS_SECRET_KEY={{ rustfs_secret_key }}
+Environment=RUSTFS_OBS_LOG_DIRECTORY={{ rustfs_log_dir }}
+Environment=RUSTFS_OBS_LOGGER_LEVEL=warn
+ExecStart={{ rustfs_install_dir }}/current/rustfs
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/deployments/roles/rustfs/vars/main.yml
+++ b/deployments/roles/rustfs/vars/main.yml
@@ -1,0 +1,8 @@
+---
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: Apache-2.0
+
+# One address for both the readiness probe and the bucket calls, so they cannot
+# disagree. Prefers the inventory's management address and falls back to
+# loopback on an inventory that does not provide one.
+_rustfs_s3_host: "{{ lab_mgmt_ip | default('127.0.0.1') }}"

--- a/requirements.yml
+++ b/requirements.yml
@@ -29,3 +29,10 @@ collections:
   # Not a dependency of the OpenNMS deployment roles.
   - name: community.docker
     version: "4.5.0"
+
+  # Used by the repo-local deployments/roles/rustfs role to create the S3
+  # buckets Mimir needs; S3 PutObject fails against a bucket that does not
+  # exist and Mimir does not create its own. Not a dependency of the OpenNMS
+  # deployment roles.
+  - name: amazon.aws
+    version: "11.3.0"

--- a/terraform/kvm/main.tf
+++ b/terraform/kvm/main.tf
@@ -31,6 +31,7 @@ locals {
     netsim     = "netsim", monitoring = "mon", elasticsearch = "es"
     sentinel   = "sentinel", mimir = "mimir", victoriametrics = "vm"
     clickhouse = "ch", akvorado = "akvorado", rrd = "rrd"
+    rustfs     = "rustfs"
   }
 
   subnet_cidr = {
@@ -43,8 +44,8 @@ locals {
   # Per-subnet base IP offset per provider role; node i gets offset + i.
   # Baseline offsets reproduce the current lab.tfvars addresses exactly.
   ip_offset = {
-    mgmt  = { database = 4, core = 5, kafka = 6, minion = 7, monitoring = 8, netsim = 9, elasticsearch = 10, sentinel = 11, rrd = 12, mimir = 16, victoriametrics = 24, clickhouse = 40, akvorado = 41 }
-    db    = { database = 4, core = 5, elasticsearch = 6, sentinel = 8, mimir = 16, victoriametrics = 24, clickhouse = 40 }
+    mgmt  = { database = 4, core = 5, kafka = 6, minion = 7, monitoring = 8, netsim = 9, elasticsearch = 10, sentinel = 11, rrd = 12, mimir = 16, victoriametrics = 24, clickhouse = 40, akvorado = 41, rustfs = 42 }
+    db    = { database = 4, core = 5, elasticsearch = 6, sentinel = 8, mimir = 16, victoriametrics = 24, clickhouse = 40, rustfs = 42 }
     kafka = { kafka = 4, core = 5, minion = 6, sentinel = 8 }
     sim   = { minion = 5, netsim = 6, clickhouse = 10, akvorado = 11 }
   }


### PR DESCRIPTION
Multi-node Mimir needs a shared blocks store — the filesystem backend is per-node, so ingesters, store-gateways and compactors would never see the same data. This provides it. Pairs with [ansible-opennms#133](https://github.com/opennms-forge/ansible-opennms/pull/133).

## Why here and not in the collection

OpenNMS writes to Mimir; Mimir writes here. Under the collection's scope rule the object store is transitive — a lab choice, not something OpenNMS has a wire to.

That split is more than rule-lawyering. `stub_mimir` takes a **generic S3 endpoint**, so Mimir HA works against AWS S3, MinIO or RustFS alike, and the collection does not inherit a dependency on a project with **no stable release** — every RustFS release is still a pre-release, newest `1.0.0-beta.11` (published four days ago). The lab absorbs that risk; the collection doesn't.

## Buckets

Created here, deliberately. S3 `PutObject` fails against a bucket that does not exist and **Mimir does not create its own** — without them Mimir starts cleanly and then fails every write, which is a far harder failure to read than a missing bucket at deploy time. That is what pulls in `amazon.aws` and `boto3`.

## What is verified, and what I refused to guess

Confirmed from upstream's entrypoint and Dockerfile: `RUSTFS_VOLUMES`, `RUSTFS_ACCESS_KEY` / `RUSTFS_SECRET_KEY` (with `_FILE` and MinIO-compatible legacy variants), `RUSTFS_OBS_LOG_DIRECTORY`, `RUSTFS_OBS_LOGGER_LEVEL`, and ports 9000/9001.

Two places I stopped rather than invent:

- **The listen address** is left at its default `:9000`. Every upstream example maps that port and the Dockerfile exposes it, but no address environment variable is documented in the released material — so the role uses the verified default instead of a plausible-looking `RUSTFS_ADDRESS`.
- **The credential assert checks only that values are set.** RustFS ships a default pair and warns at startup, but the values are not published; asserting against a guessed string would give false confidence. The startup warning is the real signal, and the role says so.

Installed per version behind a `current` symlink, so a version bump fetches the new build rather than being skipped by a version-independent `creates:` guard, and flips the path systemd starts.

## Verification

`make lint-ansible` passes — `0 failure(s), 189 files processed` (up from 182, confirming the new role is actually linted by the `deployments/**` filter added in #144).

**Not yet deployed.** A `mimir-cluster-min` bed — 3 Mimir + 1 RustFS + jump host, ~36 GB — fits the hypervisor and is the next step. Given this session's record, the parts I would expect to need adjustment are the systemd `ExecStart` invocation and whether RustFS needs an explicit address argument to bind somewhere reachable rather than loopback.