### PR TITLE
chore(riptide-flow-capacity): add SPDX headers to the matrix scripts

### DIFF
--- a/experiments/riptide-flow-capacity/matrix.sh
+++ b/experiments/riptide-flow-capacity/matrix.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: Apache-2.0
+#
+# Three base/pr replicate pairs for the riptide#391 A/B, base first in each pair.
 set -uo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")" || exit 1
 OUT=ab-391-runs

--- a/experiments/riptide-flow-capacity/matrix2.sh
+++ b/experiments/riptide-flow-capacity/matrix2.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: Apache-2.0
+#
 # Counter-balanced pass: pr runs FIRST in each pair, so that any monotonic lab drift
 # now penalises the baseline instead of the variant. If pr still loses here, the effect
 # is real; if it wins, the first pass was measuring drift.


### PR DESCRIPTION
Follow-up to #169.

`matrix.sh` and `matrix2.sh` landed without the Apache-2.0 header every other script in `experiments/riptide-flow-capacity/` carries. Both were edited in #169 to fix shellcheck SC2164, so the per-file header convention applies to them.

Adds the header, plus a one-line purpose comment to `matrix.sh`, which had none. `matrix2.sh` already documented its counter-balanced design.

Scope note: this is the per-file convention only, not the repo-wide SPDX sweep tracked as Phase 3c in #167. 52 of 66 shell/Python/Terraform files still lack a header; that is a separate mechanical diff.

## Verification

`make lint-shell` and `make lint-terraform` pass. `make lint-python` could not run locally (`ruff` is not installed); no Python is touched here and CI covers it.