### PR TITLE
refactor(terraform/kvm): name resources <environment>-<project_name>-*

### DIFF
--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -109,7 +109,7 @@ These steps are one-time host configuration required before `terraform apply`. T
 
 #### Create the `br0` bridge
 
-The `lab-external` libvirt network uses `mode = "bridge"` and attaches to `br0` on the host. This bridge must exist before Terraform runs — libvirt does not create host bridges, it only attaches to them.
+The external libvirt network (`<environment>-<project_name>-external`, e.g. `dev-benchmark-external`) uses `mode = "bridge"` and attaches to `br0` on the host. This bridge must exist before Terraform runs — libvirt does not create host bridges, it only attaches to them.
 
 **Step 1 — identify your physical uplink:**
 
@@ -264,7 +264,7 @@ Simply run the new experiment's playbook. It reconfigures OpenNMS Core and Minio
 ./deploy.sh --provider kvm --destroy
 ```
 
-This runs `terraform destroy` with the correct tfvars and removes the generated `ansible-inventory.yml`. All VMs, NICs, disks, and network resources are deleted. The libvirt networks (`lab-mgmt`, `lab-db`, etc.) are also removed for KVM.
+This runs `terraform destroy` with the correct tfvars and removes the generated `ansible-inventory.yml`. All VMs, NICs, disks, and network resources are deleted. The libvirt networks (`dev-benchmark-mgmt`, `dev-benchmark-db`, etc. — named `<environment>-<project_name>-<subnet>`) are also removed for KVM.
 
 ## Post-Reboot Checklist
 

--- a/terraform/kvm/kvm.tfvars.example
+++ b/terraform/kvm/kvm.tfvars.example
@@ -1,5 +1,12 @@
 # KVM-specific variables
 libvirt_uri        = "qemu+ssh://root@your-kvm.host/system" # Remote: "qemu+ssh://user@host/system"
+# Resource name prefix is "<environment>-<project_name>", the same scheme
+# terraform/aws uses. These must differ or every name stutters. environment says
+# what the lab is for: "dev" verifies the deployment works, "benchmark" is a run
+# whose numbers are meant to be trusted. Guest hostnames are unaffected — they
+# stay <role>-benchmark-NN on every provider.
+project_name       = "benchmark"
+environment        = "dev"
 storage_pool       = "default"
 ubuntu_cloud_image = "https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img"
 ssh_key_path       = "~/.ssh/id_rsa"

--- a/terraform/kvm/main.tf
+++ b/terraform/kvm/main.tf
@@ -1,4 +1,9 @@
 locals {
+  # Resource name prefix, identical in form to terraform/aws. Guest hostnames
+  # deliberately do NOT use it: they stay <role>-benchmark-NN on every provider
+  # because deployment overlays reference them literally.
+  name_prefix = "${var.environment}-${var.project_name}"
+
   # /etc/hosts map (hostname -> mgmt IP) for cloud-init, derived from the topology
   # below so it matches whatever deployment is selected.
   hosts = { for h, v in local.inv_hosts : h => v.ansible_host }
@@ -239,6 +244,7 @@ module "network" {
   subnet_sim   = var.subnet_sim
   subnet_mgmt  = var.subnet_mgmt
   bridge_name  = var.bridge_name
+  name_prefix  = local.name_prefix
 }
 
 module "compute" {

--- a/terraform/kvm/modules/network/main.tf
+++ b/terraform/kvm/modules/network/main.tf
@@ -11,7 +11,7 @@ terraform {
 # KVM uses 4 isolated bridge networks and one external bridge-backed network.
 
 resource "libvirt_network" "db" {
-  name      = "lab-db"
+  name      = "${var.name_prefix}-db"
   autostart = true
 
   ips = [
@@ -23,7 +23,7 @@ resource "libvirt_network" "db" {
 }
 
 resource "libvirt_network" "kafka" {
-  name      = "lab-kafka"
+  name      = "${var.name_prefix}-kafka"
   autostart = true
 
   ips = [
@@ -35,7 +35,7 @@ resource "libvirt_network" "kafka" {
 }
 
 resource "libvirt_network" "sim" {
-  name      = "lab-sim"
+  name      = "${var.name_prefix}-sim"
   autostart = true
 
   ips = [
@@ -47,7 +47,7 @@ resource "libvirt_network" "sim" {
 }
 
 resource "libvirt_network" "mgmt" {
-  name      = "lab-mgmt"
+  name      = "${var.name_prefix}-mgmt"
   autostart = true
 
   forward = {
@@ -63,7 +63,7 @@ resource "libvirt_network" "mgmt" {
 }
 
 resource "libvirt_network" "external" {
-  name      = "lab-external"
+  name      = "${var.name_prefix}-external"
   autostart = true
 
   forward = {

--- a/terraform/kvm/modules/network/variables.tf
+++ b/terraform/kvm/modules/network/variables.tf
@@ -3,3 +3,4 @@ variable "subnet_kafka" { type = string }
 variable "subnet_sim" { type = string }
 variable "subnet_mgmt" { type = string }
 variable "bridge_name" { type = string }
+variable "name_prefix" { type = string }

--- a/terraform/kvm/variables.tf
+++ b/terraform/kvm/variables.tf
@@ -26,6 +26,13 @@ variable "net_sim_cidr" { type = string }
 # tflint-ignore: terraform_unused_declarations
 variable "net_sim_gateway" { type = string }
 variable "admin_user" { type = string }
+
+# Together these form the resource name prefix, matching terraform/aws. libvirt
+# names are scoped to one hypervisor, so a prefix is not strictly needed here —
+# but a second lab on the same host would collide on lab-mgmt, and having both
+# providers name resources the same way is worth more than the brevity.
+variable "project_name" { type = string }
+variable "environment" { type = string }
 variable "vm_names" {
   type = map(string)
 }


### PR DESCRIPTION
> [!CAUTION]
> **Applying this destroys a running KVM lab.** A libvirt network cannot be renamed in place, so all five are replaced — and the domains attached to them are replaced with them. `deploy.sh` applies with `-auto-approve`, so `make deploy PROVIDER=kvm` would do it without prompting.
>
> Draft until the hypervisor is free. At the time of writing `ch-benchmark-01` and `riptide-benchmark-01` are up on these networks.

Makes `kvm` name resources the way `aws` does.

## The inconsistency

| | kvm (before) | aws |
|---|---|---|
| networks / subnets | `lab-db`, `lab-mgmt`, `lab-sim` | `dev-benchmark-mgmt`, `dev-benchmark-public` |
| other resources | `core-benchmark-01.qcow2` | `dev-benchmark-vpc`, `-igw`, `-nat`, `-rt` |
| `name_prefix` | did not exist | `<environment>-<project_name>` |

Same lab, two schemes. kvm now builds the prefix with the identical expression, so the five networks become `dev-benchmark-db`, `dev-benchmark-mgmt` and so on.

## Beyond consistency

The fixed names are a real limitation: two labs on one hypervisor collide on `lab-mgmt`. Not a problem today — one hypervisor, one lab — but it is exactly the collision a prefix exists to prevent, and it would surface as a confusing libvirt error rather than as anything naming the cause.

## Guest hostnames are deliberately excluded

On **both** providers, guests stay `<role>-benchmark-NN` and do not take the prefix.

That is not an oversight. Deployment overlays reference them literally — `deployments/vm-single/opennms-lab-vars.yml` points at `vm-benchmark-01`, `mimir-ha-min` at `rustfs-benchmark-01`, `mimir-single` at `mimir-benchmark-01`. Deriving guest names from `environment` would rename the hosts out from under four specs and leave those services pointing at machines that do not exist. `baseline` hardcodes no hostnames, so it would keep working and the breakage would only appear later, as a service unable to reach its backend.

The prefix names provider resources. A literal names guests. Verified both still render correctly.

## Verification

```
prefix "dev-benchmark"
guests core-benchmark-01, db-benchmark-01, es-benchmark-01, kafka-benchmark-01,
       minion-benchmark-01, mon-benchmark-01, netsim-benchmark-01
```

`make fmt`, `make validate-kvm`, `make tflint-kvm` and `make lint-yaml` pass. `docs/deployment-guide.md` updated where it named `lab-external` and `lab-mgmt`.

## Before merging

1. Confirm no KVM lab is in use.
2. `make destroy PROVIDER=kvm` first, or accept that the next deploy rebuilds everything.
3. `project_name` and `environment` are now required in `kvm.tfvars` — `kvm.tfvars.example` carries both, but an existing local `kvm.tfvars` needs them added or Terraform will prompt.

That last point is the one most likely to catch someone: the variables have no defaults, by design, so the prefix is always deliberate.

Refs #161.