### PR TITLE
fix(terraform/kvm): derive the simulated-network next hop from the topology

### DIFF
--- a/deployments/README.md
+++ b/deployments/README.md
@@ -67,10 +67,10 @@ default; opt out by omitting the role or setting `count: 0`. Opting out means
 also removing any `routes: { sim: net_sim }` from the spec, since that named
 route resolves to the generator (see below).
 
-`loadgen` is capped at `count: 1`. A named route's next hop is a single address,
-so only one node can serve it, and nl6 starts every generator at the same
-`nl6_auto_start_ip` — a second generator would duplicate the first rather than
-extend it.
+Keep `loadgen` at `count: 1`. A named route's next hop is a single address, so
+only one node can serve it, and nl6 starts every generator at the same
+`nl6_auto_start_ip` — a second generator duplicates the first rather than
+extending it. Not currently enforced; see #173.
 
 ### Size classes (provider translates to concrete resources)
 
@@ -112,8 +112,11 @@ from a role inside the same spec, so the provider fails the plan unless that rol
 is present *and* attached to the subnet the route needs — `net_sim` requires a
 `loadgen` with a `sim` NIC. An **inline** `{ to, via }` deliberately points
 outside the topology and is not checked; use it when the next hop is a machine
-the spec does not provision. A route key naming a subnet the role is not
-attached to is also an error, since it would otherwise be silently dropped.
+the spec does not provision.
+
+Both checks are plan-time only. Nothing in CI renders a spec today, so a route
+mistake surfaces on the first `make deploy` rather than on the pull request —
+tracked in #173.
 
 A `lab` NIC needs the provider to know the bridge LAN: `subnet_lab` (CIDR, for
 the prefix and gateway) and `lab_nameservers` (a physical LAN, unlike the

--- a/deployments/README.md
+++ b/deployments/README.md
@@ -63,7 +63,14 @@ Each role maps to a stable 2–3 char code used in the canonical descriptor:
 
 `monitoring` is always-present infrastructure (Grafana/Prometheus/Jaeger) and is
 **excluded** from the descriptor. `loadgen` is the nl6 generator — included by
-default; opt out by omitting the role or setting `count: 0`.
+default; opt out by omitting the role or setting `count: 0`. Opting out means
+also removing any `routes: { sim: net_sim }` from the spec, since that named
+route resolves to the generator (see below).
+
+`loadgen` is capped at `count: 1`. A named route's next hop is a single address,
+so only one node can serve it, and nl6 starts every generator at the same
+`nl6_auto_start_ip` — a second generator would duplicate the first rather than
+extend it.
 
 ### Size classes (provider translates to concrete resources)
 
@@ -99,6 +106,14 @@ roles:
   minion:
     routes: { sim: net_sim }                             # …or a named shared route
 ```
+
+The two forms are validated differently. A **named** route resolves its next hop
+from a role inside the same spec, so the provider fails the plan unless that role
+is present *and* attached to the subnet the route needs — `net_sim` requires a
+`loadgen` with a `sim` NIC. An **inline** `{ to, via }` deliberately points
+outside the topology and is not checked; use it when the next hop is a machine
+the spec does not provision. A route key naming a subnet the role is not
+attached to is also an error, since it would otherwise be silently dropped.
 
 A `lab` NIC needs the provider to know the bridge LAN: `subnet_lab` (CIDR, for
 the prefix and gateway) and `lab_nameservers` (a physical LAN, unlike the

--- a/deployments/es-nostore/topology.yml
+++ b/deployments/es-nostore/topology.yml
@@ -27,8 +27,7 @@ roles:
   minion:
     count: 1
     size: small
-    subnets: [mgmt, kafka, sim]
-    routes: { sim: net_sim }
+    subnets: [mgmt, kafka]
     groups: [minion]
   monitoring:
     count: 1

--- a/deployments/rrd-minimal/topology.yml
+++ b/deployments/rrd-minimal/topology.yml
@@ -28,8 +28,7 @@ roles:
   minion:
     count: 1
     size: small
-    subnets: [mgmt, kafka, sim]
-    routes: { sim: net_sim }
+    subnets: [mgmt, kafka]
     groups: [minion]
   monitoring:
     count: 1

--- a/deployments/vm-cluster-minion/topology.yml
+++ b/deployments/vm-cluster-minion/topology.yml
@@ -27,8 +27,7 @@ roles:
   minion:
     count: 1
     size: small
-    subnets: [mgmt, kafka, sim]
-    routes: { sim: net_sim }
+    subnets: [mgmt, kafka]
     groups: [minion]
   monitoring:
     count: 1

--- a/terraform/kvm/main.tf
+++ b/terraform/kvm/main.tf
@@ -83,47 +83,108 @@ locals {
     }
   ]...)
 
-  # Provider roles the selected spec actually contains, used to validate that a
-  # named route has something to point at.
-  present_proles = distinct([for key, n in local.nodes : n.prole])
+  # ── address allocation ────────────────────────────────────────────────────
+  # The single source of truth for "what address does node N hold on subnet S".
+  # Keyed only by the subnets a node actually declares, so a lookup for a subnet
+  # the node is not attached to returns nothing rather than a plausible number.
+  # Both the rendered topology and the named-route next hops read this; two
+  # independent copies of the rule is exactly the drift that caused #171.
+  node_address = {
+    for key, n in local.nodes : key => {
+      for subnet in n.cfg.subnets :
+      subnet => try(n.cfg.addresses[subnet][n.index],
+      contains(["external", "lab"], subnet) ? null : cidrhost(local.subnet_cidr[subnet], local.ip_offset[n.prole] + n.index))
+    }
+  }
+
+  # Spec role -> provider role is many-to-one (loadgen -> netsim). Invert it so
+  # errors name the role the author actually writes in topology.yml.
+  spec_role_for = { for srole, prole in local.provider_role : prole => srole }
 
   # ── named routes ──────────────────────────────────────────────────────────
   # A named route's next hop is derived from the spec, never declared. The
   # previous hardcoded var.net_sim_gateway drifted the moment the allocation
-  # scheme changed: netsim moved to .152 while the constant stayed at .134, so
-  # the minion routed the whole simulated network at an address no node held,
-  # silently (#171). Deriving it means the two cannot disagree.
+  # scheme changed, leaving every minion routing the simulated network at an
+  # address no node held, silently (#171).
   #
-  # This resolves from local.nodes rather than local.topology, which would be a
-  # cycle — topology consumes named_routes. It mirrors topology's own address
-  # rule so a spec-pinned address still wins over the block offset.
-  netsim_sim_address = try([
-    for key, n in local.nodes :
-    try(n.cfg.addresses["sim"][n.index],
-    cidrhost(local.subnet_cidr["sim"], local.ip_offset[n.prole] + n.index))
-    if n.prole == "netsim"
-  ][0], null)
+  # Each entry declares the provider role and subnet its next hop comes from,
+  # so the address, the validation and the error message all derive from one
+  # place. Resolves via local.node_address rather than local.topology, which
+  # would be a cycle: topology consumes named_routes.
+  named_route_spec = {
+    net_sim = { to = var.net_sim_cidr, role = "netsim", subnet = "sim" }
+  }
+
+  # Node keys per provider role, sorted so selection is stable across plans.
+  nodes_by_prole = {
+    for prole in distinct([for key, n in local.nodes : n.prole]) :
+    prole => sort([for key, n in local.nodes : key if n.prole == prole])
+  }
 
   named_routes = {
-    net_sim = { to = var.net_sim_cidr, via = local.netsim_sim_address }
+    for name, r in local.named_route_spec :
+    name => {
+      to = r.to
+      # null when the role is absent, or present but not attached to the subnet
+      # the route needs. Both cases are caught by the preconditions below.
+      via = try(local.node_address[local.nodes_by_prole[r.role][0]][r.subnet], null)
+    }
   }
 
-  # Provider role each named route requires to be present in the spec.
-  named_route_requires = {
-    net_sim = "netsim"
-  }
-
-  # Named routes whose target role the spec does not contain. A named route
-  # points at a role inside the topology, so an absent target is always an
-  # error; an inline { to, via } deliberately points outside it and is exempt.
-  # A named route is a string, an inline route an object — hence tostring().
-  unsatisfied_named_routes = flatten([
+  # Every route a spec declares, classified. Kept as data so each failure mode
+  # gets its own message instead of collapsing into one misleading default.
+  declared_routes = flatten([
     for key, n in local.nodes : [
-      for subnet, r in try(n.cfg.routes, {}) :
-      "${key}.${subnet} route \"${r}\" needs role \"${lookup(local.named_route_requires, r, "?")}\""
-      if can(tostring(r)) && !contains(local.present_proles, lookup(local.named_route_requires, tostring(r), "?"))
+      # try() absorbs an absent `routes:` key; the null check absorbs a present
+      # but empty one (`routes:` with no mapping), which is legal YAML.
+      for subnet, r in(try(n.cfg.routes, null) == null ? {} : n.cfg.routes) : {
+        node   = key
+        srole  = lookup(local.spec_role_for, n.prole, n.prole)
+        subnet = subnet
+        value  = r
+        # An inline route is an object carrying its own next hop. A named route
+        # is a scalar naming an entry in named_route_spec. Anything else — a
+        # list, a null — is neither, and must not be silently forwarded.
+        kind = can(r.to) && can(r.via) ? "inline" : (r != null && can(tostring(r)) ? "named" : "invalid")
+        # Routes are only rendered for subnets the node is attached to.
+        attached = contains(n.cfg.subnets, subnet)
+      }
     ]
   ])
+
+  # Four distinct authoring errors, each with its own message.
+  route_errors = concat(
+    [
+      for r in local.declared_routes :
+      "${r.node}.${r.subnet}: route value is neither a named route nor an inline { to, via }"
+      if r.kind == "invalid"
+    ],
+    [
+      for r in local.declared_routes :
+      "${r.node}.${r.subnet}: unknown named route \"${tostring(r.value)}\" (known: ${join(", ", sort(keys(local.named_route_spec)))})"
+      if r.kind == "named" && !contains(keys(local.named_route_spec), tostring(r.value))
+    ],
+    [
+      for r in local.declared_routes :
+      "${r.node}.${r.subnet}: route \"${tostring(r.value)}\" needs a \"${lookup(local.spec_role_for, local.named_route_spec[tostring(r.value)].role, local.named_route_spec[tostring(r.value)].role)}\" role with a \"${local.named_route_spec[tostring(r.value)].subnet}\" NIC, which this deployment does not have"
+      if r.kind == "named" && contains(keys(local.named_route_spec), tostring(r.value)) && local.named_routes[tostring(r.value)].via == null
+    ],
+    [
+      for r in local.declared_routes :
+      "${r.node}.${r.subnet}: route declared on a subnet this role is not attached to (subnets: ${join(", ", r.attached ? [] : local.nodes[r.node].cfg.subnets)})"
+      if !r.attached
+    ],
+  )
+
+  # A named route's next hop is a single address, so exactly one node can serve
+  # it. The simulated network is one flat CIDR routed to one gateway, and nl6
+  # starts every generator at the same nl6_auto_start_ip, so a second generator
+  # would duplicate the first rather than extend it.
+  overprovisioned_route_roles = [
+    for name, r in local.named_route_spec :
+    "named route \"${name}\" resolves to role \"${lookup(local.spec_role_for, r.role, r.role)}\" but the spec declares ${length(local.nodes_by_prole[r.role])} of them"
+    if try(length(local.nodes_by_prole[r.role]), 0) > 1
+  ]
 
   topology = {
     for key, n in local.nodes :
@@ -139,8 +200,7 @@ locals {
           # 'lab' is the physical bridge (same libvirt network as external) with a
           # static, spec-supplied address — for VMs an off-hypervisor generator
           # must reach. Specs may also pin addresses on internal subnets.
-          address = try(n.cfg.addresses[subnet][n.index],
-          contains(["external", "lab"], subnet) ? null : cidrhost(local.subnet_cidr[subnet], local.ip_offset[n.prole] + n.index))
+          address     = local.node_address[key][subnet]
           prefix      = subnet == "external" ? null : (subnet == "lab" ? tonumber(split("/", var.subnet_lab)[1]) : 26)
           gateway     = subnet == "lab" ? cidrhost(var.subnet_lab, 1) : ((subnet == "mgmt" && !try(n.cfg.public_ip, false)) ? local.gateway_mgmt : null)
           nameservers = subnet == "lab" && length(var.lab_nameservers) > 0 ? var.lab_nameservers : null
@@ -149,8 +209,15 @@ locals {
           # lookup and falls through to itself. A conditional cannot express this:
           # both of its branches are type-checked, and for a named route the
           # inline branch is a bare string, which is not a route object.
-          routes = try(n.cfg.routes[subnet], null) == null ? [] : [
-            try(local.named_routes[n.cfg.routes[subnet]], n.cfg.routes[subnet])
+          #
+          # A named route with no resolvable next hop is dropped rather than
+          # rendered with via = null: the preconditions below already fail the
+          # plan, and a null here additionally breaks the shared cloud-init
+          # template with an error that names neither the spec nor the node.
+          routes = [
+            for r in(try(n.cfg.routes[subnet], null) == null ? [] : [
+              try(local.named_routes[n.cfg.routes[subnet]], n.cfg.routes[subnet])
+            ]) : r if try(r.via, null) != null
           ]
         }
       ]
@@ -273,18 +340,39 @@ resource "terraform_data" "address_uniqueness" {
   }
 }
 
-# Fails the plan if a spec declares a named route whose target role it does not
-# contain. es-nostore, rrd-minimal and vm-cluster-minion each carried a net_sim
-# route on their minion with no generator anywhere in the spec — copied from
-# baseline along with the rest of the block. That resolved to a plausible-looking
-# constant pointing at nobody, which is why it went unnoticed for months.
-resource "terraform_data" "named_route_targets" {
-  input = length(local.unsatisfied_named_routes)
+# Fails the plan if a spec declares a route that cannot be rendered. es-nostore,
+# rrd-minimal and vm-cluster-minion each carried a net_sim route on their minion
+# with no generator anywhere in the spec — copied from baseline along with the
+# rest of the block. That resolved to a plausible-looking constant pointing at
+# nobody, which is why it went unnoticed for months.
+#
+# Checking that the next hop resolves to an address a node actually holds, and
+# not merely that the role name appears, is the point: a generator declared
+# without the NIC the route needs reproduces the original bug exactly.
+resource "terraform_data" "route_targets" {
+  input = length(local.route_errors)
 
   lifecycle {
     precondition {
-      condition     = length(local.unsatisfied_named_routes) == 0
-      error_message = "Deployment \"${var.deployment}\" declares named routes whose target role is absent: ${join("; ", local.unsatisfied_named_routes)}. Add the role to the spec, or use an inline { to, via } route if the next hop is outside this topology."
+      condition     = length(local.route_errors) == 0
+      error_message = "Deployment \"${var.deployment}\" declares routes that cannot be rendered:\n  ${join("\n  ", local.route_errors)}\nUse an inline { to, via } route if the next hop is outside this topology."
+    }
+  }
+}
+
+# A named route's next hop is one address, so exactly one node can serve it.
+# Provisioning more does not share the load: the simulated network is a single
+# flat CIDR routed to a single gateway, and nl6 starts every generator at the
+# same nl6_auto_start_ip, so a second generator duplicates the first rather than
+# extending it. Supporting more needs per-generator CIDR slices and per-generator
+# routes, which is a design change rather than a choice of which node wins.
+resource "terraform_data" "route_role_cardinality" {
+  input = length(local.overprovisioned_route_roles)
+
+  lifecycle {
+    precondition {
+      condition     = length(local.overprovisioned_route_roles) == 0
+      error_message = "Deployment \"${var.deployment}\": ${join("; ", local.overprovisioned_route_roles)}. Exactly one node can serve a named route's next hop; set count to 1."
     }
   }
 }

--- a/terraform/kvm/main.tf
+++ b/terraform/kvm/main.tf
@@ -71,10 +71,6 @@ locals {
     for i, role in local.role_order : role => local.role_block_base + i * local.role_block_size
   }
 
-  named_routes = {
-    net_sim = { to = var.net_sim_cidr, via = var.net_sim_gateway }
-  }
-
   # Expand each spec role into `count` nodes, keyed by provider role (+ -N when >1).
   nodes = merge([
     for srole, cfg in local.spec.roles : {
@@ -86,6 +82,48 @@ locals {
       }
     }
   ]...)
+
+  # Provider roles the selected spec actually contains, used to validate that a
+  # named route has something to point at.
+  present_proles = distinct([for key, n in local.nodes : n.prole])
+
+  # ── named routes ──────────────────────────────────────────────────────────
+  # A named route's next hop is derived from the spec, never declared. The
+  # previous hardcoded var.net_sim_gateway drifted the moment the allocation
+  # scheme changed: netsim moved to .152 while the constant stayed at .134, so
+  # the minion routed the whole simulated network at an address no node held,
+  # silently (#171). Deriving it means the two cannot disagree.
+  #
+  # This resolves from local.nodes rather than local.topology, which would be a
+  # cycle — topology consumes named_routes. It mirrors topology's own address
+  # rule so a spec-pinned address still wins over the block offset.
+  netsim_sim_address = try([
+    for key, n in local.nodes :
+    try(n.cfg.addresses["sim"][n.index],
+    cidrhost(local.subnet_cidr["sim"], local.ip_offset[n.prole] + n.index))
+    if n.prole == "netsim"
+  ][0], null)
+
+  named_routes = {
+    net_sim = { to = var.net_sim_cidr, via = local.netsim_sim_address }
+  }
+
+  # Provider role each named route requires to be present in the spec.
+  named_route_requires = {
+    net_sim = "netsim"
+  }
+
+  # Named routes whose target role the spec does not contain. A named route
+  # points at a role inside the topology, so an absent target is always an
+  # error; an inline { to, via } deliberately points outside it and is exempt.
+  # A named route is a string, an inline route an object — hence tostring().
+  unsatisfied_named_routes = flatten([
+    for key, n in local.nodes : [
+      for subnet, r in try(n.cfg.routes, {}) :
+      "${key}.${subnet} route \"${r}\" needs role \"${lookup(local.named_route_requires, r, "?")}\""
+      if can(tostring(r)) && !contains(local.present_proles, lookup(local.named_route_requires, tostring(r), "?"))
+    ]
+  ])
 
   topology = {
     for key, n in local.nodes :
@@ -231,6 +269,22 @@ resource "terraform_data" "address_uniqueness" {
     precondition {
       condition     = length(distinct(local.all_addresses)) == length(local.all_addresses)
       error_message = "Duplicate IP addresses in the rendered topology: a role's node count exceeds its address block (role_block_size). Raise role_block_size or re-space local.role_order."
+    }
+  }
+}
+
+# Fails the plan if a spec declares a named route whose target role it does not
+# contain. es-nostore, rrd-minimal and vm-cluster-minion each carried a net_sim
+# route on their minion with no generator anywhere in the spec — copied from
+# baseline along with the rest of the block. That resolved to a plausible-looking
+# constant pointing at nobody, which is why it went unnoticed for months.
+resource "terraform_data" "named_route_targets" {
+  input = length(local.unsatisfied_named_routes)
+
+  lifecycle {
+    precondition {
+      condition     = length(local.unsatisfied_named_routes) == 0
+      error_message = "Deployment \"${var.deployment}\" declares named routes whose target role is absent: ${join("; ", local.unsatisfied_named_routes)}. Add the role to the spec, or use an inline { to, via } route if the next hop is outside this topology."
     }
   }
 }

--- a/terraform/kvm/main.tf
+++ b/terraform/kvm/main.tf
@@ -131,60 +131,26 @@ locals {
     }
   }
 
-  # Every route a spec declares, classified. Kept as data so each failure mode
-  # gets its own message instead of collapsing into one misleading default.
-  declared_routes = flatten([
+  # Named routes a spec declares whose next hop did not resolve — the role is
+  # absent, or present without the NIC the route needs. Both render an address
+  # no node holds, which is #171.
+  #
+  # Iterating keys() rather than the map itself is deliberate: a `routes:` map
+  # mixing a named route (string) and an inline one (object) is heterogeneous,
+  # and any expression that has to unify it with an empty map fails to type-check
+  # and takes this whole local down with it. keys() is a list of strings whatever
+  # the values are, and try() absorbs an absent, null or non-mapping `routes:`.
+  #
+  # Broader route validation — unknown names, malformed values, routes on the
+  # wrong subnet — is deliberately not here. It needs fixtures and a CI check
+  # that renders every spec to be worth anything, which is #173.
+  unresolved_named_routes = distinct(flatten([
     for key, n in local.nodes : [
-      # try() absorbs an absent `routes:` key; the null check absorbs a present
-      # but empty one (`routes:` with no mapping), which is legal YAML.
-      for subnet, r in(try(n.cfg.routes, null) == null ? {} : n.cfg.routes) : {
-        node   = key
-        srole  = lookup(local.spec_role_for, n.prole, n.prole)
-        subnet = subnet
-        value  = r
-        # An inline route is an object carrying its own next hop. A named route
-        # is a scalar naming an entry in named_route_spec. Anything else — a
-        # list, a null — is neither, and must not be silently forwarded.
-        kind = can(r.to) && can(r.via) ? "inline" : (r != null && can(tostring(r)) ? "named" : "invalid")
-        # Routes are only rendered for subnets the node is attached to.
-        attached = contains(n.cfg.subnets, subnet)
-      }
+      for subnet in try(keys(n.cfg.routes), []) :
+      "${lookup(local.spec_role_for, n.prole, n.prole)}.${subnet} -> \"${tostring(n.cfg.routes[subnet])}\" needs a \"${lookup(local.spec_role_for, local.named_route_spec[tostring(n.cfg.routes[subnet])].role, local.named_route_spec[tostring(n.cfg.routes[subnet])].role)}\" role with a \"${local.named_route_spec[tostring(n.cfg.routes[subnet])].subnet}\" NIC"
+      if contains(keys(local.named_route_spec), try(tostring(n.cfg.routes[subnet]), "")) && local.named_routes[tostring(n.cfg.routes[subnet])].via == null
     ]
-  ])
-
-  # Four distinct authoring errors, each with its own message.
-  route_errors = concat(
-    [
-      for r in local.declared_routes :
-      "${r.node}.${r.subnet}: route value is neither a named route nor an inline { to, via }"
-      if r.kind == "invalid"
-    ],
-    [
-      for r in local.declared_routes :
-      "${r.node}.${r.subnet}: unknown named route \"${tostring(r.value)}\" (known: ${join(", ", sort(keys(local.named_route_spec)))})"
-      if r.kind == "named" && !contains(keys(local.named_route_spec), tostring(r.value))
-    ],
-    [
-      for r in local.declared_routes :
-      "${r.node}.${r.subnet}: route \"${tostring(r.value)}\" needs a \"${lookup(local.spec_role_for, local.named_route_spec[tostring(r.value)].role, local.named_route_spec[tostring(r.value)].role)}\" role with a \"${local.named_route_spec[tostring(r.value)].subnet}\" NIC, which this deployment does not have"
-      if r.kind == "named" && contains(keys(local.named_route_spec), tostring(r.value)) && local.named_routes[tostring(r.value)].via == null
-    ],
-    [
-      for r in local.declared_routes :
-      "${r.node}.${r.subnet}: route declared on a subnet this role is not attached to (subnets: ${join(", ", r.attached ? [] : local.nodes[r.node].cfg.subnets)})"
-      if !r.attached
-    ],
-  )
-
-  # A named route's next hop is a single address, so exactly one node can serve
-  # it. The simulated network is one flat CIDR routed to one gateway, and nl6
-  # starts every generator at the same nl6_auto_start_ip, so a second generator
-  # would duplicate the first rather than extend it.
-  overprovisioned_route_roles = [
-    for name, r in local.named_route_spec :
-    "named route \"${name}\" resolves to role \"${lookup(local.spec_role_for, r.role, r.role)}\" but the spec declares ${length(local.nodes_by_prole[r.role])} of them"
-    if try(length(local.nodes_by_prole[r.role]), 0) > 1
-  ]
+  ]))
 
   topology = {
     for key, n in local.nodes :
@@ -210,14 +176,19 @@ locals {
           # both of its branches are type-checked, and for a named route the
           # inline branch is a bare string, which is not a route object.
           #
-          # A named route with no resolvable next hop is dropped rather than
-          # rendered with via = null: the preconditions below already fail the
+          # A *named* route with no resolvable next hop is dropped rather than
+          # rendered with via = null: the precondition below already fails the
           # plan, and a null here additionally breaks the shared cloud-init
           # template with an error that names neither the spec nor the node.
+          #
+          # The filter tests that the value names a known route, not merely that
+          # via is null: an inline route written with `via:` empty must keep
+          # failing loudly rather than being silently discarded.
           routes = [
             for r in(try(n.cfg.routes[subnet], null) == null ? [] : [
               try(local.named_routes[n.cfg.routes[subnet]], n.cfg.routes[subnet])
-            ]) : r if try(r.via, null) != null
+            ]) : r
+            if !(contains(keys(local.named_routes), try(tostring(n.cfg.routes[subnet]), "")) && try(r.via, null) == null)
           ]
         }
       ]
@@ -340,7 +311,7 @@ resource "terraform_data" "address_uniqueness" {
   }
 }
 
-# Fails the plan if a spec declares a route that cannot be rendered. es-nostore,
+# Fails the plan if a named route's next hop does not resolve. es-nostore,
 # rrd-minimal and vm-cluster-minion each carried a net_sim route on their minion
 # with no generator anywhere in the spec — copied from baseline along with the
 # rest of the block. That resolved to a plausible-looking constant pointing at
@@ -349,30 +320,13 @@ resource "terraform_data" "address_uniqueness" {
 # Checking that the next hop resolves to an address a node actually holds, and
 # not merely that the role name appears, is the point: a generator declared
 # without the NIC the route needs reproduces the original bug exactly.
-resource "terraform_data" "route_targets" {
-  input = length(local.route_errors)
+resource "terraform_data" "named_route_targets" {
+  input = length(local.unresolved_named_routes)
 
   lifecycle {
     precondition {
-      condition     = length(local.route_errors) == 0
-      error_message = "Deployment \"${var.deployment}\" declares routes that cannot be rendered:\n  ${join("\n  ", local.route_errors)}\nUse an inline { to, via } route if the next hop is outside this topology."
-    }
-  }
-}
-
-# A named route's next hop is one address, so exactly one node can serve it.
-# Provisioning more does not share the load: the simulated network is a single
-# flat CIDR routed to a single gateway, and nl6 starts every generator at the
-# same nl6_auto_start_ip, so a second generator duplicates the first rather than
-# extending it. Supporting more needs per-generator CIDR slices and per-generator
-# routes, which is a design change rather than a choice of which node wins.
-resource "terraform_data" "route_role_cardinality" {
-  input = length(local.overprovisioned_route_roles)
-
-  lifecycle {
-    precondition {
-      condition     = length(local.overprovisioned_route_roles) == 0
-      error_message = "Deployment \"${var.deployment}\": ${join("; ", local.overprovisioned_route_roles)}. Exactly one node can serve a named route's next hop; set count to 1."
+      condition     = length(local.unresolved_named_routes) == 0
+      error_message = "Deployment \"${var.deployment}\" declares named routes whose next hop does not resolve:\n  ${join("\n  ", local.unresolved_named_routes)}\nAdd the role, give it the required NIC, or use an inline { to, via } route if the next hop is outside this topology."
     }
   }
 }

--- a/terraform/kvm/variables.tf
+++ b/terraform/kvm/variables.tf
@@ -18,6 +18,12 @@ variable "ip_minion_kafka" { type = string }
 variable "ip_minion_sim" { type = string }
 variable "ip_netsim_sim" { type = string }
 variable "net_sim_cidr" { type = string }
+# Declared but deliberately unused: kvm derives the simulated-network next hop
+# from the topology (#171), because a hardcoded value drifts as soon as the
+# address allocation changes. proxmox and vmware still consume it, so it stays
+# in lab.tfvars — and stays declared here so that shared file parses without an
+# undeclared-variable warning. Do not wire this back into a route.
+# tflint-ignore: terraform_unused_declarations
 variable "net_sim_gateway" { type = string }
 variable "admin_user" { type = string }
 variable "vm_names" {

--- a/terraform/kvm/variables.tf
+++ b/terraform/kvm/variables.tf
@@ -20,9 +20,9 @@ variable "ip_netsim_sim" { type = string }
 variable "net_sim_cidr" { type = string }
 # Declared but deliberately unused: kvm derives the simulated-network next hop
 # from the topology (#171), because a hardcoded value drifts as soon as the
-# address allocation changes. proxmox and vmware still consume it, so it stays
-# in lab.tfvars — and stays declared here so that shared file parses without an
-# undeclared-variable warning. Do not wire this back into a route.
+# address allocation changes. azure, proxmox and vmware still consume it, so it
+# stays in lab.tfvars — and stays declared here so that shared file parses
+# without an undeclared-variable warning. Do not wire this back into a route.
 # tflint-ignore: terraform_unused_declarations
 variable "net_sim_gateway" { type = string }
 variable "admin_user" { type = string }


### PR DESCRIPTION
Closes #171.

`lab.tfvars` declared `net_sim_gateway = 192.0.2.134`, but since `eea387e` moved address allocation to per-role blocks, netsim's `sim` NIC renders at `192.0.2.152`. Every minion in `baseline`, `mimir-ha` and `mimir-ha-min` routed the whole simulated-device network at an address no node held.

Silent failure: provisioning succeeds, the route installs, nothing answers ARP at `.134`, and SNMP polling of simulated devices just returns nothing.

## What changed

**One source of truth for addresses.** `local.node_address` answers "what address does node N hold on subnet S", keyed only by the subnets a node actually declares. Both the rendered topology and the named-route next hops read it. Deriving the next hop from a *second copy* of the rule would reproduce #171 — and did, in an earlier revision of this PR.

**Named routes declare their provenance.** `local.named_route_spec` gives each route a `role` and `subnet`, so the address, the check and the message come from one place. Resolution reads `node_address`, never `local.topology`, so the graph stays acyclic.

**One precondition:** a named route's next hop must resolve to an address a node actually holds. Checking that the role merely *appears* is not enough — a generator declared without the NIC the route needs reproduces the original bug exactly.

**Three specs cleaned up.** `es-nostore`, `rrd-minimal` and `vm-cluster-minion` each routed via `net_sim` with no generator declared. All three minion blocks are byte-identical to `baseline`'s and came from the same commit; no revision of any of them ever declared a generator. The minion was the sole occupant of the `sim` subnet in each, so the NIC goes with the route. Note this is a destroy/create for those VMs if any are live; `sim` was last in each list, so `enp1s0`/`enp2s0` naming for the survivors is unaffected.

## Review history

Two rounds of adversarial review (blind / edge-case / acceptance), each verified by execution.

Round 1 found the first cut checked that the target *role existed* rather than that it *held an address*, so a generator without a `sim` NIC still resolved to a computed `192.0.2.152`. Round 2 found the fix for that introduced a four-branch error taxonomy with three defects of its own — a `routes` map mixing a named and an inline route failed to type-check and disabled every precondition; an inline `via: null` was silently dropped; and a cardinality check rejected specs declaring no routes at all.

That taxonomy was removed in `2d21a70` and moved to #173. It never ran in CI — `terraform validate` does not evaluate preconditions and `topology-descriptor.py` does not read `routes` — so it was untested guard code that broke the plan twice. It needs fixtures and a spec-rendering check to be worth anything, which is exactly what #173 is.

What remains is what all three layers confirmed correct.

## Verification

`local.node_address` proven equivalent to `main`: full rendered interfaces (address, prefix, gateway, routes) compared across all 14 specs. **No VM's address changes anywhere.** The only deltas are the three intended spec edits and the intended `via` `.134` → `.152`.

| case | result |
|---|---|
| `baseline`, `mimir-ha`, `mimir-ha-min` | `via 192.0.2.152` = netsim's real `sim` address |
| named route, no generator | fails: needs a `loadgen` role with a `sim` NIC |
| generator present, no `sim` NIC | fails, same message |
| named + inline route on one node | renders correctly (regressed in an earlier revision, fixed) |
| `routes:` scalar / list / null / absent | no crash |
| inline `via: null` | still fails loudly, as on `main` |
| `clickhouse-riptide` | byte-identical, inline route exempt |

`make fmt`, `validate-kvm`, `validate-deployments`, `lint-yaml`, `tflint` pass; the only tflint findings are the three pre-existing `lab_cidr` ones.

No `terraform apply` or state operation at any point — work was done in a separate worktree, and the live `clickhouse-riptide` deployment was never touched.

## Known gaps, tracked in #173

A route keyed on the wrong subnet (`routes: { kafka: net_sim }`) still renders an off-link next hop unreported — the #171 class, present on `main` too. So do a self-referential route, an unknown route name, and a malformed route value. None of them are caught by any CI check today, which is the actual root cause and why they belong together in #173 rather than as more untested guard code here.

## Note on `net_sim_gateway`

It stays in `lab.tfvars`. `azure`, `proxmox` and `vmware` consume it and `.134` is correct for them, since they take netsim's address from `ip_netsim_sim` directly. kvm keeps the declaration so the shared file parses without an undeclared-variable warning, marked `tflint-ignore`. Full removal is a provable no-op but spans 14 files and forces the retired-azure decision, so it is the follow-up on #161.
