### PR TITLE
ci: self-lint the workflows with actionlint and zizmor

### DIFF
--- a/.github/workflows/code-lint.yml
+++ b/.github/workflows/code-lint.yml
@@ -82,6 +82,32 @@ jobs:
       - name: make lint-yaml
         run: make lint-yaml
 
+  actions:
+    name: Actions
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
+        with:
+          python-version: "3.12"
+
+      # Installed from the module proxy at a pinned tag, so the checksum
+      # database verifies the download; Go ships with the runner image.
+      - name: Install actionlint
+        run: |
+          go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
+          echo "$HOME/go/bin" >> "$GITHUB_PATH"
+
+      - name: Install zizmor
+        run: python3 -m pip install zizmor==1.28.0
+
+      - name: make lint-actions
+        run: make lint-actions
+
   deployment-specs:
     name: Deployment Specs
     runs-on: ubuntu-24.04

--- a/Makefile
+++ b/Makefile
@@ -125,8 +125,20 @@ lint-python: ## Run ruff on every tracked Python script (config in ruff.toml)
 lint-yaml: ## Run yamllint on every tracked YAML file (config in .yamllint)
 	yamllint $$(git ls-files '*.yml' '*.yaml')
 
+# actionlint covers workflow schema, expression typing and the shell inside
+# `run:`; zizmor covers the Actions-specific security surface (template
+# injection, credential persistence, over-broad permissions). Together they
+# enforce the hardening rules — SHA pins, least privilege, timeouts — that were
+# applied by hand and would otherwise decay to whoever remembers them.
+# Local install: brew install actionlint && pipx install zizmor
+# --no-online-audits keeps the run deterministic and token-free.
+.PHONY: lint-actions
+lint-actions: ## Lint GitHub Actions workflows (actionlint + zizmor)
+	actionlint
+	zizmor --no-online-audits .github/workflows/
+
 .PHONY: lint
-lint: fmt validate tflint lint-ansible lint-shell lint-python lint-yaml validate-deployments ## Run all lint checks
+lint: fmt validate tflint lint-ansible lint-shell lint-python lint-yaml lint-actions validate-deployments ## Run all lint checks
 
 # ── utility ─────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Phase 2b of the maintainer audit. Pure gate addition — **zero findings** against `main`.

## Why

Phase 1 hardened the workflows by hand: SHA pins with full-semver comments, least-privilege `permissions:`, concurrency groups, per-job timeouts, pinned runners, `persist-credentials: false`. Nothing enforced any of it. The next workflow anyone adds could reintroduce every one of those gaps and CI would be happy.

## What

`make lint-actions` running **actionlint** (workflow schema, expression typing, shell inside `run:`) and **zizmor** (Actions security audits), folded into `make lint`, plus an `Actions` job in the Code Lint workflow.

actionlint installs from the Go module proxy at a pinned tag, so the checksum database verifies the download. zizmor is pip-pinned like the other tools. `--no-online-audits` keeps the run deterministic and token-free.

## Verification — that the gate actually bites

A gate that reports nothing is worthless, so I reintroduced each class of regression and confirmed it fails:

| Regression | Caught as |
|---|---|
| `actions/setup-python@v7` instead of a SHA | `error[unpinned-uses]` |
| checkout without `persist-credentials: false` | `warning[artipacked]` (medium) |
| `run: if [ "$X" = x ; then …` | `SC1072` via actionlint's embedded shellcheck |

And that the exit code propagates, which is what makes it a gate rather than a report: **zizmor exits 13** on a medium-severity finding, so `make lint-actions` fails on warnings, not only on errors. Restored, the target exits 0.

## Follow-up

`Actions` needs adding to the branch-protection required list once this is merged. That completes Phase 2.

Closes #156