### PR TITLE
fix(traefik): resolve remote back ends from the inventory

### DIFF
--- a/bootstrap/roles/traefik/tasks/main.yml
+++ b/bootstrap/roles/traefik/tasks/main.yml
@@ -33,9 +33,12 @@
     - Restart traefik
   tags: ["traefik"]
 
-- name: Copy Traefik dynamic routes
-  ansible.builtin.copy:
-    src: traefik/dynamic/routes.yml
+# Templated, not copied: the OpenNMS / Kafka UI / nl6 back ends live on other
+# VMs whose addresses are provider-dependent, and most deployments do not run
+# all three roles. See the template header.
+- name: Deploy Traefik dynamic routes
+  ansible.builtin.template:
+    src: traefik/dynamic/routes.yml.j2
     dest: "{{ traefik_config_dir }}/dynamic/routes.yml"
     mode: "0644"
   notify:

--- a/bootstrap/roles/traefik/templates/traefik/dynamic/routes.yml.j2
+++ b/bootstrap/roles/traefik/templates/traefik/dynamic/routes.yml.j2
@@ -15,23 +15,23 @@
    already is that address — hence the default(). The distinction matters because
    ansible_host for the jump host is its *external* address.
 
-   Most deployments do not run all three roles (5 of 13 have no core at all), so
-   each router and service is emitted only when its group is populated. The
-   previous static file advertised all three unconditionally, which left routes
-   pointing at addresses that belonged to a different role or to no host at all.
+   Many deployments do not run all three roles — several specs have no core at
+   all, and net_sim is rarer still — so each router and service is emitted only
+   when its group is populated. The previous static file advertised all three
+   unconditionally, which left routes pointing at addresses that belonged to a
+   different role or to no host at all.
+
+   Every member of a group becomes a load-balancer server, not just the first:
+   the mimir-ha shape beds run three Kafka UI nodes, and taking groups[...][0]
+   would silently route to one and ignore the rest.
+
+   default(..., true) rather than plain default(): the second argument makes it
+   fire on an empty value as well as an undefined one, otherwise an empty
+   lab_mgmt_ip renders as "http://:8980" — valid YAML, silently dead.
 #}
 {% set have_core = groups['core'] is defined and groups['core'] | length > 0 %}
 {% set have_kafka_ui = groups['kafka_ui'] is defined and groups['kafka_ui'] | length > 0 %}
 {% set have_net_sim = groups['net_sim'] is defined and groups['net_sim'] | length > 0 %}
-{% if have_core %}
-{% set core_ip = hostvars[groups['core'][0]].lab_mgmt_ip | default(hostvars[groups['core'][0]].ansible_host) %}
-{% endif %}
-{% if have_kafka_ui %}
-{% set kafka_ui_ip = hostvars[groups['kafka_ui'][0]].lab_mgmt_ip | default(hostvars[groups['kafka_ui'][0]].ansible_host) %}
-{% endif %}
-{% if have_net_sim %}
-{% set net_sim_ip = hostvars[groups['net_sim'][0]].lab_mgmt_ip | default(hostvars[groups['net_sim'][0]].ansible_host) %}
-{% endif %}
 http:
   routers:
     app-starter:
@@ -136,14 +136,18 @@ http:
     opennms:
       loadBalancer:
         servers:
-          - url: "http://{{ core_ip }}:8980"
+{% for host in groups['core'] %}
+          - url: "http://{{ hostvars[host].lab_mgmt_ip | default(hostvars[host].ansible_host, true) }}:8980"
+{% endfor %}
 {% endif %}
 {% if have_kafka_ui %}
 
     kafka:
       loadBalancer:
         servers:
-          - url: "http://{{ kafka_ui_ip }}:8080"
+{% for host in groups['kafka_ui'] %}
+          - url: "http://{{ hostvars[host].lab_mgmt_ip | default(hostvars[host].ansible_host, true) }}:8080"
+{% endfor %}
 {% endif %}
 
     pgadmin:
@@ -160,7 +164,9 @@ http:
     opensim:
       loadBalancer:
         servers:
