### PR TITLE
fix: make `make plan PROVIDER=aws` actually work

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,8 +74,14 @@ show: check-provider ## Show deployed resources for PROVIDER, and any leftovers
 	./show.sh --provider $(PROVIDER) $(_dep_flag)
 
 .PHONY: plan
+# aws only: terraform cannot read the token cache `aws login` writes, so without
+# this the target fails on credentials even when the CLI works. deploy.sh does
+# the same thing; `make plan` bypasses deploy.sh and so needs its own.
+_aws_creds = $(if $(filter aws,$(PROVIDER)),eval "$$(aws configure export-credentials --format env 2>/dev/null)"; unset AWS_PROFILE;,)
+
 plan: check-provider ## terraform plan for PROVIDER (kvm: DEPLOYMENT=<slug>)
 	terraform -chdir=terraform/$(PROVIDER) init -input=false $(if $(filter kvm,$(PROVIDER)),-upgrade) >/dev/null
+	$(_aws_creds) \
 	terraform -chdir=terraform/$(PROVIDER) plan -input=false \
 	  -var-file=../lab.tfvars \
 	  $(if $(filter-out aws,$(PROVIDER)),-var-file=../lab-addresses.tfvars) \

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -62,8 +62,16 @@ variable "public_subnet_cidr" {
 }
 
 variable "operator_cidr" {
-  type        = string
-  description = "CIDR permitted to reach the jump host over SSH. deploy.sh supplies the caller's address; never leave this open to the world."
+  type = string
+  # Fail closed. deploy.sh detects the caller's address and passes it, and falls
+  # back to this same value when detection fails, so a real deploy is unaffected.
+  # The default exists so `make plan` works: it bypasses deploy.sh and therefore
+  # has nothing to detect with, which made planning the provider impossible.
+  #
+  # 0.0.0.0/32 is a single unroutable address, so an unset value yields a lab
+  # nobody can SSH to rather than one open to the world.
+  default     = "0.0.0.0/32"
+  description = "CIDR permitted to reach the jump host over SSH and HTTPS. deploy.sh supplies the caller's address; the default is deliberately unreachable."
 }
 
 variable "cost_profile" {


### PR DESCRIPTION
Found at step 1 of the AWS end-to-end runbook. `make plan PROVIDER=aws` had never been run — every check so far went through `terraform` directly or through `deploy.sh`.

It failed twice over, both because it bypasses `deploy.sh` and inherits none of its setup.

**1. `operator_cidr` had no default**, so planning stopped before reaching AWS:

```
Error: No value for required variable
  on variables.tf line 64
```

It now defaults to `0.0.0.0/32` — a single unroutable address, and the same value `deploy.sh` already falls back to when IP detection fails. A real deploy is unaffected, since `deploy.sh` always passes the detected address. An unset value now yields a lab nobody can reach rather than one open to the world.

**2. Then it failed on credentials**, for the reason already solved in `deploy.sh`: Terraform cannot read the token cache `aws login` writes. The plan recipe now resolves them the same way, scoped to `aws`.

## Verification

```
make plan PROVIDER=aws DEPLOYMENT=baseline   →  Plan: 58 to add, 0 to change, 0 to destroy.
```

`make -n plan PROVIDER=kvm` shows no credential export; `PROVIDER=aws` shows one. `fmt`, `validate-aws`, `tflint-aws`, `lint-shell` and `validate-topology` all pass.

## Note

`azure` declares `operator_cidr` without a default too and has the same gap, but it is retired and its credentials have expired, so it is left alone.