### PR TITLE
docs(terraform/aws): say which profile to re-authenticate against

### DIFF
--- a/terraform/aws/README.md
+++ b/terraform/aws/README.md
@@ -144,6 +144,37 @@ region         = us-east-1
 AWS_PROFILE=benchmark-lab make deploy PROVIDER=aws DEPLOYMENT=baseline
 ```
 
+### Re-authenticating
+
+`benchmark-lab` names a role, not a credential source. It holds no credentials of
+its own and assumes into the role using `source_profile`, so sign in against
+**that** profile, not this one:
+
+```bash
+AWS_PROFILE=default aws login          # or: unset AWS_PROFILE && aws login
+export AWS_PROFILE=benchmark-lab
+```
+
+Running `aws login` with `AWS_PROFILE=benchmark-lab` selected fails with:
+
+```
+Profile 'benchmark-lab' is already configured with Assume Role credentials.
+```
+
+which does not hint that `default` is the one to log into.
+
+Sessions are short — a few hours — so this comes up whenever one lapses
+mid-work. Confirm the whole chain afterwards, since it proves both the login and
+the role assumption:
+
+```bash
+aws sts get-caller-identity --query Arn --output text
+# arn:aws:sts::<ACCOUNT_ID>:assumed-role/benchmark-lab/benchmark-lab
+```
+
+If that returns a `user/...` ARN, `AWS_PROFILE` was not re-set and `deploy.sh`
+will refuse to deploy.
+
 `AWS_PROFILE` is **required** to deploy. Without it Terraform would use whichever
 credentials happen to be default, which on a shared account is usually the most
 privileged identity available — the one thing that should not be building a


### PR DESCRIPTION
Hit while resuming the end-to-end AWS run after a session expired.

`benchmark-lab` names a role, not a credential source — it holds no credentials of its own and assumes into the role via `source_profile`. Running `aws login` with it selected fails:

```
Profile 'benchmark-lab' is already configured with Assume Role credentials.
```

The message doesn't hint that `default` is the profile to log into.

Sessions last a few hours, so this surfaces the first time one lapses mid-work — and the restricted-role setup this README recommends is exactly what puts people in that position. Adds:

```bash
AWS_PROFILE=default aws login          # or: unset AWS_PROFILE && aws login
export AWS_PROFILE=benchmark-lab
```

plus the identity check, which is worth doing because it proves both the login *and* the role assumption in one command:

```bash
aws sts get-caller-identity --query Arn --output text
# arn:aws:sts::<ACCOUNT_ID>:assumed-role/benchmark-lab/benchmark-lab
```

and notes that a `user/...` ARN means `AWS_PROFILE` wasn't re-set, in which case `deploy.sh` refuses to deploy anyway.

Docs only.