### PR TITLE
feat(terraform/aws): add an EC2 provider, spec-driven from the first commit

### DIFF
--- a/.github/workflows/terraform-lint.yml
+++ b/.github/workflows/terraform-lint.yml
@@ -55,6 +55,24 @@ jobs:
       - name: make validate-azure
         run: make validate-azure
 
+  validate-aws:
+    name: Validate (AWS)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e  # v4.0.1
+        with:
+          terraform_version: "~1.5"
+
+      # No AWS credentials are needed or configured: validate checks syntax and
+      # types only, and never contacts the provider API.
+      - name: make validate-aws
+        run: make validate-aws
+
   validate-kvm:
     name: Validate (KVM)
     runs-on: ubuntu-24.04

--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,9 @@ crash.log
 # KVM tfvars contains a host-specific URI — gitignored, use kvm.tfvars.example as template
 terraform/kvm/kvm.tfvars
 
+# AWS tfvars carries a region/AZ and key path — gitignored, use aws.tfvars.example as template
+terraform/aws/aws.tfvars
+
 # Proxmox tfvars contains an API token — gitignored, use proxmox.tfvars.example as template
 terraform/proxmox/proxmox.tfvars
 

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ SHELL := /usr/bin/env bash
 .DEFAULT_GOAL := help
 
 # Providers with a Terraform root under terraform/<provider>/.
-PROVIDERS := azure kvm proxmox vmware
+PROVIDERS := aws azure kvm proxmox vmware
 
 # Deployment library — provider-agnostic topology specs under deployments/<slug>/.
 DEPLOYMENTS_DIR := deployments
@@ -30,9 +30,9 @@ DEPLOYMENT ?= baseline
 
 # The deployment is passed to deploy.sh only for spec-driven providers (kvm),
 # which selects both the Terraform topology and the Ansible config overlay.
-_dep_flag  = $(if $(filter kvm,$(PROVIDER)),--deployment $(DEPLOYMENT))
+_dep_flag  = $(if $(filter kvm aws,$(PROVIDER)),--deployment $(DEPLOYMENT))
 # `make plan` still passes the Terraform var directly (it bypasses deploy.sh).
-_dep_tfarg = $(if $(filter kvm,$(PROVIDER)),-var deployment=$(DEPLOYMENT))
+_dep_tfarg = $(if $(filter kvm aws,$(PROVIDER)),-var deployment=$(DEPLOYMENT))
 
 # ── guards ────────────────────────────────────────────────────────────────────
 
@@ -69,12 +69,17 @@ deploy: check-provider ## Provision + configure the lab (PROVIDER=…, kvm: DEPL
 destroy: check-provider confirm ## Tear down all lab resources for PROVIDER
 	./deploy.sh --provider $(PROVIDER) $(_dep_flag) --destroy $(if $(TF_ARGS),--tf-args "$(TF_ARGS)") $(V)
 
+.PHONY: show
+show: check-provider ## Show deployed resources for PROVIDER, and any leftovers
+	./show.sh --provider $(PROVIDER) $(_dep_flag)
+
 .PHONY: plan
 plan: check-provider ## terraform plan for PROVIDER (kvm: DEPLOYMENT=<slug>)
 	terraform -chdir=terraform/$(PROVIDER) init -input=false $(if $(filter kvm,$(PROVIDER)),-upgrade) >/dev/null
 	terraform -chdir=terraform/$(PROVIDER) plan -input=false \
 	  -var-file=../lab.tfvars \
-	  $(if $(filter kvm proxmox vmware,$(PROVIDER)),-var-file=../disk-sizes.tfvars) \
+	  $(if $(filter-out aws,$(PROVIDER)),-var-file=../lab-addresses.tfvars) \
+	  $(if $(filter aws kvm proxmox vmware,$(PROVIDER)),-var-file=../disk-sizes.tfvars) \
 	  -var-file=$(PROVIDER).tfvars \
 	  $(_dep_tfarg)
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -17,10 +17,10 @@ set -euo pipefail
 
 usage() {
   cat <<EOF
-Usage: $0 --provider <azure|kvm|proxmox|vmware> [OPTIONS]
+Usage: $0 --provider <aws|azure|kvm|proxmox|vmware> [OPTIONS]
 
 Options:
-  --provider   <azure|kvm|proxmox|vmware>  Target infrastructure provider (required)
+  --provider   <aws|azure|kvm|proxmox|vmware>  Target infrastructure provider (required)
   --deployment <slug>               Deployment topology from deployments/<slug>/ (kvm; default baseline)
   --destroy                         Tear down all lab resources
   --tf-args    "<args>"             Extra arguments passed verbatim to terraform
@@ -69,8 +69,8 @@ done
 
 [[ -z "$PROVIDER" ]] && { echo "Error: --provider is required" >&2; error_usage; }
 case "$PROVIDER" in
-  azure|kvm|proxmox|vmware) ;;
-  *) echo "Error: provider must be 'azure', 'kvm', 'proxmox', or 'vmware'" >&2; error_usage ;;
+  aws|azure|kvm|proxmox|vmware) ;;
+  *) echo "Error: provider must be 'aws', 'azure', 'kvm', 'proxmox', or 'vmware'" >&2; error_usage ;;
 esac
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -84,9 +84,16 @@ export ANSIBLE_CONFIG="$REPO_ROOT/ansible.cfg"
 TF_DIR="$REPO_ROOT/terraform/$PROVIDER"
 TFVARS_FILE="$TF_DIR/${PROVIDER}.tfvars"
 
-# lab.tfvars is provider-agnostic; disk-sizes.tfvars applies to kvm, proxmox, and vmware only.
+# lab.tfvars is provider-agnostic. lab-addresses.tfvars carries the legacy
+# per-host address scheme (#161); aws derives every address from the deployment
+# spec and declares none of it, so passing the file would produce a screenful of
+# "Value for undeclared variable" on every run. disk-sizes.tfvars applies to
+# every provider except azure.
 COMMON_VAR_FILES=(-var-file="../lab.tfvars")
-if [[ "$PROVIDER" == "kvm" || "$PROVIDER" == "proxmox" || "$PROVIDER" == "vmware" ]]; then
+if [[ "$PROVIDER" != "aws" ]]; then
+  COMMON_VAR_FILES+=(-var-file="../lab-addresses.tfvars")
+fi
+if [[ "$PROVIDER" == "aws" || "$PROVIDER" == "kvm" || "$PROVIDER" == "proxmox" || "$PROVIDER" == "vmware" ]]; then
   [[ -f "$REPO_ROOT/terraform/disk-sizes.tfvars" ]] || { echo "Error: terraform/disk-sizes.tfvars not found" >&2; exit 1; }
   COMMON_VAR_FILES+=(-var-file="../disk-sizes.tfvars")
 fi
@@ -98,32 +105,120 @@ if [[ ! -f "$TFVARS_FILE" ]]; then
 fi
 
 # Deployment selection: the `deployment` Terraform variable is declared only on
-# spec-driven providers (kvm today). The matching Ansible config overlay
+# spec-driven providers (kvm and aws). The matching Ansible config overlay
 # (deployments/<slug>/opennms-lab-vars.yml) is layered onto the OpenNMS play.
 DEPLOYMENT_VARS=()
-if [[ -n "$DEPLOYMENT" && "$PROVIDER" == "kvm" ]]; then
+if [[ -n "$DEPLOYMENT" && ( "$PROVIDER" == "kvm" || "$PROVIDER" == "aws" ) ]]; then
   DEPLOYMENT_VARS=(-var "deployment=$DEPLOYMENT")
 fi
 DEPLOYMENT_VARS_FILE=""
-if [[ -n "$DEPLOYMENT" && "$PROVIDER" == "kvm" && -f "$REPO_ROOT/deployments/$DEPLOYMENT/opennms-lab-vars.yml" ]]; then
+if [[ -n "$DEPLOYMENT" && ( "$PROVIDER" == "kvm" || "$PROVIDER" == "aws" ) && -f "$REPO_ROOT/deployments/$DEPLOYMENT/opennms-lab-vars.yml" ]]; then
   DEPLOYMENT_VARS_FILE="--extra-vars=@$REPO_ROOT/deployments/$DEPLOYMENT/opennms-lab-vars.yml"
 fi
