### PR TITLE
ci: lint shell, Python, YAML and deployment specs

### DIFF
--- a/.github/workflows/code-lint.yml
+++ b/.github/workflows/code-lint.yml
@@ -1,0 +1,96 @@
+---
+name: Code Lint
+
+# No `paths:` filters — see the note in ansible-lint.yml: a filtered-out workflow
+# reports nothing, which leaves a required status check pending forever.
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+# The repo-level default workflow token is read-only today; declaring it here
+# keeps that true even if the setting drifts. Nothing in this workflow writes.
+permissions:
+  contents: read
+
+# A superseded lint run tells us nothing — cancel it and keep the queue short.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# CI invokes Makefile targets, never the linters directly, so local and CI stay
+# in sync. Every job pins runs-on to a concrete image rather than ubuntu-latest,
+# so GitHub's image migrations don't move under the build on their own schedule.
+#
+# Tool versions are pinned to what the findings were triaged against; a linter
+# minor bump can introduce new rules and should land as its own reviewed change.
+jobs:
+  shell:
+    name: Shell
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+
+      # shellcheck ships with the runner image, so its version moves when the
+      # image does. Printed here so a drift-induced failure is obvious from the
+      # log rather than a mystery.
+      - name: Show shellcheck version
+        run: shellcheck --version
+
+      - name: make lint-shell
+        run: make lint-shell
+
+  python:
+    name: Python
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Install ruff
+        run: python3 -m pip install ruff==0.16.0
+
+      - name: make lint-python
+        run: make lint-python
+
+  yaml:
+    name: YAML
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Install yamllint
+        run: python3 -m pip install yamllint==1.38.0
+
+      - name: make lint-yaml
+        run: make lint-yaml
+
+  deployment-specs:
+    name: Deployment Specs
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+
+      # topology-descriptor.py is pure stdlib, so the runner's python3 is enough.
+      - name: make validate-deployments
+        run: make validate-deployments

--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,9 @@ ansible-inventory.yml
 # Repo-local Ansible Vault master key — minted by init_secrets, NEVER commit
 vault_pass.secret
 
+# === Python / lint tooling ===
+
+__pycache__/
+*.py[cod]
+.ruff_cache/
+

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,31 @@
+---
+# yamllint configuration.
+#
+# ansible-lint already embeds a yamllint pass over Ansible content. This config
+# governs the standalone `make lint-yaml` run, whose value is the YAML that
+# ansible-lint never looks at: deployments/*/topology.yml, .github/workflows/
+# and the experiment compose files.
+
+extends: default
+
+ignore: |
+  # ansible-vault ciphertext — not YAML, and never decrypted in CI.
+  group_vars/opennms_stack/vault.yml
+  # Provider plugin caches; gitignored, but keep a direct `yamllint .` honest.
+  **/.terraform/
+
+rules:
+  # Ansible vars carry JVM option strings and URLs that cannot be wrapped
+  # without changing the value. What is worth enforcing in this repo is
+  # structural — duplicate keys, indentation, document markers — not width.
+  line-length: disable
+
+  # The deployment topology specs write flow mappings spaced, e.g.
+  # { cores: 4, memory: 8 }. Allow one space; still reject two or more.
+  braces:
+    min-spaces-inside: 0
+    max-spaces-inside: 1
+
+  # `on:` in a GitHub Actions workflow is a YAML 1.1 boolean, not truthy misuse.
+  truthy:
+    allowed-values: ["true", "false", "on"]

--- a/Makefile
+++ b/Makefile
@@ -109,8 +109,24 @@ tflint-%:
 lint-ansible: ## Run ansible-lint (config in .ansible-lint)
 	ansible-lint
 
+# The file lists come from `git ls-files`, so the linters see exactly what is
+# tracked: no provider caches under .terraform/, no untracked scratch files, and
+# a new script is picked up the moment it is added rather than when someone
+# remembers to extend a glob here.
+.PHONY: lint-shell
+lint-shell: ## Run shellcheck on every tracked shell script
+	shellcheck $$(git ls-files '*.sh')
+
+.PHONY: lint-python
+lint-python: ## Run ruff on every tracked Python script (config in ruff.toml)
+	ruff check $$(git ls-files '*.py')
+
+.PHONY: lint-yaml
+lint-yaml: ## Run yamllint on every tracked YAML file (config in .yamllint)
+	yamllint $$(git ls-files '*.yml' '*.yaml')
+
 .PHONY: lint
