### PR TITLE
docs: add the community health files

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,41 @@
+<!--
+Thanks for contributing. A few notes so review goes smoothly:
+
+  * Work starts from an issue — link it below with a closing keyword.
+  * Every commit needs `git commit -s` (DCO) and, if an AI agent helped,
+    an `Assisted-by: <Agent>:<model>` trailer. See CONTRIBUTING.md.
+  * Run `make lint` before pushing; CI runs the same targets.
+-->
+
+## What this changes
+
+<!-- One or two sentences on the change itself. -->
+
+## Why
+
+<!-- The problem being solved. If the issue already explains it, say "see the issue". -->
+
+Closes #
+
+## Verification
+
+<!--
+How do you know it works? Commands and their output beat assertions.
+For lab changes that cannot be verified without provisioning, say so
+explicitly and note what was checked instead.
+-->
+
+## Checklist
+
+- [ ] `make lint` passes locally
+- [ ] Commits are signed off (`git commit -s`) and follow Conventional Commits
+- [ ] AI-assisted commits carry an `Assisted-by:` trailer
+- [ ] New source files have an SPDX licence header
+- [ ] Docs updated if behaviour or commands changed
+
+## Anything reviewers should know
+
+<!--
+Deliberate trade-offs, things you decided not to do, follow-ups you are
+leaving for later. Say it here rather than letting a reviewer find it.
+-->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,133 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+ronny@no42.org.
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,98 @@
+# Contributing
+
+Thanks for helping improve the OpenNMS benchmark lab.
+
+This is an infrastructure-as-code lab for running reproducible OpenNMS Horizon
+benchmarks. It is not a product and not intended for production deployments —
+see [SECURITY.md](SECURITY.md).
+
+## Before you start
+
+Work starts from an issue. Open one describing the problem or the experiment you
+want to add, so the discussion happens before the code. Drive-by pull requests
+are harder to review and easy to duplicate.
+
+## Making a change
+
+`main` is protected. Every change goes through a pull request — no exceptions,
+regardless of size.
+
+```bash
+git switch -c <type>/<short-description>
+# ... make your change ...
+make lint          # everything CI runs
+git commit -s
+```
+
+Reference the issue in the pull request body with a closing keyword
+(`Closes #123`) so it resolves automatically on merge.
+
+## Commit messages
+
+[Conventional Commits](https://www.conventionalcommits.org/): `<type>[scope]: <description>`,
+where type is one of `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`,
+`chore`, `ci`, `build`, `revert`. Breaking changes append `!` or add a
+`BREAKING CHANGE:` footer.
+
+### Sign-off is required
+
+Every commit needs a `Signed-off-by` trailer, added by `git commit -s`. This
+certifies the [Developer Certificate of Origin](https://developercertificate.org/) —
+that you wrote the contribution or otherwise have the right to submit it under
+this repository's licence. A bot enforces it, and the `DCO` check blocks merges
+without it.
+
+The sign-off must be a human identity. Never sign off as an AI agent.
+
+### AI-assisted contributions
+
+AI assistance is welcome, and it should be visible. Commits produced with help
+from an AI agent carry an `Assisted-by:` trailer naming the agent and model,
+before the sign-off:
+
+```
+fix(traefik): resolve remote back ends from the inventory
+
+Assisted-by: ClaudeCode:claude-opus-5
+Signed-off-by: Your Name <you@example.com>
+```
+
+The human who signs off remains responsible for the change: for reviewing it,
+for its correctness, and for its licence compliance. "The AI wrote it" is not a
+defence for code you did not read.
+
+## Checks
+
+CI runs the same `make` targets you run locally — that is the point of the
+Makefile, so please do not invoke `terraform`, `ansible-playbook` or the linters
+directly in a workflow.
+
+```bash
+make lint            # fmt, validate, tflint, ansible, shell, python, yaml, actions, deployment specs
+make lint-shell      # or run one at a time
+make help            # every target
+```
+
+Pull requests must be green before merge. The required checks cover Terraform
+formatting and validation across all four providers, TFLint, ansible-lint,
+shellcheck, ruff, yamllint, actionlint + zizmor, the deployment specs, and DCO.
+
+## Conventions worth knowing
+
+- **GitHub Actions** are pinned to a full commit SHA with the exact version in a
+  trailing comment (`uses: actions/checkout@11bd719…  # v4.2.2`). Never a bare
+  tag. `zizmor` and `actionlint` enforce the surrounding rules.
+- **`indigo423.opennms`** is pinned by git SHA in `requirements.yml` for
+  benchmark reproducibility. Bumps are deliberate, reviewed pull requests, never
+  automatic.
+- **Deployment specs** live in `deployments/<slug>/topology.yml`; the directory
+  slug and the `name:` field must match. `make validate-deployments` checks it.
+- **New source files** need an SPDX licence header.
+
+`CLAUDE.md` documents the architecture and the gotchas an automated agent — or a
+new contributor — would otherwise get wrong. It is worth reading first.
+
+## Licence
+
+By contributing you agree that your contribution is licensed under the
+[Apache License 2.0](LICENSE), as the rest of the project is.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,62 @@
+# Security Policy
+
+## What this repository is
+
+An infrastructure-as-code lab for running reproducible OpenNMS Horizon
+benchmarks. It provisions disposable VMs, loads them with synthetic SNMP, flow
+and syslog traffic, and throws them away.
+
+**It is deliberately not hardened, and it must never be deployed into a
+production network or exposed to the internet.** By design the lab ships:
+
+- default credentials (`admin` / `admin` for the OpenNMS UI, Grafana and
+  pgAdmin) documented openly in the README
+- unauthenticated Prometheus, Jaeger, Kafka UI and nl6 endpoints
+- a self-signed TLS certificate generated at provisioning time
+- an open management network between all lab VMs, with host key checking
+  disabled for Ansible
+
+None of the above are vulnerabilities. They are the point: the lab trades
+security for reproducibility and fast teardown. Reporting them will get a
+pointer back to this section.
+
+## What to report
+
+Report anything that undermines the *tooling* in ways an operator would not
+expect, for example:
+
+- provisioning code that exposes a lab beyond its intended network boundary
+- a credential, key or token committed to the repository, or written somewhere
+  it outlives the lab
+- a supply-chain problem in the pinned dependencies — a forged action pin, a
+  compromised Ansible collection SHA, a malicious container image reference
+- a workflow that could be made to execute untrusted input with elevated
+  permissions
+
+## How to report
+
+Use GitHub's **private vulnerability reporting** — the *Report a vulnerability*
+button under this repository's **Security** tab. That opens a private advisory
+visible only to maintainers.
+
+Please do not open a public issue for something you believe is genuinely
+sensitive. For everything else, a normal issue is the right place.
+
+Expect an acknowledgement within about a week. This is a personal project
+maintained in spare time, so please calibrate expectations accordingly — there
+is no commercial support commitment behind it.
+
+## Vulnerabilities in OpenNMS itself
+
+This repository *deploys* OpenNMS Horizon; it is not the OpenNMS project. A
+vulnerability in Horizon, Minion, Sentinel or the OpenNMS codebase belongs to
+the OpenNMS project's own security process, not here — report it there so it
+reaches the people who can actually fix it.
+
+Report it here only if the problem is in how *this lab* configures or provisions
+those components.
+
+## Supported versions
+
+There are no releases. `main` is the only supported ref; fixes land there and
+nowhere else.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,42 @@
+# Support
+
+## Questions about this lab
+
+Open an issue in this repository. Questions are welcome as issues — there is no
+separate forum, and no Discussions board enabled.
+
+Before you do, it is worth checking:
+
+- [README.md](README.md) — network layout, per-provider host preparation, the
+  service URLs and their default credentials
+- [CLAUDE.md](CLAUDE.md) — architecture, the `make` entry points, and the
+  gotchas that catch people out
+- [docs/](docs/) — architecture, deployment and development guides
+- the project wiki — collected experiments and their results
+
+When reporting a problem, the two most useful things you can include are the
+**provider** (`azure`, `kvm`, `proxmox` or `vmware`) and the **deployment slug**
+(`make deployments` lists them). Lab addresses differ per provider, so a symptom
+is often only reproducible on one of them.
+
+## Questions about OpenNMS itself
+
+This repository deploys OpenNMS Horizon but is not the OpenNMS project. For
+questions about using, configuring or troubleshooting OpenNMS outside the
+context of this lab, the OpenNMS community channels are the right place — you
+will get better answers from people who work on it.
+
+## Security reports
+
+See [SECURITY.md](SECURITY.md). Do not open a public issue for anything you
+believe is genuinely sensitive.
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md). Work starts from an issue.
+
+## Expectations
+
+This is a personal project maintained in spare time under the Apache 2.0
+licence. There is no commercial support, no SLA and no guaranteed response
+time. That is not a brush-off — it is so you can plan around it.


### PR DESCRIPTION
Phase 3b of the maintainer audit, plus the paperwork half of Phase 4.

## Why

The DCO sign-off rule and the `Assisted-by:` AI-attribution policy existed **only in the maintainer's private global config**. A contributor had no way to learn either — yet the DCO bot rejects their commit if they miss it. That is the gap this closes.

## Files

| File | Notes |
|---|---|
| `CONTRIBUTING.md` | Issue-first workflow, protected-main PR flow, Conventional Commits, DCO sign-off (human identity, **never** an agent), the `Assisted-by:` trailer with the human signer still accountable for review and licence compliance, `make lint` to reproduce CI |
| `SECURITY.md` | What to report — and what not to |
| `SUPPORT.md` | Questions go to issues; asks for provider + deployment slug |
| `CODE_OF_CONDUCT.md` | Contributor Covenant 2.1 |
| `.github/pull_request_template.md` | `Closes #` prompt + verification section |

## SECURITY.md is deliberately blunt

This lab ships `admin`/`admin`, unauthenticated Prometheus/Jaeger/Kafka UI/nl6, a self-signed cert and `host_key_checking = False` — all by design, all documented in the README. Writing a policy that implies otherwise would invite a stream of reports about the lab being insecure *on purpose*.

So those are listed explicitly as **non-vulnerabilities**, and the file steers reports toward things that actually matter here: a committed credential, a forged action pin, a compromised collection SHA, a workflow executing untrusted input. Horizon CVEs are routed to the OpenNMS project rather than implying this repo triages them.

It also states plainly that there are no releases and `main` is the only supported ref, and sets a spare-time response expectation rather than an implied SLA.

## Relative links, deliberately

`opennms-forge/opennms-benchmark` turns out to be a **fork of this repository** (parent = `indigo423`), yet the README tells people to clone the fork and use *its* wiki. Hardcoding either org would be wrong when viewed from the other, so every internal link is relative and resolves correctly from whichever fork a reader is on.

That README discrepancy is worth settling separately — see the note below.

## Verification

- every relative link resolves to a real file (7 checked, 0 broken)
- each `SECURITY.md` claim checked against the tree: `host_key_checking = False` in `ansible.cfg`, the `openssl req -x509` task in the traefik role, the credentials table in `README.md`
- `make lint-yaml` and `make lint-actions` still clean

## Not in this PR

Repo settings (squash-only merges, `delete_branch_on_merge`, topics, labels, enabling private vulnerability reporting) are API changes, not files — applied separately.

**Open question for you:** the README points contributors at `opennms-forge/opennms-benchmark`, which is a stale fork (last pushed 21 July) of this repo. Either the README links need updating, or that fork is meant to be the public face and this is the dev repo. I did not want to pick a side silently.

Closes #165