-          - url: "http://{{ net_sim_ip }}:8080"
+{% for host in groups['net_sim'] %}
+          - url: "http://{{ hostvars[host].lab_mgmt_ip | default(hostvars[host].ansible_host, true) }}:8080"
+{% endfor %}
 {% endif %}
 
     app-starter:

--- a/bootstrap/roles/traefik/templates/traefik/dynamic/routes.yml.j2
+++ b/bootstrap/roles/traefik/templates/traefik/dynamic/routes.yml.j2
@@ -1,4 +1,37 @@
 ---
+{# managed by the traefik role — edit the template, not the rendered file
+
+   Back ends split two ways:
+
+   * Services co-located on this monitoring VM reach the host through
+     host.docker.internal and are provider-independent.
+   * OpenNMS, Kafka UI and nl6 live on other VMs. Their addresses differ per
+     provider (kvm derives them from per-role blocks, azure reads fixed values
+     out of lab.tfvars — see #161), so they are resolved from the inventory
+     rather than written down here.
+
+   lab_mgmt_ip is emitted by the kvm topology inventory and is always the in-lab
+   management address. Azure/Proxmox/VMware do not set it, and there ansible_host
+   already is that address — hence the default(). The distinction matters because
+   ansible_host for the jump host is its *external* address.
+
+   Most deployments do not run all three roles (5 of 13 have no core at all), so
+   each router and service is emitted only when its group is populated. The
+   previous static file advertised all three unconditionally, which left routes
+   pointing at addresses that belonged to a different role or to no host at all.
+#}
+{% set have_core = groups['core'] is defined and groups['core'] | length > 0 %}
+{% set have_kafka_ui = groups['kafka_ui'] is defined and groups['kafka_ui'] | length > 0 %}
+{% set have_net_sim = groups['net_sim'] is defined and groups['net_sim'] | length > 0 %}
+{% if have_core %}
+{% set core_ip = hostvars[groups['core'][0]].lab_mgmt_ip | default(hostvars[groups['core'][0]].ansible_host) %}
+{% endif %}
+{% if have_kafka_ui %}
+{% set kafka_ui_ip = hostvars[groups['kafka_ui'][0]].lab_mgmt_ip | default(hostvars[groups['kafka_ui'][0]].ansible_host) %}
+{% endif %}
+{% if have_net_sim %}
+{% set net_sim_ip = hostvars[groups['net_sim'][0]].lab_mgmt_ip | default(hostvars[groups['net_sim'][0]].ansible_host) %}
+{% endif %}
 http:
   routers:
     app-starter:
@@ -25,18 +58,22 @@ http:
         - websecure
       service: jaeger
       tls: {}
+{% if have_core %}
     opennms:
       rule: "PathPrefix(`/opennms`)"
       entryPoints:
         - websecure
       service: opennms
       tls: {}
+{% endif %}
+{% if have_kafka_ui %}
     kafka:
       rule: "PathPrefix(`/kafka`)"
       entryPoints:
         - websecure
       service: kafka
       tls: {}
+{% endif %}
     pgadmin:
       rule: "PathPrefix(`/pgadmin`)"
       entryPoints:
@@ -51,6 +88,7 @@ http:
       middlewares:
         - kibana-strip
       tls: {}
+{% if have_net_sim %}
     opensim:
       rule: "PathPrefix(`/nl6`)"
       entryPoints:
@@ -65,15 +103,18 @@ http:
         - websecure
       service: opensim
       tls: {}
+{% endif %}
   middlewares:
     kibana-strip:
       stripPrefix:
         prefixes:
           - /kibana
+{% if have_net_sim %}
     opensim-strip:
       stripPrefix:
         prefixes:
           - /nl6
+{% endif %}
 
   services:
     grafana:
@@ -90,16 +131,20 @@ http:
       loadBalancer:
         servers:
           - url: "http://host.docker.internal:16686"
+{% if have_core %}
 
     opennms:
       loadBalancer:
         servers:
-          - url: "http://192.0.2.197:8980"
+          - url: "http://{{ core_ip }}:8980"
+{% endif %}
+{% if have_kafka_ui %}
 
     kafka:
       loadBalancer:
         servers:
-          - url: "http://192.0.2.198:8080"
+          - url: "http://{{ kafka_ui_ip }}:8080"
+{% endif %}
 
     pgadmin:
       loadBalancer:
@@ -110,11 +155,13 @@ http:
       loadBalancer:
         servers:
           - url: "http://host.docker.internal:5601"
+{% if have_net_sim %}
 
     opensim:
       loadBalancer:
         servers:
-          - url: "http://192.0.2.201:8080"
+          - url: "http://{{ net_sim_ip }}:8080"
+{% endif %}
 
     app-starter:
       loadBalancer:


### PR DESCRIPTION
Found while rewriting `CLAUDE.md`. This is the live half of #161.

## The bug

`bootstrap/` runs on every provider and is internally split down the middle:

| role | scheme it hardcodes | correct on |
|---|---|---|
| grafana, kafka_ui, kibana, nl6 | kvm | kvm only |
| **traefik** | **azure** | azure only |

Both run on the same monitoring VM in the same deployment, so **no provider had a fully working bootstrap**.

On kvm — the primary path, and what every `deployments/` spec targets — Traefik's three off-box routes resolved to addresses belonging to a different role, or to nothing at all:

| route | hardcoded | on kvm that is |
|---|---|---|
| `/opennms` | `192.0.2.197` | inside the **database** block — no host |
| `/kafka` | `192.0.2.198` | inside the **database** block — no host |
| `/nl6` | `192.0.2.201` | inside the **core** block — no host |

Three of the eight URLs the README advertises returned 502 on kvm.

## The fix

`routes.yml` becomes a template resolving those back ends from inventory groups. The group names (`core`, `kafka_ui`, `net_sim`) are identical across all four providers — azure's inventory template and the kvm topology specs use the same vocabulary — so one template is correct everywhere. Locally-hosted services keep `host.docker.internal` and are untouched.

Three details worth calling out:

- **`lab_mgmt_ip` is preferred over `ansible_host`.** The kvm topology inventory sets both, and for the jump host `ansible_host` is the *external* address. Azure/Proxmox/VMware do not set `lab_mgmt_ip`, and there `ansible_host` already is the management address — hence the `default()`, with the boolean second argument so it fires on an empty value too.
- **Every group member becomes a load-balancer server.** `mimir-ha` and `mimir-ha-min` both run `kafka_ui = 3`.
- **Routers and services are emitted only when their group is populated.** 4 of 13 deployments have no `core`, 7 have no `kafka_ui`, and 10 have no `net_sim`. The static file advertised all three unconditionally, so most topologies carried dead routes.

## Verification

Rendered against seven inventory shapes using Ansible's `trim_blocks` semantics:

| case | result |
|---|---|
| kvm baseline | `/opennms` → `192.0.2.200` ✅ was `.197` |
| azure baseline | `/opennms` → `192.0.2.197`, unchanged |
| `kafka_ui = 3` (mimir-ha-min) | 3 load-balancer servers |
| empty `lab_mgmt_ip` | falls back to `ansible_host`, no `http://:8980` |
| jump host | `lab_mgmt_ip` wins over the external `ansible_host` |
| empty groups / no groups | no remote routes emitted |

All parse as YAML with zero dangling router→service references and no empty-host URLs. `ansible-lint` passes the role at the **production** profile.

## Review history

Second commit applies three findings from a code review of the first: multi-node groups were dropping all but the first back end; `default()` missed a defined-but-empty `lab_mgmt_ip`; and the header comment carried two wrong counts (from `grep -c` matching `routes: { sim: net_sim }` as if it were a group). The counts above are yaml-parsed.

One finding deferred and recorded in `_bmad-output/implementation-artifacts/deferred-work.md`: `files/traefik/dynamic/tls.yml` is never copied by any task although `traefik.yml` watches that directory, so its TLS config has never applied. Pre-existing and unrelated to routing.

## Scope

This does **not** converge the two terraform address schemes — that stays open in #161, along with `opennms-lab-vars.yml` hardcoding kvm addresses globally and the README's direct-URL column.

Refs #161