+
+# ── AWS credentials ───────────────────────────────────────────────────────────
+
+# Terraform resolves credentials from env vars, the shared credentials file,
+# `sso-session` profiles, process credentials and IMDS. It does NOT read the
+# token cache that `aws login` writes, so a perfectly working CLI can sit next
+# to a Terraform run that cannot authenticate at all -- and the symptom is a
+# two-minute IMDS probe followed by "No valid credential sources found", which
+# points nowhere useful.
+#
+# Export whatever the CLI has already resolved, and disable the IMDS fallback so
+# a genuine absence of credentials fails in a second rather than two minutes.
+ensure_aws_credentials() {
+  [[ "$PROVIDER" == "aws" ]] || return 0
+
+  export AWS_EC2_METADATA_DISABLED=true
+
+  # Requiring an explicit profile is the difference between choosing which
+  # identity builds the lab and inheriting whichever one happens to be default.
+  # On an account shared with anything else, the default is usually the most
+  # privileged identity available -- which is precisely what should not be
+  # creating a disposable benchmark bed.
+  #
+  # Not enforced when destroying: being unable to tear a lab down is worse than
+  # tearing it down with more authority than necessary, and a lab nobody can
+  # remove keeps billing.
+  if [[ -z "${AWS_PROFILE:-}" && "${AWS_ALLOW_DEFAULT_CREDENTIALS:-}" != "1" ]]; then
+    if [[ "$DESTROY" == true ]]; then
+      warn "AWS_PROFILE is not set; destroying with whatever credentials are default"
+    else
+      echo "Error: AWS_PROFILE is not set." >&2
+      echo "       Deploying would use whichever AWS credentials happen to be default." >&2
+      echo "       On a shared account that is usually your most privileged identity." >&2
+      echo "" >&2
+      echo "       Choose one explicitly:" >&2
+      echo "         AWS_PROFILE=benchmark-lab make deploy PROVIDER=aws DEPLOYMENT=<slug>" >&2
+      echo "" >&2
+      echo "       Available profiles:" >&2
+      aws configure list-profiles 2>/dev/null | sed 's/^/         /' >&2 || true
+      echo "" >&2
+      echo "       Set AWS_ALLOW_DEFAULT_CREDENTIALS=1 to bypass (CI, or static keys" >&2
+      echo "       supplied by the environment rather than a profile)." >&2
+      exit 1
+    fi
+  fi
+
+  if [[ -z "${AWS_ACCESS_KEY_ID:-}" ]] && aws configure export-credentials --format env >/dev/null 2>&1; then
+    info "exporting AWS credentials resolved by the CLI${AWS_PROFILE:+ (profile: $AWS_PROFILE)}"
+    eval "$(aws configure export-credentials --format env)"
+    # The export already resolved whatever the profile pointed at, including an
+    # assumed role. Leaving AWS_PROFILE set makes the Terraform provider try to
+    # resolve it again from scratch, which fails when the source profile has no
+    # static credentials of its own -- the usual case when signing in with
+    # `aws login` or SSO.
+    unset AWS_PROFILE
+  fi
+
+  if ! aws sts get-caller-identity >/dev/null 2>&1; then
+    echo "Error: no usable AWS credentials." >&2
+    echo "       Sign in first, e.g.  aws login   (or  aws configure sso)." >&2
+    echo "       Verify with:         aws sts get-caller-identity" >&2
+    exit 1
+  fi
+
+  local ident
+  ident=$(aws sts get-caller-identity --query 'Arn' --output text 2>/dev/null || echo unknown)
+  info "aws identity: $ident"
+
+  # A set AWS_PROFILE is not by itself proof of anything -- AWS_PROFILE=default
+  # satisfies the check above while still being the unrestricted user. An
+  # assumed role is the shape a scoped identity takes, so say so when it is not
+  # one. A warning rather than an error: a properly scoped IAM user is a
+  # legitimate setup, just not the one this lab is built around.
+  case "$ident" in
+    *:assumed-role/*) ;;
+    unknown) ;;
+    *)
+      warn "this is an IAM user, not an assumed role."
+      warn "  If a scoped role exists, prefer it: AWS_PROFILE=benchmark-lab"
+      warn "  See terraform/aws/README.md, 'Running under a restricted role'."
+      ;;
+  esac
+}
 
 # ── provider-specific extra vars ──────────────────────────────────────────────
 
 # Populate PROVIDER_VARS array with extra -var flags needed for this provider.
-# Azure: detect the operator's public IP for the NSG SSH-allow rule.
+# Azure and AWS: detect the operator's public IP for the SSH-allow rule.
 PROVIDER_VARS=()
 
 set_provider_vars() {
   PROVIDER_VARS=()
-  if [[ "$PROVIDER" == "azure" ]]; then
+  if [[ "$PROVIDER" == "azure" || "$PROVIDER" == "aws" ]]; then
     local op_ip
     op_ip=$(host -4 myip.opendns.com resolver1.opendns.com 2>/dev/null \
             | awk '/has address/ {print $NF; exit}' || true)
     if [[ -n "$op_ip" ]]; then
       info "detected operator IP: $op_ip"
       PROVIDER_VARS=(-var "operator_cidr=${op_ip}/32")
+    elif [[ "$PROVIDER" == "aws" ]]; then
+      # aws declares operator_cidr with no default, so terraform would prompt.
+      # Fail closed: a lab nobody can reach beats a lab open to the internet.
+      warn "could not detect public IP; restricting operator SSH to 0.0.0.0/32 (unreachable)"
+      PROVIDER_VARS=(-var "operator_cidr=0.0.0.0/32")
     else
       warn "could not detect public IP; SSH access on monitoring VM will be open to *"
     fi
@@ -189,6 +284,7 @@ tf_output() {
 
 if $DESTROY; then
   step "Destroying infrastructure ($PROVIDER)..."
+  ensure_aws_credentials
   tf_init
   set_provider_vars
   tf_destroy "${PROVIDER_VARS[@]+"${PROVIDER_VARS[@]}"}"
@@ -200,8 +296,41 @@ fi
 # ── deploy path ───────────────────────────────────────────────────────────────
 
 step "[1/3] Provisioning infrastructure ($PROVIDER)..."
+ensure_aws_credentials
 tf_init
 set_provider_vars
+
+# aws bills by the hour, so cost_profile defaults to the cheap tier and spend is
+# opted into. The trade is that a smoke lab looks exactly like a benchmark bed
+# and cannot produce valid numbers, so announce which one is being built before
+# it exists rather than after. console evaluates the variable without contacting
+# AWS, so this costs nothing and needs no credentials.
+COST_PROFILE=""
+if [[ "$PROVIDER" == "aws" ]]; then
+  COST_PROFILE=$(echo 'var.cost_profile' \
+    | terraform -chdir="$TF_DIR" console \
+        "${COMMON_VAR_FILES[@]}" \
+        -var-file="${PROVIDER}.tfvars" \
+        "${DEPLOYMENT_VARS[@]+"${DEPLOYMENT_VARS[@]}"}" \
+        "${PROVIDER_VARS[@]+"${PROVIDER_VARS[@]}"}" 2>/dev/null \
+    | tr -d '"' | tail -n1 || true)
+  case "$COST_PROFILE" in
+    smoke)
+      warn "cost profile: SMOKE — burstable instances, capped disks."
+      warn "  Cheap enough to test the stack with. CPU credits deplete under"
+      warn "  sustained load, so any benchmark run on this lab is invalid."
+      warn "  Measuring? Re-run with: TF_ARGS=\"-var cost_profile=benchmark\""
+      ;;
+    benchmark)
+      info "cost profile: benchmark — fixed-performance instances, full disks."
+      info "  This is the expensive tier. Destroy the lab when you are done."
+      ;;
+    *)
+      [[ -n "$COST_PROFILE" ]] && info "cost profile: $COST_PROFILE"
+      ;;
+  esac
+fi
+
 tf_apply "${PROVIDER_VARS[@]+"${PROVIDER_VARS[@]}"}"
 
 # KVM and Proxmox: the monitoring VM's external (jump host) IP is DHCP-assigned
@@ -268,11 +397,12 @@ ansible-galaxy collection install \
 # the shared one, which keeps its play order — the stack's dependency graph —
 # in exactly one place.
 # Gated on kvm for the same reason as the vars overlay above: only kvm is
-# spec-driven, so on other providers --deployment does not shape the infra and
+# spec-driven (kvm and aws), so on other providers --deployment does not shape
+# the infra and
 # a per-deployment playbook would target hosts that were never provisioned.
 DEPLOYMENT_PLAYBOOK="$REPO_ROOT/opennms-playbook.yml"
 STACK_LABEL="OpenNMS Horizon"
-if [[ -n "$DEPLOYMENT" && "$PROVIDER" == "kvm" && -f "$REPO_ROOT/deployments/$DEPLOYMENT/playbook.yml" ]]; then
+if [[ -n "$DEPLOYMENT" && ( "$PROVIDER" == "kvm" || "$PROVIDER" == "aws" ) && -f "$REPO_ROOT/deployments/$DEPLOYMENT/playbook.yml" ]]; then
   DEPLOYMENT_PLAYBOOK="$REPO_ROOT/deployments/$DEPLOYMENT/playbook.yml"
   STACK_LABEL="$DEPLOYMENT stack"
 fi
@@ -286,3 +416,21 @@ ansible-playbook \
   "$DEPLOYMENT_PLAYBOOK" \
   --extra-vars="@$REPO_ROOT/opennms-lab-vars.yml" \
   $DEPLOYMENT_VARS_FILE
+
+# Closing reminder. The pre-flight notice scrolls far off screen behind
+# Terraform and two Ansible runs, and this is the moment someone starts
+# measuring.
+if [[ "$COST_PROFILE" == "smoke" ]]; then
+  echo
+  warn "════════════════════════════════════════════════════════════════"
+  warn "  This lab was built with cost_profile=smoke."
+  warn "  Burstable instances: fine for testing the stack, invalid for"
+  warn "  benchmarking. Numbers from this lab will look plausible and"
+  warn "  will be wrong."
+  warn "  Every host carries lab_cost_profile=smoke in the inventory."
+  warn "════════════════════════════════════════════════════════════════"
+elif [[ "$COST_PROFILE" == "benchmark" ]]; then
+  echo
+  info "cost_profile=benchmark — this lab bills at the full rate."
+  info "Run 'make destroy PROVIDER=aws CONFIRM=yes' when you are finished."
+fi

--- a/docs/aws-iam/benchmark-lab-policy.json
+++ b/docs/aws-iam/benchmark-lab-policy.json
@@ -1,0 +1,91 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "LabNeedsTheseServices",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:*",
+        "resource-groups:*",
+        "tag:GetResources",
+        "tag:TagResources",
+        "tag:UntagResources",
+        "ssm:GetParameter",
+        "ssm:GetParameters",
+        "sts:GetCallerIdentity"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "NothingInsideTheProductionVpc",
+      "Effect": "Deny",
+      "Action": "ec2:*",
+      "Resource": "*",
+      "Condition": {
+        "StringEquals": {
+          "ec2:Vpc": "arn:aws:ec2:us-east-1:519827938511:vpc/vpc-11dd7777"
+        }
+      }
+    },
+    {
+      "Sid": "NoDestructionOfAnythingNotTaggedAsTheLab",
+      "Effect": "Deny",
+      "Action": [
+        "ec2:TerminateInstances",
+        "ec2:StopInstances",
+        "ec2:ModifyInstanceAttribute",
+        "ec2:DeleteVpc",
+        "ec2:DeleteSubnet",
+        "ec2:DeleteSecurityGroup",
+        "ec2:DeleteNatGateway",
+        "ec2:DeleteVolume",
+        "ec2:DetachVolume",
+        "ec2:DeleteNetworkInterface",
+        "ec2:DeleteInternetGateway",
+        "ec2:DeleteRouteTable",
+        "ec2:DeleteRoute",
+        "ec2:DeleteKeyPair",
+        "ec2:DeletePlacementGroup",
+        "ec2:CreateSnapshot",
+        "ec2:DeleteSnapshot"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringNotEquals": {
+          "aws:ResourceTag/project": "benchmark"
+        }
+      }
+    },
+    {
+      "Sid": "NoSelfEscalation",
+      "Effect": "Deny",
+      "Action": [
+        "iam:*",
+        "organizations:*",
+        "account:*",
+        "sts:AssumeRole"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "HandsOffProductionElasticIps",
+      "Effect": "Deny",
+      "Action": [
+        "ec2:DisassociateAddress",
+        "ec2:ReleaseAddress",
+        "ec2:AssociateAddress"
+      ],
+      "Resource": [
+        "arn:aws:ec2:us-east-1:519827938511:elastic-ip/eipalloc-0c82de5dc30d34611",
+        "arn:aws:ec2:us-east-1:519827938511:elastic-ip/eipalloc-0445c46a03d243582",
+        "arn:aws:ec2:us-east-1:519827938511:elastic-ip/eipalloc-08282be41c456e594",
+        "arn:aws:ec2:us-east-1:519827938511:elastic-ip/eipalloc-0cf1b3f4252ce1c1f",
+        "arn:aws:ec2:us-east-1:519827938511:elastic-ip/eipalloc-0c91a4e2d92ff239f",
+        "arn:aws:ec2:us-east-1:519827938511:elastic-ip/eipalloc-8f17fcb1",
+        "arn:aws:ec2:us-east-1:519827938511:elastic-ip/eipalloc-fb766ef2",
+        "arn:aws:ec2:us-east-1:519827938511:elastic-ip/eipalloc-0225cbdd88221a1b8",
+        "arn:aws:ec2:us-east-1:519827938511:elastic-ip/eipalloc-0f753e3ecc97ad2dc"
+      ]
+    }
+  ]
+}

--- a/docs/aws-iam/trust-policy.json
+++ b/docs/aws-iam/trust-policy.json
@@ -1,0 +1,11 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "OnlyRonnyMayAssume",
+      "Effect": "Allow",
+      "Principal": { "AWS": "arn:aws:iam::519827938511:user/rtrommer" },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}

--- a/show.sh
+++ b/show.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: Apache-2.0
+#
+# Show what a provider currently has deployed, from two directions:
+#
+#   Terraform state  — what Terraform believes it created
+#   the provider     — what actually exists
+#
+# The gap between them is the point. Terraform state alone cannot answer "did
+# the destroy leave anything behind", because a leftover is by definition
+# something state no longer tracks. Anything present at the provider but absent
+# from state is either an interrupted apply, a failed destroy, or something
+# created by hand — and on a metered provider it is billing either way.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+PROVIDER=""
+DEPLOYMENT=""
+
+usage() {
+  cat <<EOF
+Usage: $0 --provider <aws|azure|kvm|proxmox|vmware> [--deployment <slug>]
+
+Shows deployed resources for PROVIDER: Terraform's view, the provider's view,
+and anything that appears in one but not the other.
+EOF
+  exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --provider)   PROVIDER="$2"; shift 2 ;;
+    --deployment) DEPLOYMENT="$2"; shift 2 ;;
+    -h|--help)    usage ;;
+    *) echo "Error: unknown argument '$1'" >&2; usage ;;
+  esac
+done
+
+[[ -z "$PROVIDER" ]] && { echo "Error: --provider is required" >&2; usage; }
+
+case "$PROVIDER" in
+  aws|azure|kvm|proxmox|vmware) ;;
+  *) echo "Error: unknown provider '$PROVIDER'" >&2; usage ;;
+esac
+
+TF_DIR="$REPO_ROOT/terraform/$PROVIDER"
+[[ -d "$TF_DIR" ]] || { echo "Error: $TF_DIR does not exist" >&2; exit 1; }
+
+step() { echo; echo "==> $*"; }
+info() { echo "    $*"; }
+warn() { echo "    warning: $*" >&2; }
+
+# ── Terraform's view ──────────────────────────────────────────────────────────
+
+step "Terraform state ($PROVIDER)"
+
+STATE="$TF_DIR/terraform.tfstate"
+tf_count=0
+
+if [[ ! -f "$STATE" ]]; then
+  info "no state file — this provider has never been applied from here"
+else
+  tf_count=$(python3 - "$STATE" <<'PY'
+import json, sys
+from collections import Counter
+try:
+    s = json.load(open(sys.argv[1]))
+except Exception:
+    print(0); sys.exit()
+c = Counter()
+for r in s.get("resources", []):
+    # data sources are lookups, not things that exist
+    if r.get("mode") == "data":
+        continue
+    c[r["type"]] += len(r.get("instances", []))
+total = sum(c.values())
+for k, v in sorted(c.items(), key=lambda x: (-x[1], x[0])):
+    print(f"    {v:>4}  {k}", file=sys.stderr)
+print(f"    serial {s.get('serial', '?')}", file=sys.stderr)
+print(total)
+PY
+)
+  if [[ "$tf_count" == "0" ]]; then
+    info "state is empty — Terraform believes nothing is deployed"
+  fi
+  info "-----"
+  info "$tf_count resource(s) tracked"
+fi
+
+# ── the provider's view ───────────────────────────────────────────────────────
+
+step "Live at the provider ($PROVIDER)"
+
+case "$PROVIDER" in
+  aws)
+    if ! command -v aws >/dev/null 2>&1; then
+      warn "aws CLI not installed — cannot check what actually exists"
+      exit 0
+    fi
+    export AWS_EC2_METADATA_DISABLED=true
+    if [[ -z "${AWS_ACCESS_KEY_ID:-}" ]] && aws configure export-credentials --format env >/dev/null 2>&1; then
+      eval "$(aws configure export-credentials --format env)"
+      unset AWS_PROFILE
+    fi
+    if ! aws sts get-caller-identity >/dev/null 2>&1; then
+      warn "no usable AWS credentials — showing Terraform state only"
+      warn "sign in first, e.g. aws login"
+      exit 0
+    fi
+    info "account: $(aws sts get-caller-identity --query Account --output text)"
+
+    # Quoted: each element is one AWS CLI filter expression, and the commas
+    # are part of it rather than element separators.
+    filter=("Name=tag:project,Values=benchmark")
+    [[ -n "$DEPLOYMENT" ]] && filter+=("Name=tag:deployment,Values=$DEPLOYMENT")
+
+    # Query each service directly rather than the tagging API: that API keeps
+    # returning deleted resources for a day or so, which would report a
+    # completed teardown as a pile of leftovers.
+    inst=$(aws ec2 describe-instances --filters "${filter[@]}" \
+             Name=instance-state-name,Values=pending,running,stopping,stopped \
+             --query 'Reservations[].Instances[]' --output json 2>/dev/null || echo '[]')
+    n_inst=$(echo "$inst" | python3 -c 'import json,sys; print(len(json.load(sys.stdin)))')
+
+    n_vpc=$(aws ec2 describe-vpcs --filters "${filter[@]}" --query 'length(Vpcs)' --output text 2>/dev/null || echo 0)
+    # shellcheck disable=SC2016  # backticks are JMESPath literals, not shell
+    n_nat=$(aws ec2 describe-nat-gateways --filter "${filter[@]}" \
+              --query 'length(NatGateways[?State==`available`||State==`pending`])' --output text 2>/dev/null || echo 0)
+    n_eip=$(aws ec2 describe-addresses --filters "${filter[@]}" --query 'length(Addresses)' --output text 2>/dev/null || echo 0)
+    n_eni=$(aws ec2 describe-network-interfaces --filters "${filter[@]}" --query 'length(NetworkInterfaces)' --output text 2>/dev/null || echo 0)
+    n_sub=$(aws ec2 describe-subnets --filters "${filter[@]}" --query 'length(Subnets)' --output text 2>/dev/null || echo 0)
+    n_sg=$(aws ec2 describe-security-groups --filters "${filter[@]}" --query 'length(SecurityGroups)' --output text 2>/dev/null || echo 0)
+    n_vol=$(aws ec2 describe-volumes --filters "${filter[@]}" --query 'length(Volumes)' --output text 2>/dev/null || echo 0)
+
+    live=$(( n_inst + n_vpc + n_nat + n_eip + n_eni + n_sub + n_sg + n_vol ))
+
+    if [[ "$live" -eq 0 ]]; then
+      info "nothing tagged project=benchmark${DEPLOYMENT:+ / deployment=$DEPLOYMENT} exists"
+    else
+      # Billable first: these are the ones worth noticing after a destroy.
+      printf '    %-18s %s\n' "instances"       "$n_inst"
+      printf '    %-18s %s\n' "nat gateways"    "$n_nat"
+      printf '    %-18s %s\n' "elastic ips"     "$n_eip"
+      printf '    %-18s %s\n' "ebs volumes"     "$n_vol"
+      printf '    %-18s %s\n' "vpcs"            "$n_vpc"
+      printf '    %-18s %s\n' "subnets"         "$n_sub"
+      printf '    %-18s %s\n' "security groups" "$n_sg"
+      printf '    %-18s %s\n' "network ifaces"  "$n_eni"
+
+      if [[ "$n_inst" -gt 0 ]]; then
+        echo
+        echo "$inst" | python3 -c '
+import json, sys
+for i in json.load(sys.stdin):
+    name = next((t["Value"] for t in i.get("Tags", []) if t["Key"] == "Name"), "?")
+    print(f"    {name:<24} {i[\"InstanceType\"]:<12} {i[\"State\"][\"Name\"]:<10} {i.get(\"PrivateIpAddress\",\"-\")}")
+'
+      fi
+    fi
+
+    # ── the bit state alone cannot tell you ───────────────────────────────────
+    step "Reconciliation"
+    if [[ "$tf_count" -eq 0 && "$live" -gt 0 ]]; then
+      warn "$live resource(s) exist at AWS but Terraform tracks none."
+      warn "Left over from a failed destroy, or created outside Terraform."
+      [[ "$n_nat" -gt 0 || "$n_eip" -gt 0 || "$n_inst" -gt 0 ]] && \
+        warn "Some of these bill by the hour. Remove them before they are forgotten."
+    elif [[ "$tf_count" -gt 0 && "$live" -eq 0 ]]; then
+      warn "Terraform tracks $tf_count resource(s) but none exist at AWS."
+      warn "They were probably removed by hand; 'terraform plan' will want to rebuild them."
+    elif [[ "$tf_count" -eq 0 && "$live" -eq 0 ]]; then
+      info "clean — nothing tracked, nothing deployed"
+    else
+      info "Terraform tracks $tf_count resource(s); $live tagged resource(s) live at AWS."
+      info "Counts differ by design — one Terraform resource is not one AWS object."
+      info "Run 'make plan PROVIDER=aws' for an authoritative drift check."
+    fi
+    ;;
+
+  kvm|proxmox|vmware|azure)
+    info "no live query implemented for '$PROVIDER'."
+    info "Terraform state above is the only view; 'make plan PROVIDER=$PROVIDER' shows drift."
+    ;;
+esac
+
+echo

--- a/terraform/aws/README.md
+++ b/terraform/aws/README.md
@@ -1,0 +1,297 @@
+# AWS provider
+
+Provisions the lab on EC2 from `deployments/<slug>/topology.yml`.
+
+> [!WARNING]
+> **Check whose account you are in.** These labs are cheap, but nothing stops
+> them being provisioned beside production. Scope any cleanup to Terraform
+> state or the deployment's resource group — never a console-wide tag sweep.
+>
+> This provider bills by the hour. `mimir-ha-min` is 19 instances. Run
+> `make destroy PROVIDER=aws CONFIRM=yes` when you are done, and verify in the
+> console rather than trusting Terraform state alone.
+
+## Status
+
+Statically verified only. `make validate-aws`, `make tflint-aws` and `make fmt`
+pass, and every supported spec renders through `terraform console` without
+contacting AWS. **No `terraform apply` has been run**, so this is proven in
+shape, not in behaviour. See #174.
+
+## Setup
+
+```bash
+cp aws.tfvars.example aws.tfvars   # edit region, project, ssh_key_path
+aws login                          # or aws configure sso / aws configure
+aws sts get-caller-identity        # confirm you are signed in
+make deploy PROVIDER=aws DEPLOYMENT=baseline
+```
+
+**`aws login` alone is not enough for Terraform.** It writes a token cache the
+AWS CLI understands and the Terraform provider does not, so the CLI works while
+Terraform reports `No valid credential sources found` after a two-minute IMDS
+probe. `deploy.sh` handles this: it exports whatever the CLI has resolved via
+`aws configure export-credentials` and disables the IMDS fallback so a genuine
+absence of credentials fails immediately with a usable message. Running
+Terraform by hand needs the same step:
+
+```bash
+eval "$(aws configure export-credentials --format env)"
+```
+
+`deploy.sh` detects your public address and passes it as `operator_cidr`, which
+scopes SSH ingress to the jump host. If detection fails the provider fails
+closed — `0.0.0.0/32`, reachable by nobody — rather than opening the lab.
+
+## What differs from the hypervisor providers
+
+**Spec-driven, with no per-host address variables.** Like `kvm` and unlike
+`azure`/`proxmox`/`vmware`, this root reads the deployment spec and derives every
+address from it. It declares no `ip_database`/`ip_core` variables, so it cannot
+drift from the other providers the way tracked in #161.
+
+**One availability zone.** An ENI cannot span zones and lab nodes are multi-homed
+across `mgmt`/`db`/`kafka`/`sim`, so every subnet lives in one AZ. That is also
+what you want for a benchmark: cross-AZ latency is not the thing being measured.
+
+**Static addressing comes from the platform.** The address is pinned on the ENI
+and DHCP hands the guest exactly that, so `network_config_supported = false` and
+the netplan document is unused. Static routes ride in user-data as a systemd
+unit, the same path Azure uses.
+
+**Burstable instances are confined to the smoke profile.** A `t`-class instance
+depletes its CPU credits partway through a sustained run, so the second half of a
+measurement is not comparable to the first. Azure's `Standard_B2ms`/`B4ms` has
+this problem across the board; here it is contained to the tier where nothing is
+being measured. `cost_profile = "benchmark"` uses `m6i` throughout.
+
+**Storage is a sizing decision.** `gp3`'s 3000 IOPS baseline bottlenecks the
+`database` and `clickhouse` roles well before CPU does. Raise `root_volume_iops`
+for disk-bound work rather than accepting the default silently.
+
+## Which account this builds in
+
+Give the lab its own AWS account. Everything else here is a workaround for not
+having done that: a dedicated account gives separate IAM, separate quotas, a
+separate billing line, and no path to anything that matters — none of which a
+tag convention can promise.
+
+If your organization already exists, adding a member account is free:
+
+```bash
+aws organizations create-account \
+  --email <alias>@example.com \
+  --account-name "opennms-benchmark-lab" \
+  --role-name OrganizationAccountAccessRole
+```
+
+Then add a profile that assumes into it, and point the lab at that profile:
+
+```ini
+# ~/.aws/config
+[profile benchmark-lab]
+role_arn       = arn:aws:iam::<NEW_ACCOUNT_ID>:role/OrganizationAccountAccessRole
+source_profile = default
+region         = us-east-1
+```
+
+```bash
+AWS_PROFILE=benchmark-lab make deploy PROVIDER=aws DEPLOYMENT=baseline
+```
+
+`deploy.sh` prints the resolved identity before provisioning, so the account is
+visible at the point it still matters.
+
+Finally, pin it in `aws.tfvars` so a stray profile cannot undo the separation:
+
+```hcl
+allowed_account_ids = ["<NEW_ACCOUNT_ID>"]
+```
+
+Terraform then refuses to run anywhere else rather than quietly building a lab
+beside production. Left empty, the check is disabled.
+
+## Running under a restricted role
+
+A dedicated account is the real answer. Until there is one, a scoped IAM role
+removes the credentials' ability to damage anything else — which is what stops a
+Terraform bug or a mistyped command, the failure that actually happens.
+
+`docs/aws-iam/` holds the two policy documents. The role allows the EC2, SSM and
+resource-group calls the lab makes, and explicitly denies:
+
+- anything at all inside the production VPC (`ec2:Vpc` condition)
+- destroying any resource not tagged `project = benchmark`
+- `iam:*`, `organizations:*` and `account:*`, so it cannot grant itself more
+
+```bash
+aws iam create-role --role-name benchmark-lab \
+  --assume-role-policy-document file://docs/aws-iam/trust-policy.json
+aws iam put-role-policy --role-name benchmark-lab \
+  --policy-name benchmark-lab-permissions \
+  --policy-document file://docs/aws-iam/benchmark-lab-policy.json
+```
+
+```ini
+# ~/.aws/config
+[profile benchmark-lab]
+role_arn       = arn:aws:iam::<ACCOUNT_ID>:role/benchmark-lab
+source_profile = default
+region         = us-east-1
+```
+
+```bash
+AWS_PROFILE=benchmark-lab make deploy PROVIDER=aws DEPLOYMENT=baseline
+```
+
+`AWS_PROFILE` is **required** to deploy. Without it Terraform would use whichever
+credentials happen to be default, which on a shared account is usually the most
+privileged identity available — the one thing that should not be building a
+disposable lab. `deploy.sh` refuses and lists the profiles it can see.
+
+Destroying only warns. A lab nobody can tear down keeps billing, so being unable
+to remove one is worse than removing it with more authority than needed.
+
+Setting the variable is not by itself proof of anything: `AWS_PROFILE=default`
+satisfies it while still being the unrestricted user. `deploy.sh` also reports
+the resolved identity and says so when it is an IAM user rather than an assumed
+role.
+
+`AWS_ALLOW_DEFAULT_CREDENTIALS=1` bypasses the requirement, for CI or static keys
+supplied by the environment rather than a profile.
+
+Verify it before trusting it — a policy that denies nothing looks identical to
+one that works until the day it matters:
+
+```bash
+AWS_PROFILE=benchmark-lab aws ec2 terminate-instances --dry-run --instance-ids <a-production-instance>
+# UnauthorizedOperation ... with an explicit deny in an identity-based policy
+```
+
+**This stops accidents, not you.** Anyone holding `iam:*` can revoke the
+restriction, so it is a seatbelt rather than a wall. Only a separate account, or
+an SCP someone else controls, makes it a boundary.
+
+## Checking what is deployed
+
+```bash
+make show PROVIDER=aws                        # everything tagged project=benchmark
+make show PROVIDER=aws DEPLOYMENT=baseline    # narrowed to one deployment
+```
+
+Reports Terraform's view and AWS's view separately, then reconciles them. The
+second view is the point: a leftover is by definition something state no longer
+tracks, so `terraform state list` cannot find one. Anything live at AWS with an
+empty state is an interrupted apply, a failed destroy, or something made by
+hand — and instances, NAT gateways and Elastic IPs bill either way.
+
+It queries each EC2 service directly rather than the Resource Groups Tagging
+API, which keeps returning deleted resources for about a day and would report a
+clean teardown as a pile of leftovers.
+
+## Seeing just this lab in the console
+
+Every resource carries `project`, `environment` and `deployment` tags via the
+provider's `default_tags`, and Terraform creates a resource group querying them:
+
+```bash
+terraform -chdir=terraform/aws output -raw console_url
+```
+
+That opens a console view containing this deployment and nothing else. One group
+per deployment, so two labs running at once stay distinct. Resource groups cost
+nothing.
+
+Without applying anything, Tag Editor does the same ad hoc — filter on
+`deployment = <slug>` under **Resource Groups & Tag Editor → Tag Editor**.
+
+For spend rather than inventory, activate `project` and `deployment` as cost
+allocation tags in Billing → Cost Allocation Tags; Cost Explorer can then break
+the bill down per deployment. AWS takes up to 24 hours to start populating them.
+
+## Cost profiles
+
+`cost_profile` picks between measurement-grade infrastructure and the cheapest
+shape that still brings the stack up.
+
+| | `benchmark` | `smoke` (default) |
+|---|---|---|
+| instances | `m6i` fixed-performance | `t3a` burstable |
+| root volumes | per-role, up to 100 GiB | capped at `smoke_max_disk_gb` (20) |
+| spot | refused | allowed via `spot = true` |
+| `baseline` (7 nodes), us-east-1 | ~$1.15/hr | ~$0.28/hr, or ~$0.13/hr on spot |
+
+Rough figures, from list prices that drift — check the calculator before
+budgeting. Instances dominate; the NAT gateway (~$0.045/hr) and EBS are minor
+by comparison, which is why the tier changes instance types rather than
+architecture.
+
+**`smoke` is the default.** Cost is opted into, not out of: the expensive
+mistake is provisioning measurement-grade instances without meaning to, and the
+cheap mistake is a run that has to be repeated.
+
+```bash
+make deploy PROVIDER=aws DEPLOYMENT=baseline                                  # smoke
+make deploy PROVIDER=aws DEPLOYMENT=baseline TF_ARGS="-var cost_profile=benchmark"
+```
+
+**A smoke lab cannot produce valid numbers.** Burstable instances deplete their
+CPU credits partway through a sustained run, so the second half of a
+measurement is not comparable to the first — the failure is silent, and the
+numbers look entirely plausible. Since it is also the default, five things make it hard to miss:
+
+- `deploy.sh` announces the profile *before* provisioning, so it can be acted
+  on rather than regretted, and prints a banner again when the deploy finishes
+- every instance is tagged `cost-profile`
+- every host carries `lab_cost_profile` in the Ansible inventory, so a report or
+  experiment ledger can record which kind of infrastructure it ran on
+- `terraform output cost_profile` states it
+- `spot = true` under `cost_profile = "benchmark"` fails the plan outright: an
+  interruption mid-run yields a partial result that still looks like a result
+
+Use it to prove wiring — that cloud-init lands, the jump host works, the
+simulated network routes, Ansible reaches every node. Then switch to
+`benchmark` before measuring anything.
+
+## The simulated network
+
+`netsim` answers for every address in `10.42.0.0/16`. On a hypervisor that is
+free — it is a private L2 segment nobody validates. A VPC validates the source
+and destination of every packet, so three things have to line up:
+
+1. `ip route add local 10.42.0.0/16 dev lo` on the simulator, so the kernel
+   accepts the whole range without an address per device. An ENI cannot carry
+   ~1000 secondary addresses. This is emitted by `modules/cloud-init`'s
+   `local_routes`, and this provider is its first consumer anywhere in the repo.
+2. A VPC route-table entry sending `10.42.0.0/16` at the simulator's `sim` ENI.
+3. `source_dest_check = false` on that ENI, needed in **both** directions: polls
+   arrive for addresses that are not the instance's own, and traps, syslog and
+   flows leave with a source that is not its own either.
+
+A route-table entry targets exactly one ENI, so **the simulator is capped at one
+node**. The plan fails if a spec declares more. That matches every existing spec
+and the reasoning in `deployments/README.md`: nl6 starts every generator at the
+same `nl6_auto_start_ip`, so a second one duplicates the first rather than
+extending it.
+
+## Unsupported specs
+
+`clickhouse-riptide` uses the `lab` subnet — a physical bridge on the KVM host
+with site-pinned addresses and a route via a named machine on that LAN. There is
+no VPC equivalent, so the plan fails with a message pointing at `PROVIDER=kvm`
+rather than approximating something that does not match the spec.
+
+The other 13 specs are supported.
+
+## Known gaps
+
+- ~~`192.0.2.0/24` as a VPC CIDR is unverified.~~ **Confirmed working**
+  (2026-07-30): AWS accepts the shared supernet, so this provider stays on the
+  same addressing as `kvm` rather than opening a third scheme in #161. The public
+  subnet uses `198.51.100.0/28` (TEST-NET-2) as a secondary VPC CIDR, since the
+  lab supernet fills its whole /24.
+- **`modules/diagram` is skipped.** It takes ~15 hand-maintained `ip_*` inputs a
+  spec-driven root does not have. Making it topology-driven is separate work.
+- **Cost is estimated for `baseline` only.** The other twelve supported specs
+  have no figure yet; `mimir-ha-min` at 19 nodes is the one worth knowing before
+  someone starts it. Tracked in #174.

--- a/terraform/aws/aws.tfvars.example
+++ b/terraform/aws/aws.tfvars.example
@@ -1,0 +1,40 @@
+# AWS-specific variables. Copy to aws.tfvars and edit.
+#
+# Cost warning: unlike the hypervisor providers this bills by the hour.
+# mimir-ha-min is 19 instances. Run `make destroy PROVIDER=aws` when done.
+
+# Refuse to provision into any other account. Strongly recommended once the lab
+# has its own account: it is the difference between a wrong-profile mistake
+# being an error message and being a VPC in your production account.
+# allowed_account_ids = ["123456789012"]
+
+region       = "us-east-1"
+project_name = "benchmark"
+environment  = "dev"
+ssh_key_path = "~/.ssh/id_rsa"
+
+# Every subnet lives in one AZ, because an ENI cannot span availability zones
+# and lab nodes are multi-homed. Leave empty to take the region's first zone.
+# availability_zone = "eu-central-1a"
+
+# cost_profile defaults to "smoke": the cheapest shape that still boots the
+# stack, so cost is opted into rather than out of. smoke uses burstable
+# instances and CANNOT produce valid measurements — wiring tests only.
+# Set "benchmark" when you are measuring something.
+# cost_profile = "benchmark"
+# spot         = false         # ~70% cheaper; refused under the benchmark profile.
+
+# Instance types are deliberately not burstable: a t-class instance depletes
+# its CPU credits partway through a sustained run, which silently invalidates
+# the second half of a measurement.
+# instance_types = {
+#   tiny = "m6i.large", small = "m6i.large", medium = "m6i.xlarge"
+#   large = "m6i.xlarge", xlarge = "m6i.2xlarge"
+# }
+
+# gp3's 3000 IOPS baseline bottlenecks the database and clickhouse roles well
+# before CPU does. Raise it for disk-bound benchmarks.
+# root_volume_iops       = 3000
+# root_volume_throughput = 125
+
+# operator_cidr is supplied by deploy.sh from the caller's public address.

--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -1,0 +1,345 @@
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: Apache-2.0
+
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+data "aws_ssm_parameter" "ubuntu" {
+  name = var.ami_ssm_parameter
+}
+
+# One lookup per distinct instance type in play, so the ENI ceiling is read from
+# AWS rather than assumed. The first real apply failed because t3a.small offers
+# two interfaces and minion takes three -- a constraint that had been verified
+# against m6i and never re-checked when the cheap tier was added.
+data "aws_ec2_instance_type" "selected" {
+  for_each = toset(values(local.instance_types))
+
+  instance_type = each.value
+}
+
+locals {
+  az = var.availability_zone != "" ? var.availability_zone : data.aws_availability_zones.available.names[0]
+
+  name_prefix = "${var.environment}-${var.project_name}"
+
+  # ── deployment spec → aws topology translation ────────────────────────────
+  # Same spec the kvm provider consumes. This provider is spec-driven from the
+  # first commit: it declares no per-host address variables, so it cannot join
+  # the kvm/legacy divergence tracked in #161.
+  spec = yamldecode(file("${path.root}/../../deployments/${var.deployment}/topology.yml"))
+
+  # Spec role → provider role key (identity unless remapped). nl6 runs on netsim.
+  provider_role = {
+    loadgen = "netsim"
+  }
+
+  # Inverted, so errors name the role the author writes in topology.yml.
+  spec_role_for = { for srole, prole in local.provider_role : prole => srole }
+
+  role_shortname = {
+    database   = "db", core = "core", kafka = "kafka", minion = "minion"
+    netsim     = "netsim", monitoring = "mon", elasticsearch = "es"
+    sentinel   = "sentinel", mimir = "mimir", victoriametrics = "vm"
+    clickhouse = "ch", akvorado = "akvorado", rrd = "rrd"
+    rustfs     = "rustfs", riptide = "riptide"
+  }
+
+  subnet_cidr = {
+    mgmt  = var.subnet_mgmt
+    db    = var.subnet_db
+    kafka = var.subnet_kafka
+    sim   = var.subnet_sim
+  }
+
+  # Address allocation matches terraform/kvm exactly: every role gets a
+  # contiguous block of role_block_size addresses in every subnet. Keeping the
+  # two providers on one scheme is the point — a second scheme is how kvm and
+  # azure came to disagree (#161).
+  role_block_size = 4
+  role_block_base = 4
+  role_order = [
+    "database", "core", "kafka", "minion", "monitoring", "netsim",
+    "elasticsearch", "sentinel", "rrd", "mimir", "victoriametrics",
+    "clickhouse", "akvorado", "rustfs", "riptide",
+  ]
+  ip_offset = {
+    for i, role in local.role_order : role => local.role_block_base + i * local.role_block_size
+  }
+
+  # ── cost profile ──────────────────────────────────────────────────────────
+  smoke          = var.cost_profile == "smoke"
+  instance_types = local.smoke ? var.instance_types_smoke : var.instance_types
+
+  nodes = merge([
+    for srole, cfg in local.spec.roles : {
+      for i in range(try(cfg.count, 1)) :
+      "${lookup(local.provider_role, srole, srole)}${try(cfg.count, 1) > 1 ? "-${i}" : ""}" => {
+        prole = lookup(local.provider_role, srole, srole)
+        index = i
+        cfg   = cfg
+      }
+    }
+  ]...)
+
+  # Subnets any role in this spec asks for. `external` is the public subnet;
+  # `lab` has no VPC analogue and is rejected by the precondition below.
+  requested_subnets = distinct(flatten([for key, n in local.nodes : n.cfg.subnets]))
+  vpc_subnets       = [for s in local.requested_subnets : s if contains(keys(local.subnet_cidr), s)]
+  needs_public      = contains(local.requested_subnets, "external")
+
+  # Single source of truth for "what address does node N hold on subnet S",
+  # keyed only by the subnets a node declares. A lookup for an unattached subnet
+  # yields nothing rather than a plausible number — the lesson from #171, where
+  # two encodings of this rule drifted apart.
+  node_address = {
+    for key, n in local.nodes : key => {
+      for subnet in n.cfg.subnets :
+      subnet => try(n.cfg.addresses[subnet][n.index],
+      contains(["external", "lab"], subnet) ? null : cidrhost(local.subnet_cidr[subnet], local.ip_offset[n.prole] + n.index))
+    }
+  }
+
+  nodes_by_prole = {
+    for prole in distinct([for key, n in local.nodes : n.prole]) :
+    prole => sort([for key, n in local.nodes : key if n.prole == prole])
+  }
+
+  # ── the simulated network ─────────────────────────────────────────────────
+  # netsim answers for every address in net_sim_cidr. On a hypervisor that is
+  # free; in a VPC every source and destination is validated, so this address is
+  # needed in TWO places: the guest route on the poller, and the VPC route table
+  # entry targeting netsim's ENI. Derived once so the two cannot disagree.
+  netsim_key         = try(local.nodes_by_prole["netsim"][0], null)
+  netsim_sim_address = try(local.node_address[local.netsim_key]["sim"], null)
+
+  named_routes = {
+    net_sim = { to = var.net_sim_cidr, via = local.netsim_sim_address }
+  }
+
+  topology = {
+    for key, n in local.nodes :
+    key => {
+      # "benchmark" is literal, matching terraform/kvm. Guest hostnames are a
+      # cross-provider contract: deployment overlays reference them directly
+      # (vm-single points at vm-benchmark-01, mimir-ha-min at
+      # rustfs-benchmark-01), so deriving them from var.environment would break
+      # those specs on this provider only. environment names AWS resources and
+      # tags, not guests.
+      name    = "${local.role_shortname[n.prole]}-benchmark-${format("%02d", n.index + 1)}"
+      prole   = n.prole
+      size    = n.cfg.size
+      disk_gb = local.smoke ? min(lookup(var.disk_sizes_gb, n.prole, 30), var.smoke_max_disk_gb) : lookup(var.disk_sizes_gb, n.prole, 30)
+      public  = try(n.cfg.public_ip, false)
+      subnets = n.cfg.subnets
+      # netsim must accept traffic for the whole simulated range without an
+      # address per device: `ip route add local <cidr> dev lo` does that. This
+      # is the first consumer of modules/cloud-init's local_routes.
+      local_routes = n.prole == "netsim" ? [var.net_sim_cidr] : []
+      interfaces = [
+        for si, subnet in n.cfg.subnets : {
+          subnet  = subnet
+          address = local.node_address[key][subnet]
+          # A named route resolving to nothing is dropped; the precondition
+          # below fails the plan and a null next hop would only obscure it.
+          routes = [
+            for r in(try(n.cfg.routes[subnet], null) == null ? [] : [
+              try(local.named_routes[n.cfg.routes[subnet]], n.cfg.routes[subnet])
+            ]) : r
+            if !(contains(keys(local.named_routes), try(tostring(n.cfg.routes[subnet]), "")) && try(r.via, null) == null)
+          ]
+        } if !contains(["external", "lab"], subnet)
+      ]
+    }
+  }
+
+  # hostname -> mgmt address, for /etc/hosts and the Ansible inventory.
+  inv_hosts = {
+    for key, n in local.nodes :
+    local.topology[key].name => {
+      ansible_host = try(local.node_address[key]["mgmt"], "")
+      groups       = try(n.cfg.groups, [])
+      # Derived, not hardcoded: the name follows the position of the sim NIC in
+      # the spec's subnet list, so a spec ordering subnets differently does not
+      # point the generator at the management interface.
+      host_vars = merge(
+        # Carried on every host so anything consuming the inventory — a report,
+        # an experiment ledger — can tell that a run happened on infrastructure
+        # that cannot produce valid numbers.
+        { lab_cost_profile = var.cost_profile },
+        n.prole == "netsim" ? {
+          nl6_net_interface = try("ens${index([for i in local.topology[key].interfaces : i.subnet], "sim") + 5}", "")
+        } : {}
+      )
+    }
+  }
+
+  hosts = { for h, v in local.inv_hosts : h => v.ansible_host }
+
+  jump_node_key  = one([for key, n in local.nodes : key if try(n.cfg.public_ip, false)])
+  jump_host_name = local.jump_node_key != null ? local.topology[local.jump_node_key].name : ""
+
+  onms_stack_children = ["database", "core", "message_broker", "elasticsearch", "minion", "sentinel", "grafana"]
+
+  # ── spec compatibility ────────────────────────────────────────────────────
+  unsupported_lab = [
+    for key, n in local.nodes :
+    "${lookup(local.spec_role_for, n.prole, n.prole)} declares the 'lab' subnet"
+    if contains(n.cfg.subnets, "lab")
+  ]
+
+  # A VPC route table entry targets exactly one ENI, so the simulated network
+  # can only be served by one node. This matches every existing spec and the
+  # reasoning in deployments/README.md: nl6 starts every generator at the same
+  # nl6_auto_start_ip, so a second one duplicates rather than extends.
+  too_many_generators = try(length(local.nodes_by_prole["netsim"]), 0) > 1
+
+  # A public node carries one extra interface in the public subnet.
+  eni_overcommit = [
+    for key, n in local.topology :
+    "${n.name} on ${local.instance_types[n.size]}: needs ${length(n.interfaces) + (n.public ? 1 : 0)} interfaces, type supports ${data.aws_ec2_instance_type.selected[local.instance_types[n.size]].maximum_network_interfaces}"
+    if length(n.interfaces) + (n.public ? 1 : 0) > data.aws_ec2_instance_type.selected[local.instance_types[n.size]].maximum_network_interfaces
+  ]
+
+  unresolved_named_routes = distinct(flatten([
+    for key, n in local.nodes : [
+      for subnet in try(keys(n.cfg.routes), []) :
+      "${lookup(local.spec_role_for, n.prole, n.prole)}.${subnet} -> \"${tostring(n.cfg.routes[subnet])}\""
+      if contains(keys(local.named_routes), try(tostring(n.cfg.routes[subnet]), "")) && local.named_routes[tostring(n.cfg.routes[subnet])].via == null
+    ]
+  ]))
+}
+
+module "network" {
+  source = "./modules/network"
+
+  name_prefix        = local.name_prefix
+  lab_cidr           = var.lab_cidr
+  availability_zone  = local.az
+  subnet_cidrs       = { for s in local.vpc_subnets : s => local.subnet_cidr[s] }
+  needs_public       = local.needs_public
+  operator_cidr      = var.operator_cidr
+  public_subnet_cidr = var.public_subnet_cidr
+  topology           = local.topology
+  net_sim_cidr       = var.net_sim_cidr
+  netsim_node        = local.netsim_key
+}
+
+module "compute" {
+  source = "./modules/compute"
+
+  name_prefix    = local.name_prefix
+  ami_id         = data.aws_ssm_parameter.ubuntu.value
+  admin_user     = var.admin_user
+  ssh_public_key = trimspace(file(pathexpand("${var.ssh_key_path}.pub")))
+  instance_types = local.instance_types
+
+  cost_profile = var.cost_profile
+
+  spot                      = var.spot
+  root_volume_type          = var.root_volume_type
+  root_volume_iops          = var.root_volume_iops
+  root_volume_throughput    = var.root_volume_throughput
+  placement_strategy        = var.placement_group_strategy
+  hosts                     = local.hosts
+  topology                  = local.topology
+  network_interface_ids     = module.network.network_interface_ids
+  jump_public_interface_ids = module.network.jump_public_interface_ids
+  jump_eip_allocation_ids   = module.network.jump_eip_allocation_ids
+}
+
+module "inventory" {
+  source = "../modules/topology-inventory"
+
+  hosts          = local.inv_hosts
+  admin_user     = var.admin_user
+  ssh_key_path   = var.ssh_key_path
+  jump_host      = module.network.jump_host_public_ip
+  jump_host_name = local.jump_host_name
+  parent_groups  = { opennms_stack = local.onms_stack_children }
+}
+
+# The `lab` subnet is a libvirt physical bridge carrying site-pinned addresses
+# and a route via a named machine on that LAN. There is no VPC analogue, and
+# approximating one would silently produce a topology that does not match the
+# spec. Refuse instead. clickhouse-riptide is the only affected deployment.
+resource "terraform_data" "supported_spec" {
+  input = length(local.unsupported_lab)
+
+  lifecycle {
+    precondition {
+      condition     = length(local.unsupported_lab) == 0
+      error_message = "Deployment \"${var.deployment}\" cannot run on AWS: ${join("; ", local.unsupported_lab)}. The 'lab' subnet is a physical bridge on the KVM host with site-specific addresses; it has no VPC equivalent. Use PROVIDER=kvm for this deployment."
+    }
+    precondition {
+      condition     = !local.too_many_generators
+      error_message = "Deployment \"${var.deployment}\" declares more than one load generator. A VPC route table entry for ${var.net_sim_cidr} targets exactly one network interface, so only one generator can serve the simulated network."
+    }
+  }
+}
+
+# A benchmark whose instances can vanish mid-run, or whose CPU allowance
+# depletes partway through, produces numbers that look valid and are not. The
+# smoke profile exists precisely so that trade is explicit; taking it silently
+# under the benchmark profile is what this refuses.
+resource "terraform_data" "measurement_grade" {
+  input = var.cost_profile
+
+  lifecycle {
+    precondition {
+      condition     = !(var.cost_profile == "benchmark" && var.spot)
+      error_message = "cost_profile is 'benchmark' but spot is enabled. A spot interruption partway through a run yields a partial result that still looks like a result. Set cost_profile = \"smoke\" if you are testing the stack rather than measuring it."
+    }
+  }
+}
+
+# A console view scoped to exactly this lab. Every resource the provider creates
+# carries project/environment/deployment via the provider's default_tags, so a
+# tag query is enough -- nothing has to be registered as it is created. Resource
+# groups are free, and one per deployment keeps two concurrent labs distinct.
+resource "aws_resourcegroups_group" "lab" {
+  name = "${local.name_prefix}-${var.deployment}"
+  # Resource Groups restricts descriptions to [\sa-zA-Z0-9_.-]; no colons or commas.
+  description = "OpenNMS benchmark lab - deployment ${var.deployment} - cost profile ${var.cost_profile}"
+
+  resource_query {
+    query = jsonencode({
+      ResourceTypeFilters = ["AWS::AllSupported"]
+      TagFilters = [
+        { Key = "project", Values = [var.project_name] },
+        { Key = "environment", Values = [var.environment] },
+        { Key = "deployment", Values = [var.deployment] },
+      ]
+    })
+  }
+}
+
+# Fails the plan when a node needs more interfaces than its instance type can
+# attach. This surfaced as AttachmentLimitExceeded halfway through the first
+# real apply, after the VPC and every ENI had already been created -- the sort
+# of failure that is cheap at plan time and irritating at apply time.
+resource "terraform_data" "eni_budget" {
+  input = length(local.eni_overcommit)
+
+  lifecycle {
+    precondition {
+      condition     = length(local.eni_overcommit) == 0
+      error_message = "Deployment \"${var.deployment}\" asks for more network interfaces than the chosen instance types can attach:\n  ${join("\n  ", local.eni_overcommit)}\nRaise the type in instance_types (or instance_types_smoke), or reduce the role's subnets."
+    }
+  }
+}
+
+# Fails the plan when a named route's next hop does not resolve — the role is
+# absent, or present without the NIC the route needs. Both would render an
+# address no node holds, which is #171.
+resource "terraform_data" "named_route_targets" {
+  input = length(local.unresolved_named_routes)
+
+  lifecycle {
+    precondition {
+      condition     = length(local.unresolved_named_routes) == 0
+      error_message = "Deployment \"${var.deployment}\" declares named routes whose next hop does not resolve: ${join("; ", local.unresolved_named_routes)}. The route needs a generator with a 'sim' NIC in the same spec."
+    }
+  }
+}

--- a/terraform/aws/modules/compute/main.tf
+++ b/terraform/aws/modules/compute/main.tf
@@ -1,0 +1,133 @@
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: Apache-2.0
+
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+resource "aws_key_pair" "lab" {
+  key_name   = "${var.name_prefix}-key"
+  public_key = var.ssh_public_key
+}
+
+# Packs instances close together for consistent, low inter-node latency. A
+# distributed benchmark measuring replication or flow throughput is otherwise
+# reading placement variance as a result.
+#
+# Benchmark profile only. Cluster placement is not supported by burstable
+# instance types at all, and a wiring test has nothing to gain from latency
+# guarantees -- attaching one to a t3a instance fails the RunInstances call.
+resource "aws_placement_group" "lab" {
+  count = var.cost_profile == "benchmark" ? 1 : 0
+
+  name     = "${var.name_prefix}-pg"
+  strategy = var.placement_strategy
+}
+
+module "cloud_init" {
+  for_each = var.topology
+  source   = "../../../modules/cloud-init"
+
+  vm_name        = each.value.name
+  admin_user     = var.admin_user
+  ssh_public_key = var.ssh_public_key
+  hosts          = var.hosts
+
+  # EC2 delivers only user-data — there is no separate network-config channel
+  # as on libvirt. It does not need one: the address is pinned on the ENI and
+  # arrives over DHCP. Static routes ride in user-data as a systemd unit, the
+  # same path Azure uses.
+  network_config_supported = false
+
+  # netsim answers for every simulated device. `ip route add local <cidr> dev lo`
+  # makes the kernel accept the whole range without an address per device, which
+  # is the only way this works inside a VPC: an ENI cannot carry ~1000 secondary
+  # addresses. This is the first place in the repo that passes local_routes.
+  local_routes = each.value.local_routes
+
+  interfaces = [
+    for idx, iface in each.value.interfaces : {
+      name    = "ens${idx + 5}"
+      address = iface.address
+      prefix  = 26
+      gateway = null
+      routes  = iface.routes
+    }
+  ]
+}
+
+resource "aws_instance" "lab" {
+  for_each = var.topology
+
+  ami                         = var.ami_id
+  instance_type               = var.instance_types[each.value.size]
+  key_name                    = aws_key_pair.lab.key_name
+  placement_group             = var.cost_profile == "benchmark" ? aws_placement_group.lab[0].name : null
+  user_data                   = module.cloud_init[each.key].user_data
+  user_data_replace_on_change = true
+
+  # Interface 0 is the node's first declared subnet; the rest attach in spec
+  # order, which is what the ens5, ens6, … naming above assumes.
+  dynamic "network_interface" {
+    for_each = each.value.interfaces
+    content {
+      network_interface_id = var.network_interface_ids["${each.key}-${network_interface.value.subnet}"]
+      device_index         = network_interface.key
+    }
+  }
+
+  # The public NIC attaches last, so it never shifts the index of a lab NIC and
+  # the predictable ens5/ens6/… names stay aligned with the spec's subnet order.
+  dynamic "network_interface" {
+    for_each = contains(keys(var.jump_public_interface_ids), each.key) ? [1] : []
+    content {
+      network_interface_id = var.jump_public_interface_ids[each.key]
+      device_index         = length(each.value.interfaces)
+    }
+  }
+
+  root_block_device {
+    volume_size = each.value.disk_gb
+    volume_type = var.root_volume_type
+    iops        = var.root_volume_type == "gp3" ? var.root_volume_iops : null
+    throughput  = var.root_volume_type == "gp3" ? var.root_volume_throughput : null
+
+    tags = { Name = "${each.value.name}-root" }
+  }
+
+  # Spot is refused under the benchmark profile: an interruption partway
+  # through a run produces a partial result that still looks like a result.
+  dynamic "instance_market_options" {
+    for_each = var.spot ? [1] : []
+    content {
+      market_type = "spot"
+      spot_options {
+        instance_interruption_behavior = "terminate"
+        spot_instance_type             = "one-time"
+      }
+    }
+  }
+
+  tags = {
+    Name         = each.value.name
+    role         = each.value.prole
+    cost-profile = var.cost_profile
+  }
+}
+
+# The instance must be running before its address can be attached; aws_instance
+# only returns once it is, so depending on it is what makes this correct.
+resource "aws_eip_association" "jump" {
+  for_each = var.jump_eip_allocation_ids
+
+  allocation_id        = each.value
+  network_interface_id = var.jump_public_interface_ids[each.key]
+
+  depends_on = [aws_instance.lab]
+}

--- a/terraform/aws/modules/compute/outputs.tf
+++ b/terraform/aws/modules/compute/outputs.tf
@@ -1,0 +1,10 @@
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: Apache-2.0
+
+output "instance_ids" {
+  value = { for k, i in aws_instance.lab : k => i.id }
+}
+
+output "private_ips" {
+  value = { for k, i in aws_instance.lab : k => i.private_ip }
+}

--- a/terraform/aws/modules/compute/variables.tf
+++ b/terraform/aws/modules/compute/variables.tf
@@ -1,0 +1,54 @@
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: Apache-2.0
+
+variable "name_prefix" { type = string }
+variable "ami_id" { type = string }
+variable "admin_user" { type = string }
+variable "ssh_public_key" { type = string }
+variable "instance_types" { type = map(string) }
+variable "cost_profile" { type = string }
+variable "spot" { type = bool }
+variable "root_volume_type" { type = string }
+variable "root_volume_iops" { type = number }
+variable "root_volume_throughput" { type = number }
+variable "placement_strategy" { type = string }
+
+variable "hosts" {
+  type        = map(string)
+  description = "Hostname -> mgmt address, rendered into /etc/hosts by cloud-init."
+}
+
+variable "network_interface_ids" {
+  type        = map(string)
+  description = "ENI id per '<node>-<subnet>' key, from the network module."
+}
+
+variable "jump_public_interface_ids" {
+  type        = map(string)
+  default     = {}
+  description = "Public-subnet ENI per public node. Attached after the lab NICs so predictable interface naming is unaffected."
+}
+
+variable "jump_eip_allocation_ids" {
+  type        = map(string)
+  default     = {}
+  description = "Elastic IP allocation id per public node, associated here rather than in the network module so it can wait for the instance."
+}
+
+variable "topology" {
+  description = "Rendered topology consumed per node."
+  type = map(object({
+    name         = string
+    prole        = string
+    size         = string
+    disk_gb      = number
+    public       = bool
+    subnets      = list(string)
+    local_routes = list(string)
+    interfaces = list(object({
+      subnet  = string
+      address = string
+      routes  = list(object({ to = string, via = string }))
+    }))
+  }))
+}

--- a/terraform/aws/modules/network/main.tf
+++ b/terraform/aws/modules/network/main.tf
@@ -1,0 +1,270 @@
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: Apache-2.0
+
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+locals {
+  # Flatten the topology into one ENI per (node, subnet). `external` is excluded
+  # upstream: a public node reaches the internet through an EIP on its mgmt ENI
+  # rather than a second interface, because a second default route in the guest
+  # is a routing problem the hypervisor providers avoid with a DHCP NIC.
+  enis = merge([
+    for key, node in var.topology : {
+      for iface in node.interfaces :
+      "${key}-${iface.subnet}" => {
+        node    = key
+        subnet  = iface.subnet
+        address = iface.address
+        primary = iface.subnet == node.subnets[0]
+      }
+    }
+  ]...)
+}
+
+resource "aws_vpc" "lab" {
+  cidr_block           = var.lab_cidr
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = { Name = "${var.name_prefix}-vpc" }
+}
+
+# One subnet per spec subnet, all in a single AZ: an ENI cannot span zones, and
+# nodes here are multi-homed across mgmt/db/kafka/sim.
+resource "aws_subnet" "lab" {
+  for_each = var.subnet_cidrs
+
+  vpc_id            = aws_vpc.lab.id
+  cidr_block        = each.value
+  availability_zone = var.availability_zone
+
+  tags = { Name = "${var.name_prefix}-${each.key}" }
+}
+
+# The lab supernet fills its whole /24, so the public subnet comes from a
+# secondary VPC CIDR rather than a slice of it.
+resource "aws_vpc_ipv4_cidr_block_association" "public" {
+  count = var.needs_public ? 1 : 0
+
+  vpc_id     = aws_vpc.lab.id
+  cidr_block = var.public_subnet_cidr
+}
+
+# The jump host needs a NIC here, not merely an EIP: an Elastic IP only works
+# for an instance whose subnet routes 0.0.0.0/0 at an internet gateway. This
+# subnet is also where the NAT gateway lives.
+resource "aws_subnet" "public" {
+  count = var.needs_public ? 1 : 0
+
+  vpc_id                  = aws_vpc.lab.id
+  cidr_block              = var.public_subnet_cidr
+  availability_zone       = var.availability_zone
+  map_public_ip_on_launch = false
+
+  depends_on = [aws_vpc_ipv4_cidr_block_association.public]
+
+  tags = { Name = "${var.name_prefix}-public" }
+}
+
+resource "aws_internet_gateway" "lab" {
+  count = var.needs_public ? 1 : 0
+
+  vpc_id = aws_vpc.lab.id
+  tags   = { Name = "${var.name_prefix}-igw" }
+}
+
+# Egress for the lab subnets. Without this every node except the jump host has
+# no route off the VPC, and bootstrap fails on the first apt or docker pull:
+# an internet gateway only serves instances that hold a public address, and
+# only the jump host has one.
+resource "aws_eip" "nat" {
+  count = var.needs_public ? 1 : 0
+
+  domain = "vpc"
+  tags   = { Name = "${var.name_prefix}-nat-eip" }
+}
+
+resource "aws_nat_gateway" "lab" {
+  count = var.needs_public ? 1 : 0
+
+  allocation_id = aws_eip.nat[0].id
+  subnet_id     = aws_subnet.public[0].id
+
+  depends_on = [aws_internet_gateway.lab]
+
+  tags = { Name = "${var.name_prefix}-nat" }
+}
+
+# Two tables, because one subnet cannot route 0.0.0.0/0 at both an internet
+# gateway and a NAT gateway: the public subnet needs the former for the jump
+# host's inbound SSH, the lab subnets need the latter for outbound bootstrap.
+resource "aws_route_table" "public" {
+  count = var.needs_public ? 1 : 0
+
+  vpc_id = aws_vpc.lab.id
+  tags   = { Name = "${var.name_prefix}-rt-public" }
+}
+
+resource "aws_route" "internet" {
+  count = var.needs_public ? 1 : 0
+
+  route_table_id         = aws_route_table.public[0].id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.lab[0].id
+}
+
+resource "aws_route_table_association" "public" {
+  count = var.needs_public ? 1 : 0
+
+  subnet_id      = aws_subnet.public[0].id
+  route_table_id = aws_route_table.public[0].id
+}
+
+resource "aws_route_table" "lab" {
+  vpc_id = aws_vpc.lab.id
+  tags   = { Name = "${var.name_prefix}-rt" }
+}
+
+resource "aws_route" "nat" {
+  count = var.needs_public ? 1 : 0
+
+  route_table_id         = aws_route_table.lab.id
+  destination_cidr_block = "0.0.0.0/0"
+  nat_gateway_id         = aws_nat_gateway.lab[0].id
+}
+
+# The simulated-device network. netsim answers for every address in this range
+# via a local route on loopback, but the VPC will not deliver traffic addressed
+# to it — nor accept traffic sourced from it — without both of these:
+#
+#   1. this route, sending the whole range at netsim's sim interface
+#   2. source_dest_check = false on that interface (below)
+#
+# Neither has an analogue in the hypervisor providers, where the simulated
+# network is just a private L2 segment nobody validates.
+resource "aws_route" "net_sim" {
+  # Guarded on the interface existing, not merely on a simulator being present:
+  # a simulator declared without a `sim` NIC would otherwise fail here on an
+  # invalid index rather than on the precondition that explains it.
+  count = var.netsim_node != null && contains(keys(local.enis), "${var.netsim_node}-sim") ? 1 : 0
+
+  route_table_id         = aws_route_table.lab.id
+  destination_cidr_block = var.net_sim_cidr
+  network_interface_id   = aws_network_interface.lab["${var.netsim_node}-sim"].id
+}
+
+resource "aws_route_table_association" "lab" {
+  for_each = aws_subnet.lab
+
+  subnet_id      = each.value.id
+  route_table_id = aws_route_table.lab.id
+}
+
+resource "aws_security_group" "lab" {
+  name        = "${var.name_prefix}-lab"
+  description = "Intra-lab traffic, plus operator SSH to the jump host"
+  vpc_id      = aws_vpc.lab.id
+
+  tags = { Name = "${var.name_prefix}-lab" }
+}
+
+# Everything inside the lab supernet talks freely; this is a benchmark bed, and
+# per-service rules would be a second topology to keep in sync with the spec.
+resource "aws_vpc_security_group_ingress_rule" "intra_lab" {
+  security_group_id = aws_security_group.lab.id
+  cidr_ipv4         = var.lab_cidr
+  ip_protocol       = "-1"
+  description       = "All traffic within the lab supernet"
+}
+
+# Simulated devices source traffic from outside the VPC CIDR, so the collectors
+# must accept it explicitly.
+resource "aws_vpc_security_group_ingress_rule" "net_sim" {
+  security_group_id = aws_security_group.lab.id
+  cidr_ipv4         = var.net_sim_cidr
+  ip_protocol       = "-1"
+  description       = "Traffic sourced from simulated devices"
+}
+
+resource "aws_vpc_security_group_ingress_rule" "operator_ssh" {
+  count = var.needs_public ? 1 : 0
+
+  security_group_id = aws_security_group.lab.id
+  cidr_ipv4         = var.operator_cidr
+  from_port         = 22
+  to_port           = 22
+  ip_protocol       = "tcp"
+  description       = "Operator SSH to the jump host"
+}
+
+# Traefik fronts Grafana, Prometheus, Jaeger and Kafka UI on the monitoring
+# node over TLS. Without this the lab deploys successfully and every dashboard
+# is unreachable. Azure's NSG opens 22 and 443 for the same reason.
+resource "aws_vpc_security_group_ingress_rule" "operator_https" {
+  count = var.needs_public ? 1 : 0
+
+  security_group_id = aws_security_group.lab.id
+  cidr_ipv4         = var.operator_cidr
+  from_port         = 443
+  to_port           = 443
+  ip_protocol       = "tcp"
+  description       = "Operator HTTPS to the lab UIs"
+}
+
+resource "aws_vpc_security_group_egress_rule" "all" {
+  security_group_id = aws_security_group.lab.id
+  cidr_ipv4         = "0.0.0.0/0"
+  ip_protocol       = "-1"
+  description       = "All egress"
+}
+
+# Static addressing comes from the platform: the address is pinned on the ENI
+# and DHCP hands the guest exactly that. This is why network_config_supported
+# is false for this provider — the netplan document is unnecessary.
+resource "aws_network_interface" "lab" {
+  for_each = local.enis
+
+  subnet_id       = aws_subnet.lab[each.value.subnet].id
+  private_ips     = [each.value.address]
+  security_groups = [aws_security_group.lab.id]
+
+  # netsim forwards for addresses that are not its own in both directions, so
+  # the VPC's source/destination validation has to be disabled on its sim NIC.
+  source_dest_check = !(each.value.node == var.netsim_node && each.value.subnet == "sim")
+
+  tags = { Name = "${var.name_prefix}-${each.key}" }
+}
+
+# The jump host gets an extra interface in the public subnet. An EIP attached
+# to a lab-subnet ENI would be inert: that subnet routes 0.0.0.0/0 at the NAT
+# gateway, so inbound SSH would never arrive.
+resource "aws_network_interface" "jump_public" {
+  for_each = { for key, node in var.topology : key => node if node.public }
+
+  subnet_id       = aws_subnet.public[0].id
+  security_groups = [aws_security_group.lab.id]
+
+  tags = { Name = "${var.name_prefix}-${each.key}-public" }
+}
+
+# Allocated here, associated in the compute module. Associating at allocation
+# time attaches the address to an interface whose instance is still pending,
+# which AWS rejects with IncorrectInstanceState -- the association has to wait
+# for the instance to be running, and only the compute module can express that.
+resource "aws_eip" "jump" {
+  for_each = { for key, node in var.topology : key => node if node.public }
+
+  domain = "vpc"
+
+  tags = { Name = "${var.name_prefix}-${each.key}-eip" }
+
+  depends_on = [aws_internet_gateway.lab]
+}

--- a/terraform/aws/modules/network/outputs.tf
+++ b/terraform/aws/modules/network/outputs.tf
@@ -1,0 +1,26 @@
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: Apache-2.0
+
+output "network_interface_ids" {
+  value       = { for k, eni in aws_network_interface.lab : k => eni.id }
+  description = "ENI id per '<node>-<subnet>' key, consumed by the compute module."
+}
+
+output "jump_public_interface_ids" {
+  value       = { for k, eni in aws_network_interface.jump_public : k => eni.id }
+  description = "Public-subnet ENI per public node, attached last so lab NIC ordering is unaffected."
+}
+
+output "jump_eip_allocation_ids" {
+  value       = { for k, e in aws_eip.jump : k => e.allocation_id }
+  description = "Allocation id per public node; the compute module associates these once the instance is running."
+}
+
+output "jump_host_public_ip" {
+  value       = try(values(aws_eip.jump)[0].public_ip, "")
+  description = "Public address of the jump host, or empty when the deployment has none."
+}
+
+output "vpc_id" {
+  value = aws_vpc.lab.id
+}

--- a/terraform/aws/modules/network/variables.tf
+++ b/terraform/aws/modules/network/variables.tf
@@ -1,0 +1,44 @@
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: Apache-2.0
+
+variable "name_prefix" { type = string }
+variable "lab_cidr" { type = string }
+variable "availability_zone" { type = string }
+
+variable "subnet_cidrs" {
+  type        = map(string)
+  description = "Spec subnet name -> CIDR, for the subnets this deployment actually uses."
+}
+
+variable "needs_public" {
+  type        = bool
+  description = "Whether any node is marked public_ip, requiring an internet gateway and an EIP."
+}
+
+variable "operator_cidr" { type = string }
+
+variable "public_subnet_cidr" {
+  type        = string
+  description = "CIDR for the public subnet, added to the VPC as a secondary block. The lab supernet fills its whole /24, so this cannot be a slice of it. Hosts the NAT gateway and the jump host's internet-facing NIC."
+}
+variable "net_sim_cidr" { type = string }
+
+variable "netsim_node" {
+  type        = string
+  default     = null
+  description = "Node key of the simulator, or null when the deployment has none. Its sim interface is the route target for net_sim_cidr and the only one with source/dest checking disabled."
+}
+
+variable "topology" {
+  description = "Rendered topology: node key -> { name, subnets, public, interfaces[{subnet, address, routes}] }."
+  type = map(object({
+    name    = string
+    subnets = list(string)
+    public  = bool
+    interfaces = list(object({
+      subnet  = string
+      address = string
+      routes  = list(object({ to = string, via = string }))
+    }))
+  }))
+}

--- a/terraform/aws/outputs.tf
+++ b/terraform/aws/outputs.tf
@@ -1,0 +1,30 @@
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: Apache-2.0
+
+output "jump_host" {
+  value       = module.network.jump_host_public_ip
+  description = "Public address of the jump host; empty when the deployment declares none."
+}
+
+output "vpc_id" {
+  value = module.network.vpc_id
+}
+
+output "instances" {
+  value       = module.compute.private_ips
+  description = "Node key -> primary private address."
+}
+
+output "console_url" {
+  value       = "https://${var.region}.console.aws.amazon.com/resource-groups/group/${aws_resourcegroups_group.lab.name}?region=${var.region}"
+  description = "Console view scoped to this deployment's resources and nothing else."
+}
+
+output "cost_profile" {
+  value       = var.cost_profile
+  description = "'smoke' means the instances are burstable and cannot produce valid measurements."
+}
+
+output "deployment" {
+  value = var.deployment
+}

--- a/terraform/aws/providers.tf
+++ b/terraform/aws/providers.tf
@@ -1,0 +1,34 @@
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: Apache-2.0
+
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = "~> 2.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+
+  # A lab is cheap to rebuild and a production account is not. Pinning this
+  # means an exported profile for the wrong account fails immediately instead of
+  # provisioning a VPC beside something that matters.
+  allowed_account_ids = length(var.allowed_account_ids) > 0 ? var.allowed_account_ids : null
+
+  default_tags {
+    tags = {
+      project     = var.project_name
+      environment = var.environment
+      deployment  = var.deployment
+      managed-by  = "terraform"
+    }
+  }
+}

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -1,0 +1,165 @@
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: Apache-2.0
+
+# Shared (from lab.tfvars). Only structural values are read here: this provider
+# derives every per-host address from the deployment spec, so the ip_* variables
+# the legacy providers declare are deliberately absent (#161, #174).
+#
+# They live in lab-addresses.tfvars, which deploy.sh does not pass to this
+# provider. Declaring them here to accept the shared file would reintroduce the
+# per-host constants this provider exists to avoid, and tflint would then flag
+# every one as unused.
+variable "lab_cidr" { type = string }
+variable "subnet_db" { type = string }
+variable "subnet_kafka" { type = string }
+variable "subnet_sim" { type = string }
+variable "subnet_mgmt" { type = string }
+variable "net_sim_cidr" { type = string }
+variable "admin_user" { type = string }
+
+# Disk sizes (from disk-sizes.tfvars)
+variable "disk_sizes_gb" {
+  type        = map(number)
+  description = "Provider role -> root volume size in GiB."
+  default     = {}
+}
+
+variable "deployment" {
+  type        = string
+  default     = "baseline"
+  description = "Deployment slug under deployments/; selects the topology spec to provision."
+}
+
+variable "region" {
+  type        = string
+  description = "AWS region. All subnets live in one availability zone within it, because an ENI is bound to a single AZ."
+}
+
+variable "availability_zone" {
+  type        = string
+  default     = ""
+  description = "AZ for every subnet. Empty selects the region's first available zone. A single AZ is deliberate: ENIs cannot span zones, and a benchmark wants consistent inter-node latency anyway."
+}
+
+variable "allowed_account_ids" {
+  type        = list(string)
+  default     = []
+  description = "Account IDs this lab may be provisioned into. Terraform refuses to run anywhere else, which is what stops a stray AWS_PROFILE from building a benchmark bed next to production. Empty disables the check, for anyone without a dedicated account."
+}
+
+variable "project_name" { type = string }
+variable "environment" { type = string }
+
+variable "ssh_key_path" {
+  type        = string
+  description = "Path to the private SSH key; the .pub alongside it is uploaded as the EC2 key pair."
+}
+
+variable "public_subnet_cidr" {
+  type        = string
+  default     = "198.51.100.0/28"
+  description = "Public subnet, added to the VPC as a secondary CIDR because the lab supernet fills its whole /24. Hosts the NAT gateway that gives private nodes their egress, and the jump host's internet-facing NIC. RFC 5737 TEST-NET-2 by default, matching the lab's use of TEST-NET-3."
+}
+
+variable "operator_cidr" {
+  type        = string
+  description = "CIDR permitted to reach the jump host over SSH. deploy.sh supplies the caller's address; never leave this open to the world."
+}
+
+variable "cost_profile" {
+  type = string
+  # Defaults to the cheap tier on purpose. The expensive mistake is provisioning
+  # measurement-grade instances without meaning to; the cheap mistake is a run
+  # that has to be repeated. Cost is opted into, not out of.
+  #
+  # The risk this creates -- a smoke lab mistaken for a benchmark -- is handled
+  # by making the profile impossible to miss rather than by defaulting to spend:
+  # deploy.sh announces it before provisioning and warns at the end, every
+  # instance is tagged, every host carries lab_cost_profile in the inventory,
+  # and `terraform output cost_profile` states it.
+  default     = "smoke"
+  description = "'benchmark' for measurement-grade infrastructure, or 'smoke' for the cheapest shape that still starts the stack. Defaults to 'smoke' so cost is opted into; a smoke lab is for proving wiring, never for producing numbers."
+
+  validation {
+    condition     = contains(["benchmark", "smoke"], var.cost_profile)
+    error_message = "cost_profile must be 'benchmark' or 'smoke'."
+  }
+}
+
+variable "spot" {
+  type        = bool
+  default     = false
+  description = "Request spot capacity. Roughly 70% cheaper, at the cost of interruption mid-run. Sensible for a smoke test, not for a measurement, and refused outright when cost_profile is 'benchmark'."
+}
+
+variable "smoke_max_disk_gb" {
+  type        = number
+  default     = 20
+  description = "Root volume cap under the smoke profile. Ubuntu needs roughly 10 GiB; the benchmark sizes (up to 100 GiB for core and clickhouse) exist to hold data a smoke test never generates."
+}
+
+# ── instance sizing ───────────────────────────────────────────────────────────
+# Deliberately NOT burstable. A t-class instance depletes its CPU credits partway
+# through a sustained run, so the second half of a measurement is not comparable
+# to the first — the lab's whole output is benchmark numbers, and Azure's use of
+# Standard_B2ms/B4ms is a latent measurement bug this provider does not inherit.
+variable "instance_types" {
+  type        = map(string)
+  description = "T-shirt size class -> EC2 instance type. All five classes are in use across the deployment library."
+  default = {
+    tiny   = "m6i.large"
+    small  = "m6i.large"
+    medium = "m6i.xlarge"
+    large  = "m6i.xlarge"
+    xlarge = "m6i.2xlarge"
+  }
+}
+
+# Burstable on purpose here, and ONLY here. Credit depletion makes these
+# useless for measurement, which is exactly why they are confined to the smoke
+# profile: the goal is proving the stack comes up, not timing it. Sizes track
+# the memory floor in the size_map rather than its vCPU counts.
+variable "instance_types_smoke" {
+  type        = map(string)
+  description = "T-shirt size class -> EC2 instance type under the smoke profile."
+  # Nothing below t3a.medium: t3a.small offers only 2 ENIs, and core and minion
+  # both take 3. The saving from a smaller type is not worth a tier that cannot
+  # run half the deployment library.
+  default = {
+    tiny   = "t3a.medium"
+    small  = "t3a.medium"
+    medium = "t3a.medium"
+    large  = "t3a.medium"
+    xlarge = "t3a.large"
+  }
+}
+
+variable "root_volume_type" {
+  type        = string
+  default     = "gp3"
+  description = "EBS volume type for root volumes."
+}
+
+variable "root_volume_iops" {
+  type        = number
+  default     = 3000
+  description = "Provisioned IOPS. gp3's 3000 baseline bottlenecks the database and clickhouse roles well before CPU does; raise it for disk-bound benchmarks rather than accepting the default silently."
+}
+
+variable "root_volume_throughput" {
+  type        = number
+  default     = 125
+  description = "EBS throughput in MiB/s."
+}
+
+variable "placement_group_strategy" {
+  type        = string
+  default     = "cluster"
+  description = "Placement strategy for the benchmark profile. 'cluster' packs instances for consistent low inter-node latency, which a distributed benchmark depends on. No placement group is created under the smoke profile: burstable types do not support cluster placement, and a wiring test does not need latency guarantees."
+}
+
+variable "ami_ssm_parameter" {
+  type        = string
+  default     = "/aws/service/canonical/ubuntu/server/24.04/stable/current/amd64/hvm/ebs-gp3/ami-id"
+  description = "SSM public parameter resolving the Ubuntu 24.04 AMI, so the image is not a hardcoded per-region ID that rots."
+}

--- a/terraform/lab-addresses.tfvars
+++ b/terraform/lab-addresses.tfvars
@@ -1,0 +1,45 @@
+# Per-host addresses for the fixed-topology providers.
+#
+# azure, proxmox and vmware hardcode a seven-role lab and address each host
+# from these values. kvm declares them too, but only to feed the diagram
+# module — it derives the addresses it actually provisions from the deployment
+# spec. aws does not read this file at all.
+#
+# This is the legacy allocation scheme tracked in #161. It is split out so the
+# providers that have moved past it do not receive values they deliberately do
+# not declare, and so that retiring it is a matter of deleting one file rather
+# than picking values out of a shared one.
+
+# Management IPs (subnet-mgmt) — used by Ansible, Prometheus, operator SSH
+ip_database      = "192.0.2.196"
+ip_core          = "192.0.2.197"
+ip_kafka         = "192.0.2.198"
+ip_minion        = "192.0.2.199"
+ip_monitoring    = "192.0.2.200"
+ip_netsim        = "192.0.2.201"
+ip_elasticsearch = "192.0.2.202"
+
+# Internal IPs per subnet
+ip_database_db  = "192.0.2.4"
+ip_core_db      = "192.0.2.5"
+ip_kafka_kafka  = "192.0.2.68"
+ip_core_kafka   = "192.0.2.69"
+ip_minion_kafka = "192.0.2.70"
+ip_minion_sim   = "192.0.2.133"
+ip_netsim_sim   = "192.0.2.134"
+ip_es_core      = "192.0.2.6"
+
+# Next hop for the simulated network. Correct for the fixed-topology providers,
+# whose netsim really is at ip_netsim_sim. kvm derives this instead (#171).
+net_sim_gateway = "192.0.2.134"
+
+# VM names
+vm_names = {
+  database      = "db-benchmark-01"
+  core          = "core-benchmark-01"
+  kafka         = "kafka-benchmark-01"
+  minion        = "minion-benchmark-01"
+  netsim        = "netsim-benchmark-01"
+  monitoring    = "mon-benchmark-01"
+  elasticsearch = "es-benchmark-01"
+}

--- a/terraform/lab.tfvars
+++ b/terraform/lab.tfvars
@@ -1,6 +1,9 @@
-# Shared lab variables — provider-agnostic
+# Shared lab variables — provider-agnostic, read by every provider.
 # These values are load-bearing across Ansible inventory, OpenNMS config,
 # and Prometheus scrape targets. Do not make them per-provider variables.
+#
+# Per-host addresses live in lab-addresses.tfvars, which the spec-driven
+# providers do not read: they derive every address from the deployment spec.
 
 # Network — RFC 5737 TEST-NET-3, non-routable by internet standards
 lab_cidr     = "192.0.2.0/24"
@@ -9,39 +12,8 @@ subnet_kafka = "192.0.2.64/26"
 subnet_sim   = "192.0.2.128/26"
 subnet_mgmt  = "192.0.2.192/26"
 
-# Management IPs (subnet-mgmt) — used by Ansible, Prometheus, operator SSH
-ip_database      = "192.0.2.196"
-ip_core          = "192.0.2.197"
-ip_kafka         = "192.0.2.198"
-ip_minion        = "192.0.2.199"
-ip_monitoring    = "192.0.2.200"
-ip_netsim        = "192.0.2.201"
-ip_elasticsearch = "192.0.2.202"
-
-# Internal IPs per subnet
-ip_database_db  = "192.0.2.4"
-ip_core_db      = "192.0.2.5"
-ip_kafka_kafka  = "192.0.2.68"
-ip_core_kafka   = "192.0.2.69"
-ip_minion_kafka = "192.0.2.70"
-ip_minion_sim   = "192.0.2.133"
-ip_netsim_sim   = "192.0.2.134"
-ip_es_core      = "192.0.2.6"
-
-# SNMP simulation network — routed via netsim VM
-net_sim_cidr    = "10.42.0.0/16"
-net_sim_gateway = "192.0.2.134"
-
-# VM names
-vm_names = {
-  database      = "db-benchmark-01"
-  core          = "core-benchmark-01"
-  kafka         = "kafka-benchmark-01"
-  minion        = "minion-benchmark-01"
-  netsim        = "netsim-benchmark-01"
-  monitoring    = "mon-benchmark-01"
-  elasticsearch = "es-benchmark-01"
-}
+# SNMP simulation network — routed via the netsim node
+net_sim_cidr = "10.42.0.0/16"
 
 # Admin username
 admin_user = "azureuser"


### PR DESCRIPTION
Refs #174. Static verification only — see "Status" below.

Adds `terraform/aws` as a fifth provider, driven directly by `deployments/<slug>/topology.yml`.

## Why spec-driven

Two lineages exist here. `azure`, `proxmox` and `vmware` hardcode seven roles and thread ~50 `ip_*`/`nic_*` variables by hand. `kvm` reads the spec and derives everything.

AWS joining the legacy lineage would be a fourth copy of a shape the repo is migrating away from, and it would inherit #161's divergence. Joining the spec-driven one means it consumes `modules/topology-inventory`, declares **no per-host address variables**, and becomes the second consumer of `topology.yml` — the only real test of whether that spec is genuinely provider-agnostic. Today it has one consumer and "provider-agnostic" is an untested claim.

It shares kvm's role-block allocation deliberately. A second scheme is precisely how kvm and azure came to disagree.

## The simulated network

The one part with no analogue in the existing providers. `netsim` answers for ~1000 devices across `10.42.0.0/16`; on a hypervisor that is a private L2 segment nobody validates, while a VPC checks every source and destination.

```
   minion ── SNMP poll ──▶ 10.42.0.37     ✗ no VPC route for 10.42/16
   netsim ── traps/flows from 10.42.0.37  ✗ source not on the ENI
```

Three things line up:

1. `ip route add local 10.42.0.0/16 dev lo` on the simulator, so the kernel accepts the whole range without an address per device — an ENI cannot carry ~1000 secondary IPs. **This is the first consumer of `modules/cloud-init`'s `local_routes`**, declared and unused in the repo until now.
2. A VPC route-table entry sending the range at the simulator's `sim` ENI.
3. `source_dest_check = false` on that ENI, needed in **both** directions.

A route-table entry targets exactly one ENI, so the simulator is capped at one node and the plan fails if a spec declares more. That matches every existing spec and the reasoning already in `deployments/README.md`.

## Benchmark validity

Instance defaults are `m6i`, **deliberately not burstable**. A `t`-class instance depletes its CPU credits partway through a sustained run, so the second half of a measurement is not comparable to the first. Azure runs `Standard_B2ms`/`B4ms` and has that problem; this does not inherit it.

Storage is an explicit sizing axis rather than a default, because `gp3`'s 3000 IOPS baseline bottlenecks the `database` and `clickhouse` roles well before CPU does. Instances go in a cluster placement group so inter-node latency does not vary between runs.

## Scope

13 of 14 specs supported. `clickhouse-riptide` uses the `lab` subnet — a physical bridge on the KVM host with site-pinned addresses and a route via a named machine — so the plan fails pointing at `PROVIDER=kvm` rather than approximating something that does not match the spec.

Static addressing comes from the platform: the address is pinned on the ENI and DHCP delivers it, so `network_config_supported = false` and the netplan document is unused — the same path azure takes.

## Status: statically verified, never applied

`make fmt`, `make validate` (all five providers), `make validate-aws`, `make tflint-aws`, `make lint-yaml`, `make lint-shell` and `make validate-deployments` all pass. Every supported spec renders through `terraform console` without contacting AWS:

| spec | result |
|---|---|
| `baseline`, `mimir-ha-min` | `via 192.0.2.152`, subnets `mgmt/db/kafka/sim`, public jump host |
| `es-nostore`, `vm-single` | render clean, no generator so no `net_sim` route |
| `clickhouse-riptide` | rejected, naming both `lab` roles |

**No `terraform apply` has been run** — the AWS CLI here has no credentials. This is proven in shape, not behaviour.

## Known gaps

- **`192.0.2.0/24` as a VPC CIDR is unverified.** TEST-NET-1, not RFC1918. AWS permits arbitrary IPv4 CIDRs but this is off the beaten path and is the first thing to confirm before an apply. Keeping the shared supernet is what stops AWS opening a third front in #161.
- `modules/diagram` is skipped — it takes ~15 hand-maintained `ip_*` inputs a spec-driven root does not have.
- No per-spec cost estimate yet. `mimir-ha-min` is 19 instances and this bills by the hour.

`proxmox`, `vmware` and the retired `azure` are untouched.

## Note

The new `.tf` files carry SPDX headers. No existing `.tf` in the repo does — that is the Phase 3c sweep in #167 — but the convention applies to new files and this is the direction that sweep is heading.