### PR TITLE
ci: gate every change and harden the lint workflows

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -1,19 +1,15 @@
 ---
 name: Ansible Lint
 
+# No `paths:` filters: they let a PR touching only unlisted files merge with no
+# checks at all, and a filtered-out workflow reports nothing — which would leave
+# a required status check pending forever once main is protected. The job is
+# cheap enough that linting everything beats reasoning about the filter list.
 on:
   pull_request:
-    paths:
-      - "bootstrap/**"
-      - "deployments/**"
-      - "experiments/**"
-      - "opennms-playbook.yml"
-      - "opennms-lab-vars.yml"
-      - "requirements.yml"
-      - ".ansible-lint"
-      # Owns roles_path, so it governs whether roles resolve at all.
-      - "ansible.cfg"
-      - "Makefile"
+  push:
+    branches:
+      - main
 
 # CI invokes the `make lint-ansible` target, never ansible-lint directly, so local
 # and CI stay in sync.

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -11,14 +11,31 @@ on:
     branches:
       - main
 
+# The repo-level default workflow token is read-only today; declaring it here
+# keeps that true even if the setting drifts. Nothing in this workflow writes.
+permissions:
+  contents: read
+
+# A superseded lint run tells us nothing — cancel it and keep the queue short.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 # CI invokes the `make lint-ansible` target, never ansible-lint directly, so local
 # and CI stay in sync.
 jobs:
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    # Pinned rather than ubuntu-latest so GitHub's image migrations don't move
+    # under the build on their own schedule.
+    runs-on: ubuntu-24.04
+    # Collection installs dominate the runtime; 15m is generous headroom, and a
+    # real hang now fails in minutes instead of burning the 6h default.
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:

--- a/.github/workflows/terraform-lint.yml
+++ b/.github/workflows/terraform-lint.yml
@@ -1,11 +1,13 @@
 ---
 name: Terraform Lint
 
+# No `paths:` filters — see the note in ansible-lint.yml: a filtered-out workflow
+# reports nothing, which leaves a required status check pending forever.
 on:
   pull_request:
-    paths:
-      - "terraform/**"
-      - "Makefile"
+  push:
+    branches:
+      - main
 
 # CI invokes Makefile targets, never terraform directly, so local and CI stay in sync.
 jobs:

--- a/.github/workflows/terraform-lint.yml
+++ b/.github/workflows/terraform-lint.yml
@@ -9,13 +9,28 @@ on:
     branches:
       - main
 
+# The repo-level default workflow token is read-only today; declaring it here
+# keeps that true even if the setting drifts. Nothing in this workflow writes.
+permissions:
+  contents: read
+
+# A superseded lint run tells us nothing — cancel it and keep the queue short.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 # CI invokes Makefile targets, never terraform directly, so local and CI stay in sync.
+# Every job pins runs-on to a concrete image rather than ubuntu-latest, so
+# GitHub's image migrations don't move under the build on their own schedule.
 jobs:
   fmt:
     name: Format Check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
 
       - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e  # v4.0.1
         with:
@@ -26,9 +41,12 @@ jobs:
 
   validate-azure:
     name: Validate (Azure)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
 
       - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e  # v4.0.1
         with:
@@ -39,9 +57,12 @@ jobs:
 
   validate-kvm:
     name: Validate (KVM)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
 
       - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e  # v4.0.1
         with:
@@ -54,9 +75,12 @@ jobs:
 
   validate-proxmox:
     name: Validate (Proxmox)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
 
       - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e  # v4.0.1
         with:
@@ -67,9 +91,12 @@ jobs:
 
   validate-vmware:
     name: Validate (VMware)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
 
       - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e  # v4.0.1
         with:
@@ -80,9 +107,12 @@ jobs:
 
   tflint:
     name: TFLint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
 
       - uses: terraform-linters/setup-tflint@6e1e0642c0289bd619021bf6b34e3c08ed1e005a  # v6.3.0
         with:


### PR DESCRIPTION
Phase 1 of the maintainer audit. Two commits, reviewable independently.

## 1. `ci: lint every pull request and every push to main`

Both workflows were `pull_request`-only *with* `paths:` filters, so a PR touching only `deploy.sh`, `deployments/bin/*.py`, `docs/` or `.github/` merged with **zero** checks, and `main` itself was never verified after a merge.

Filters are not just a coverage hole — a filtered-out workflow reports no status at all, so a required status check would sit pending forever once branch protection lands. Dropped them and added `push: branches: [main]`.

The tradeoff is that a docs-only PR now runs all seven jobs. For this repo that is a few minutes of runner time and it removes an entire class of "which paths did I forget" bugs.

## 2. `ci: harden the lint workflows`

| Change | Why |
|---|---|
| `permissions: contents: read` top-level | Repo default is already read-only, but that setting is invisible from the workflow and can drift |
| `concurrency` + `cancel-in-progress` | A superseded lint run tells us nothing |
| `timeout-minutes` on all 7 jobs | The 6h default is not a timeout |
| `runs-on: ubuntu-24.04` | Image migrations happen on our schedule, not GitHub's |
| `persist-credentials: false` on all 7 checkouts | No step pushes with the token |

No change to what is linted or how — every job still shells out to a `make` target.

## Verification

- `actionlint .github/workflows/*.yml` → clean
- Both hygiene greps (unpinned actions / missing full-semver comment) → empty
- 7 checkouts, 7 `persist-credentials: false`
- This PR is itself the test of commit 1: it touches only `.github/**`, which the old filters excluded, so under the previous config it would have merged with no checks at all.

## Follow-up

Blocks the next step: enabling branch protection on `main` with these checks required.

Closes #152