### PR TITLE
fix: give OpenNMS 60% of memory rather than half

### DIFF
--- a/opennms-lab-vars.yml
+++ b/opennms-lab-vars.yml
@@ -121,11 +121,14 @@ kafka_server_properties:
 # assumption — that a t-shirt size implies a memory size — being true on one
 # provider and silently false on another.
 #
-# Half of physical memory, capped at the previous 8192 so a 16 GB core renders
+# 60% of physical memory, capped at the previous 8192 so a 16 GB core renders
 # exactly what it did before and existing benchmark numbers stay comparable.
+# Integer arithmetic (* 6 // 10) rather than a float multiply: the value is
+# quoted straight into a shell config file, where a rounding artefact has no
+# business appearing.
 opennms_jvm_conf:
-  JAVA_HEAP_SIZE: "{{ [ansible_memtotal_mb | int // 2, 8192] | min }}"
-  JAVA_INITIAL_HEAP_SIZE: "{{ [ansible_memtotal_mb | int // 2, 8192] | min }}"
+  JAVA_HEAP_SIZE: "{{ [ansible_memtotal_mb | int * 6 // 10, 8192] | min }}"
+  JAVA_INITIAL_HEAP_SIZE: "{{ [ansible_memtotal_mb | int * 6 // 10, 8192] | min }}"
   # Raw value only — opennms.conf.j2 wraps each opennms_jvm_conf value in shell
   # quotes itself. Pre-quoting here produced ADDITIONAL_MANAGER_OPTIONS=""..."",
   # so `install -dis` passed the literal token "-XX:+UseG1GC to java as a class.


### PR DESCRIPTION
Follow-up to #179, which derived the heap from physical memory at 50%. Raises it to 60%.

| machine | 50% (before) | 60% (now) | left for OS + off-heap |
|---|---|---|---|
| 16384 MB (kvm `xlarge`) | 8192 | **8192 — unchanged** | 8192 |
| 8192 MB | 4096 | 4915 | 3277 |
| 7840 MB (AWS smoke core) | 3920 | 4704 | 3136 |
| 2048 MB (`tiny`) | 1024 | 1228 | 820 |

A 16 GB core is unchanged because the 8192 cap still binds — 60% would ask for 9830. That was the point of the cap: kvm renders exactly what it always has, so existing benchmark numbers stay comparable.

Integer arithmetic (`* 6 // 10`) rather than a float multiply, for the same reason as #179 — the value is quoted straight into a shell config file and a rounding artefact has no business appearing there.

The 820 MB left at `tiny` is tight, but `tiny` is documented as "enough to start a service, not enough to measure one".