### PR TITLE
ci: pin actionlint by commit and correct the Actions job's claims

### DIFF
--- a/.github/workflows/code-lint.yml
+++ b/.github/workflows/code-lint.yml
@@ -95,12 +95,19 @@ jobs:
         with:
           python-version: "3.12"
 
-      # Installed from the module proxy at a pinned tag, so the checksum
-      # database verifies the download; Go ships with the runner image.
+      # Pinned to the commit behind v1.7.12, matching how the actions above are
+      # pinned. The module proxy's checksum database already made the tag
+      # content-immutable — a retag upstream fails verification rather than
+      # installing different code — so this is for consistency and
+      # reviewability, not because the tag was unsafe.
+      #
+      # What is NOT pinned is the toolchain: the runner's Go bootstraps
+      # whichever go1.25.x satisfies actionlint's go directive and downloads it
+      # at build time. The source is fixed; the compiler that builds it is not.
       - name: Install actionlint
         run: |
-          go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
-          echo "$HOME/go/bin" >> "$GITHUB_PATH"
+          go install github.com/rhysd/actionlint/cmd/actionlint@914e7df21a07ef503a81201c76d2b11c789d3fca  # v1.7.12
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
       - name: Install zizmor
         run: python3 -m pip install zizmor==1.28.0

--- a/Makefile
+++ b/Makefile
@@ -130,8 +130,17 @@ lint-yaml: ## Run yamllint on every tracked YAML file (config in .yamllint)
 # injection, credential persistence, over-broad permissions). Together they
 # enforce the hardening rules — SHA pins, least privilege, timeouts — that were
 # applied by hand and would otherwise decay to whoever remembers them.
-# Local install: brew install actionlint && pipx install zizmor
-# --no-online-audits keeps the run deterministic and token-free.
+# Install the same versions CI pins, or `make lint-actions` means one thing on
+# your machine and another in CI — the drift ruff.toml exists to prevent:
+#   go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
+#   pipx install zizmor==1.28.0
+#
+# --no-online-audits keeps the run deterministic and token-free, at a cost worth
+# stating: it disables impostor-commit (is this SHA a real commit of that repo?)
+# and ref-version-mismatch (does the `# vX.Y.Z` comment match the pinned SHA?).
+# Both are exactly the conventions this repo pins by hand, so offline mode will
+# not catch a forged or mislabelled pin. Enabling them needs a GH token on a
+# required check — tracked separately.
 .PHONY: lint-actions
 lint-actions: ## Lint GitHub Actions workflows (actionlint + zizmor)
 	actionlint


### PR DESCRIPTION
Follow-up from a code review of PR #157. Applies 4 of the 5 findings; the 5th is deliberately left for a decision.

## Applied

**F2 — actionlint pinned by a mutable tag.** It installed `@v1.7.12` while the two `uses:` lines directly above pin 40-char SHAs. Now `@914e7df21a07ef503a81201c76d2b11c789d3fca  # v1.7.12`.

Stated honestly rather than oversold: Go's checksum database already made `@v1.7.12` content-immutable — a retag upstream fails verification rather than silently installing different code. This is a **consistency and reviewability** fix.

**F3 — the comment misdescribed the step.** It claimed "Go ships with the runner image". The CI log:

```
go: github.com/rhysd/actionlint@v1.7.12 requires go >= 1.25.0; switching to go1.25.12
go: downloading go1.25.12 (linux/amd64)
```

The shipped Go bootstraps a different, network-fetched toolchain. Source pinned, compiler floating — the comment now says that instead of implying the step is hermetic.

**F4 — local-install hint was unpinned** (`brew install actionlint && pipx install zizmor`) while CI pinned 1.7.12 / 1.28.0, so `make lint-actions` meant different things locally and in CI. Exactly the drift `ruff.toml` was added to prevent.

**F5 — `go env GOPATH`** instead of assuming `$HOME/go`.

## Documented, not changed

`--no-online-audits` disables zizmor's `impostor-commit` and `ref-version-mismatch` audits — the two that verify precisely what this repo pins by hand. Proven:

```
offline:  actions/checkout@0000000000000000000000000000000000000000  # v4.2.2
          → "No findings to report. Good job!"
online:   → error[impostor-commit] (high)
          → warning[ref-version-mismatch] (medium) — "points to commit 11bd71901bbe"
```

I verified the repo's current pins **are** genuine (online run on the real workflows: clean), so nothing is broken today. The Makefile comment now records the coverage cost.

**Left open on purpose:** enabling online audits would put an API-dependent check on a required gate. With `github.token` the limit is 5000/hr against 3 files so flake risk is low but not zero; the alternative is a scheduled online run. That is a judgment call, not a patch.

## Verification

- `make lint-actions` exits 0; `yamllint` clean
- the `run:` block executed verbatim under `bash -e`: installs **actionlint v1.7.12**, `go env GOPATH` resolves
- note the gate cannot catch F2 itself — `unpinned-uses` covers `uses:`, not `go install` inside `run:`. That is why it took a review.

Closes #158