### PR TITLE
fix: size the OpenNMS heap from the machine, not the spec

### DIFF
--- a/opennms-lab-vars.yml
+++ b/opennms-lab-vars.yml
@@ -112,9 +112,20 @@ kafka_server_properties:
 # opennms_properties_timeseries:
 #   org.opennms.timeseries.strategy: osgi
 
+# Heap follows the machine, not the spec's nominal size. A fixed 8192 was sized
+# for an xlarge core (16 GB) and is exactly the whole machine on anything
+# smaller, so the JVM cannot commit it and OpenNMS dies at startup with
+#   Native memory allocation (mmap) failed to map 8589934592 bytes
+# That has now happened twice: on mimir-ha-min, whose core is medium, and on the
+# AWS smoke tier, where xlarge maps to an 8 GB instance. Both were the same
+# assumption — that a t-shirt size implies a memory size — being true on one
+# provider and silently false on another.
+#
+# Half of physical memory, capped at the previous 8192 so a 16 GB core renders
+# exactly what it did before and existing benchmark numbers stay comparable.
 opennms_jvm_conf:
-  JAVA_HEAP_SIZE: 8192
-  JAVA_INITIAL_HEAP_SIZE: 8192
+  JAVA_HEAP_SIZE: "{{ [ansible_memtotal_mb | int // 2, 8192] | min }}"
+  JAVA_INITIAL_HEAP_SIZE: "{{ [ansible_memtotal_mb | int // 2, 8192] | min }}"
   # Raw value only — opennms.conf.j2 wraps each opennms_jvm_conf value in shell
   # quotes itself. Pre-quoting here produced ADDITIONAL_MANAGER_OPTIONS=""..."",
   # so `install -dis` passed the literal token "-XX:+UseG1GC to java as a class.


### PR DESCRIPTION
Found during the first end-to-end AWS deploy. Steps 1–3 passed; step 4 failed starting OpenNMS on `core`.

```
os::commit_memory(0x0000000600000000, 8589934592, 0) failed; error='Not enough space'
Native memory allocation (mmap) failed to map 8589934592 bytes
```

An 8 GiB heap on a machine with 7840 MB total.

## Cause

`JAVA_HEAP_SIZE` was pinned at `8192`, sized for an `xlarge` core with 16 GB. The AWS smoke tier maps `xlarge` to a `t3a.large` — 8 GB — so the heap became the whole machine.

**This is the second time.** `deployments/mimir-ha-min/opennms-lab-vars.yml` already carries a hand-written override quoting the identical error, because its core is `medium`. Same assumption both times: that a t-shirt size implies a memory size. True on kvm, silently false elsewhere.

## Fix

Half of physical memory, capped at the previous `8192`:

```yaml
JAVA_HEAP_SIZE: "{{ [ansible_memtotal_mb | int // 2, 8192] | min }}"
```

| machine | heap |
|---|---|
| 16384 MB (kvm `xlarge`) | **8192 — unchanged** |
| 8192 MB | 4096 |
| 7840 MB (AWS smoke core) | 3920 |
| 2048 MB (`tiny`) | 1024 |

The cap matters: a 16 GB core renders exactly what it did before, so existing benchmark numbers stay comparable. Integer division rather than a float multiply, since the value is quoted into a shell config file and rounding has no business there.

## Note

`mimir-ha-min`'s override is now redundant — its medium core would derive 4096 rather than the 2048 it pins. Left in place deliberately: overlays layer after the root vars so it still wins, and changing it would move a bed that may have recorded numbers. Worth revisiting separately.