-lint: fmt validate tflint lint-ansible ## Run all lint checks
+lint: fmt validate tflint lint-ansible lint-shell lint-python lint-yaml validate-deployments ## Run all lint checks
 
 # ── utility ─────────────────────────────────────────────────────────────────────
 

--- a/deployments/baseline/topology.yml
+++ b/deployments/baseline/topology.yml
@@ -1,3 +1,4 @@
+---
 name: baseline
 description: >-
   The current single-node lab (reference topology). One instance of each

--- a/deployments/bin/topology-descriptor.py
+++ b/deployments/bin/topology-descriptor.py
@@ -8,8 +8,8 @@ Usage:
     topology-descriptor.py <path/to/topology.yml>
     topology-descriptor.py --validate <path/to/topology.yml>   # exit non-zero on schema errors
 """
-import sys
 import re
+import sys
 
 # role -> descriptor code. monitoring is infra and intentionally excluded.
 ROLE_CODES = {

--- a/deployments/clickhouse-akvorado/topology.yml
+++ b/deployments/clickhouse-akvorado/topology.yml
@@ -1,3 +1,4 @@
+---
 name: clickhouse-akvorado
 description: >-
   Deployment H — standalone flow-engine comparison: 1 ClickHouse, 1 Akvorado.

--- a/deployments/es-cluster-min/topology.yml
+++ b/deployments/es-cluster-min/topology.yml
@@ -1,3 +1,4 @@
+---
 name: es-cluster-min
 description: >-
   Component test bed — Elasticsearch cluster formation only. Not an A–H

--- a/deployments/es-nostore/topology.yml
+++ b/deployments/es-nostore/topology.yml
@@ -1,3 +1,4 @@
+---
 name: es-nostore
 description: >-
   Deployment D — Elasticsearch for flows, no metrics TSDB persistence, 1

--- a/deployments/kafka-cluster-min/topology.yml
+++ b/deployments/kafka-cluster-min/topology.yml
@@ -1,3 +1,4 @@
+---
 name: kafka-cluster-min
 description: >-
   Component test bed — KRaft cluster formation only. Not an A–H benchmark

--- a/deployments/mimir-cluster-min/topology.yml
+++ b/deployments/mimir-cluster-min/topology.yml
@@ -1,3 +1,4 @@
+---
 name: mimir-cluster-min
 description: >-
   Component test bed — Mimir cluster formation against shared object storage.

--- a/deployments/mimir-ha-min/topology.yml
+++ b/deployments/mimir-ha-min/topology.yml
@@ -1,3 +1,4 @@
+---
 name: mimir-ha-min
 description: >-
   Shape test bed — Deployment A's wiring at sizes that fit the lab hypervisor.

--- a/deployments/mimir-ha/topology.yml
+++ b/deployments/mimir-ha/topology.yml
@@ -1,3 +1,4 @@
+---
 name: mimir-ha
 description: >-
   Deployment A — full HA stack: 3 Elasticsearch, 3 Mimir, 3 Sentinel, 3 Kafka,

--- a/deployments/mimir-single/topology.yml
+++ b/deployments/mimir-single/topology.yml
@@ -1,3 +1,4 @@
+---
 name: mimir-single
 description: Deployment G — single Mimir, 1 PostgreSQL, 1 Core.
 roles:

--- a/deployments/rrd-minimal/topology.yml
+++ b/deployments/rrd-minimal/topology.yml
@@ -1,3 +1,4 @@
+---
 name: rrd-minimal
 description: >-
   Deployment B — RRDTool storage on Core, minimal: 1 PostgreSQL, 1 Kafka,

--- a/deployments/vm-cluster-es/topology.yml
+++ b/deployments/vm-cluster-es/topology.yml
@@ -1,3 +1,4 @@
+---
 name: vm-cluster-es
 description: >-
   Deployment C — VictoriaMetrics cluster (3 nodes) for metrics + 1 Elasticsearch

--- a/deployments/vm-cluster-minion/topology.yml
+++ b/deployments/vm-cluster-minion/topology.yml
@@ -1,3 +1,4 @@
+---
 name: vm-cluster-minion
 description: >-
   Deployment E — VictoriaMetrics cluster (3 nodes), 1 PostgreSQL, 1 Core,

--- a/deployments/vm-single/topology.yml
+++ b/deployments/vm-single/topology.yml
@@ -1,3 +1,4 @@
+---
 name: vm-single
 description: Deployment F — single VictoriaMetrics, 1 PostgreSQL, 1 Core.
 roles:

--- a/experiments/inventory/generate_nodes.sh
+++ b/experiments/inventory/generate_nodes.sh
@@ -14,14 +14,14 @@ printf '<?xml version="1.0" encoding="UTF-8"?>
 # Outer loop for third octet (0-255)
 for third_octet in {36..39}; do
     # Inner loop for fourth octet (1-254 for first/last subnet, 0-255 for middle subnets)
-    if [ $third_octet -eq 0 ]; then
+    if [ "$third_octet" -eq 0 ]; then
         # First subnet: skip .0 (network address)
         start_fourth=1
     else
         start_fourth=0
     fi
 
-    if [ $third_octet -eq 39 ]; then
+    if [ "$third_octet" -eq 39 ]; then
         # Last subnet: skip .255 (broadcast address)
         end_fourth=254
     else

--- a/experiments/inventory/provisioning.sh
+++ b/experiments/inventory/provisioning.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
-OPENNMS_HOST=192.0.2.197
-OPENNMS_USER=admin
-OPENNMS_PASS=admin
-OPENNMS_PORT=8980
+OPENNMS_HOST="192.0.2.197"
+OPENNMS_USER="admin"
+OPENNMS_PASS="admin"
+OPENNMS_PORT="8980"
 BATCH="${1:-01}"
 
 #
@@ -10,25 +10,25 @@ BATCH="${1:-01}"
 #
 
 echo -n "Create Foreign Sources                             ... "
-curl -s -u ${OPENNMS_USER}:${OPENNMS_PASS} \
+curl -s -u "${OPENNMS_USER}:${OPENNMS_PASS}" \
      -X POST \
      -H "Content-Type: application/xml" \
      -H "Accept: application/xml" \
      -d "@1k-batch${BATCH}-fs.xml" \
-     http://${OPENNMS_HOST}:${OPENNMS_PORT}/opennms/rest/foreignSources
+     "http://${OPENNMS_HOST}:${OPENNMS_PORT}/opennms/rest/foreignSources"
 echo "DONE"
 
 echo -n "Create Requisition                                 ... "
-curl -s -u ${OPENNMS_USER}:${OPENNMS_PASS} \
+curl -s -u "${OPENNMS_USER}:${OPENNMS_PASS}" \
      -X POST \
      -H "Content-Type: application/xml" \
      -H "Accept: application/xml" \
-     -d @1k-batch${BATCH}.xml \
-     http://${OPENNMS_HOST}:${OPENNMS_PORT}/opennms/rest/requisitions
+     -d "@1k-batch${BATCH}.xml" \
+     "http://${OPENNMS_HOST}:${OPENNMS_PORT}/opennms/rest/requisitions"
 echo "DONE"
 
 echo -n "Import requisition for batch ${BATCH}                    ... "
-curl -s -u ${OPENNMS_USER}:${OPENNMS_PASS} \
+curl -s -u "${OPENNMS_USER}:${OPENNMS_PASS}" \
      -X PUT \
      "http://${OPENNMS_HOST}:${OPENNMS_PORT}/opennms/rest/requisitions/1022-nodes-batch-${BATCH}/import"
 echo "DONE"

--- a/experiments/nms-20027-painless-flows/bin/build-report.py
+++ b/experiments/nms-20027-painless-flows/bin/build-report.py
@@ -172,7 +172,8 @@ def main():
             "hypothesis": "Painless scripted_metric is competitive or faster on both dense and sparse shapes.",
             "independent_variable": "sut.config_delta",
             "baseline_variant": BASELINE,
-            "claim_class": "relative A/B (laptop-container scope: generator co-located; absolute numbers out of scope). "
+            "claim_class": "relative A/B (laptop-container scope: generator co-located; "
+                           "absolute numbers out of scope). "
                            f"Corpus: {corpus['doc_count']} flows (plan amended from 40M; ES-indexing-bound seed), "
                            "direction normalized unknown->ingress.",
             "date": "2026-07-22",

--- a/experiments/nms-20027-painless-flows/bin/build-sut.sh
+++ b/experiments/nms-20027-painless-flows/bin/build-sut.sh
@@ -41,7 +41,10 @@ if [ -n "$(git -C "$SRC_DIR" status --porcelain)" ]; then
 fi
 
 JAVA_VERSION="$(java -version 2>&1 | head -1)"
-MVN_VERSION="$( (cd "$SRC_DIR" && ./mvnw --version 2>/dev/null || mvn --version) | head -1)"
+# Braces group the wrapper/fallback pair so this reads as "cd, then try ./mvnw
+# else mvn" — the previous `cd && a || b` form let `mvn --version` run when the
+# cd itself failed, reporting a toolchain from the wrong directory.
+MVN_VERSION="$(cd "$SRC_DIR" && { ./mvnw --version 2>/dev/null || mvn --version; } | head -1)"
 echo "toolchain: $JAVA_VERSION / $MVN_VERSION"
 
 # --- 1.2 assembly tarball ----------------------------------------------------

--- a/experiments/nms-20027-painless-flows/bin/corpus-identity-html.py
+++ b/experiments/nms-20027-painless-flows/bin/corpus-identity-html.py
@@ -6,7 +6,7 @@
 # self-contained, human-readable HTML page in results/.
 import html
 import json
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 
 EXP = Path(__file__).resolve().parent.parent
@@ -17,8 +17,8 @@ summary = {}
 if report_path.is_file():
     summary = json.loads(report_path.read_text()).get("summary", {})
 
-t0 = datetime.fromtimestamp(ident["window_start_ms"] / 1000, tz=timezone.utc)
-t1 = datetime.fromtimestamp(ident["window_end_ms"] / 1000, tz=timezone.utc)
+t0 = datetime.fromtimestamp(ident["window_start_ms"] / 1000, tz=UTC)
+t1 = datetime.fromtimestamp(ident["window_end_ms"] / 1000, tz=UTC)
 dur = ident["window_end_ms"] - ident["window_start_ms"]
 sent = summary.get("sent")
 reconciled = sent == ident["doc_count"] if sent is not None else None

--- a/experiments/nms-20027-painless-flows/bin/diff-quality.py
+++ b/experiments/nms-20027-painless-flows/bin/diff-quality.py
@@ -30,7 +30,9 @@ def series_diff(qid):
     b, c = body(B, qid), body(C, qid)
     det_b = body(B, qid, 2) == body(B, qid, 3)
     det_c = body(C, qid, 2) == body(C, qid, 3)
-    keyfn = lambda col: json.dumps(col, sort_keys=True)
+    def keyfn(col):
+        return json.dumps(col, sort_keys=True)
+
     kb = {keyfn(col): i for i, col in enumerate(b["columns"])}
     kc = {keyfn(col): i for i, col in enumerate(c["columns"])}
     shared, only_b, only_c = sorted(kb.keys() & kc.keys()), kb.keys() - kc.keys(), kc.keys() - kb.keys()
@@ -44,7 +46,11 @@ def series_diff(qid):
         sb = sum(x for x in vb if x is not None)
         sc = sum(x for x in vc if x is not None)
         col_diffs = 0
-        for i, (x, y) in enumerate(zip(vb, vc)):
+        # strict=False keeps the existing truncate-to-shorter behaviour. The two
+        # series come from the same query against two variants and should be the
+        # same length; if they ever are not, the extra buckets are silently
+        # dropped rather than reported. Made explicit here, not changed.
+        for i, (x, y) in enumerate(zip(vb, vc, strict=False)):
             total_buckets += 1
             if x != y and not (x is None and y is None):
                 if x is None or y is None:
@@ -85,7 +91,7 @@ def totals_diff(qid):
     for app in sorted(rows_b.keys() & rows_c.keys()):
         vb, vc = rows_b[app], rows_c[app]
         deltas = [round((y - x) / x * 100, 4) if isinstance(x, (int, float)) and x else None
-                  for x, y in zip(vb, vc)]
+                  for x, y in zip(vb, vc, strict=False)]  # see note in series_diff
         per_app.append({"app": app, "plugin": vb, "painless": vc, "rel_delta_pct": deltas})
     return {
         "kind": "totals", "query": qid, "headers": b.get("headers"),

--- a/experiments/nms-20027-painless-flows/bin/seed-corpus.sh
+++ b/experiments/nms-20027-painless-flows/bin/seed-corpus.sh
@@ -120,7 +120,9 @@ fi
 # counts — only possible when flow-source-per-device=true gave each device its
 # own exporter identity; with shared-socket sourcing (cardinality 1) the
 # aggregate check above is the gate and this step is skipped.
-RECONCILE_BIN="${RECONCILE_BIN:-$(ls "$EXP_DIR"/build/nl6-reconcile-* 2>/dev/null | head -1 || true)}"
+# find + sort rather than ls: same alphabetical pick, but safe for paths with
+# spaces or newlines (SC2012).
+RECONCILE_BIN="${RECONCILE_BIN:-$(find "$EXP_DIR/build" -maxdepth 1 -name 'nl6-reconcile-*' 2>/dev/null | sort | head -1 || true)}"
 CARD="$(curl -sf "$ES_URL/netflow-*/_search" -H 'Content-Type: application/json' \
   -d '{"size":0,"aggs":{"card":{"cardinality":{"field":"host"}}}}' | jq -r '.aggregations.card.value')"
 if [ -n "$RECONCILE_BIN" ] && [ -x "$RECONCILE_BIN" ] && [ "$CARD" -ge "$DEVICES" ]; then

--- a/experiments/nms-20027-painless-flows/compose.yml
+++ b/experiments/nms-20027-painless-flows/compose.yml
@@ -5,7 +5,7 @@
 # Core + PostgreSQL + Elasticsearch + nl6 only — no Minion/Sentinel/Kafka.
 # Select the variant via VARIANT=variant-b-plugin | variant-c-painless.
 # Co-located layout: valid for relative A/B claims only (never absolute capacity).
-
+---
 services:
   database:
     image: postgres:15.13            # pinned; recorded as sut.db_version in the manifest
@@ -89,8 +89,9 @@ services:
       # verify collector routing from the nl6sim namespace at use.
       - "-flow-source-per-device=false"
       - "-flow-tick-interval"
-      - "1"    # 1s emission ticks: 5x smaller bursts, same rate — the receiver's
-               # UDP rcvbuf overflowed on the default 5s batch cycle at 1000 devices
+      # 1s emission ticks: 5x smaller bursts at the same rate — the receiver's
+      # UDP rcvbuf overflowed on the default 5s batch cycle at 1000 devices.
+      - "1"
       - "-fidelity"
     cap_add:
       - NET_ADMIN

--- a/render-diagrams.sh
+++ b/render-diagrams.sh
@@ -66,13 +66,21 @@ export vm_name_netsim        ; vm_name_netsim=$(       _extract_vm netsim)
 export vm_name_elasticsearch ; vm_name_elasticsearch=$(_extract_vm elasticsearch)
 
 # --- render -----------------------------------------------------------------
-VARS='${subnet_mgmt}${subnet_db}${subnet_kafka}${subnet_sim}'
-VARS+='${ip_monitoring}${ip_database}${ip_core}${ip_kafka}${ip_minion}${ip_netsim}${ip_elasticsearch}'
-VARS+='${ip_database_db}${ip_core_db}${ip_es_core}'
-VARS+='${ip_kafka_kafka}${ip_core_kafka}${ip_minion_kafka}'
-VARS+='${ip_minion_sim}${ip_netsim_sim}'
-VARS+='${vm_name_monitoring}${vm_name_database}${vm_name_core}${vm_name_kafka}'
-VARS+='${vm_name_minion}${vm_name_netsim}${vm_name_elasticsearch}'
+# envsubst's SHELL-FORMAT argument is a literal list of ${var} references naming
+# which variables to substitute — it must NOT expand here, so the single quotes
+# are deliberate and SC2016 is a false positive for this whole block.
+# The braces make one compound command, so the directive covers every append —
+# on a bare sequence it would only apply to the first line.
+# shellcheck disable=SC2016
+{
+  VARS='${subnet_mgmt}${subnet_db}${subnet_kafka}${subnet_sim}'
+  VARS+='${ip_monitoring}${ip_database}${ip_core}${ip_kafka}${ip_minion}${ip_netsim}${ip_elasticsearch}'
+  VARS+='${ip_database_db}${ip_core_db}${ip_es_core}'
+  VARS+='${ip_kafka_kafka}${ip_core_kafka}${ip_minion_kafka}'
+  VARS+='${ip_minion_sim}${ip_netsim_sim}'
+  VARS+='${vm_name_monitoring}${vm_name_database}${vm_name_core}${vm_name_kafka}'
+  VARS+='${vm_name_minion}${vm_name_netsim}${vm_name_elasticsearch}'
+}
 
 outdir="$REPO_ROOT/assets"
 mkdir -p "$outdir"

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,23 @@
+# Ruff configuration for the repo's helper scripts (deployments/bin,
+# experiments/*/bin).
+#
+# This file exists mainly to pin the ruleset. Ruff resolves configuration by
+# walking up from each file, so without a config inside the repo a contributor
+# with a global ~/.config/ruff/ruff.toml lints against a different rule set than
+# CI does — which is exactly the local/CI drift the Makefile front-door is meant
+# to prevent.
+#
+# py311 is the floor we support (Debian 12); runners and lab VMs ship 3.12.
+target-version = "py311"
+
+# These are report-generation scripts with wide f-strings and long literal URLs;
+# 88 would be churn for no readability gain.
+line-length = 120
+
+[lint]
+# E/F  pycodestyle + pyflakes — the default pair, real errors.
+# I    import sorting, so diffs stay small.
+# UP   pyupgrade — keeps the scripts on modern syntax as the floor moves.
+# B    bugbear — the mutable-default and zip-strict class of bugs.
+# SIM  flake8-simplify — cheap readability wins.
+select = ["E", "F", "I", "UP", "B", "SIM"]


### PR DESCRIPTION
Phase 2a of the maintainer audit. Five commits, each independently reviewable: three fix commits (one per language), then the make targets, then the workflow.

## What was unlinted

10 shell scripts, 4 Python scripts, and all YAML that `ansible-lint` does not scan. `make validate-deployments` already existed but nothing ever ran it.

## Findings and fixes

| | Findings | Notes |
|---|---|---|
| shellcheck | 14 (12 note, 2 warning, 0 error) | `deploy.sh` was already clean |
| ruff | 7 (5 auto-fixed) | |
| yamllint | 30 after config | 0 duplicate-key findings — the result worth checking |
| validate-deployments | passes | only needed wiring |

Two fixes are behaviour-relevant rather than cosmetic:

- **`build-sut.sh`** used `cd "$SRC_DIR" && ./mvnw --version || mvn --version`. That is not if-then-else: when the `cd` failed, `mvn --version` ran anyway and the manifest recorded a toolchain from the wrong directory. Now grouped in braces.
- **`provisioning.sh`** passed `-u ${USER}:${PASS}` unquoted to curl, which word-splits on any password containing whitespace.

## Config choices, driven by what is in the tree

- **`ruff.toml` exists mainly to pin the ruleset.** Ruff resolves config by walking up from each file, so with no config in the repo a contributor with a global `~/.config/ruff` config lints against a different rule set than CI. That is live today — the first ruff run here picked up an out-of-repo config and reported rules the defaults never select.
- **`line-length` disabled in yamllint.** Six lines exceed 120 chars and every one is a JVM option string or URL in an Ansible vars file that cannot be wrapped without changing the value.
- **`braces` allow one space inside** — the topology specs write `{ cores: 4 }`, and the repo prefers that form 10 occurrences to 4.
- **`vault.yml` ignored** — ansible-vault ciphertext, not YAML.

## Deliberately not changed

`diff-quality.py`'s two `zip()` calls got an explicit `strict=False`, preserving the current truncate-to-shorter behaviour rather than changing an analysis script's semantics in a lint commit. A length mismatch between the two variant series is therefore still dropped silently — worth a separate look.

## Verification

- `make lint-shell`, `make lint-python`, `make lint-yaml` all exit 0
- `actionlint` and `zizmor` clean on the new workflow, which also passes the yamllint config it introduces
- all 4 Python scripts byte-compile; all 13 tracked deployment specs still validate and emit **identical** descriptors
- `compose.yml` still parses (4 services)
- re-running `render-diagrams.sh` reproduces `assets/` **byte-identically**

## Follow-up

The four new checks (`Shell`, `Python`, `YAML`, `Deployment Specs`) need adding to the branch-protection required list once this is merged.

Closes #154