### PR TITLE
fix(terraform/aws): route the jump host's replies out its public NIC

### DIFF
--- a/assets/ck1m.drawio
+++ b/assets/ck1m.drawio
@@ -1,0 +1,271 @@
+<mxfile host="app.diagrams.net" modified="2026-03-31T00:00:00.000Z" agent="Claude Code" version="21.0.0" type="device">
+  <diagram name="Network Layout" id="net-layout">
+    <mxGraphModel dx="1600" dy="800" grid="0" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="0" pageScale="1" pageWidth="1654" pageHeight="1169" math="0" shadow="0">
+      <root>
+        <mxCell id="0" />
+        <mxCell id="1" parent="0" />
+
+        <!-- ═══════════════════════════════════════════════════════════════ -->
+        <!-- VMs                                                             -->
+        <!-- ═══════════════════════════════════════════════════════════════ -->
+
+        <mxCell id="vm_mon" value="mon-benchmark-01"
+          style="rounded=1;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;fontStyle=1;fontSize=18;"
+          vertex="1" parent="1">
+          <mxGeometry x="655" y="20" width="190" height="40" as="geometry" />
+        </mxCell>
+
+        <mxCell id="vm_kafka" value="kafka-benchmark-01"
+          style="rounded=1;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;fontStyle=1;fontSize=18;"
+          vertex="1" parent="1">
+          <mxGeometry x="655" y="230" width="190" height="40" as="geometry" />
+        </mxCell>
+
+        <mxCell id="vm_pgsql" value="db-benchmark-01"
+          style="rounded=1;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontStyle=1;fontSize=18;"
+          vertex="1" parent="1">
+          <mxGeometry x="10" y="480" width="190" height="40" as="geometry" />
+        </mxCell>
+
+        <mxCell id="vm_es" value="es-benchmark-01"
+          style="rounded=1;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontStyle=1;fontSize=18;"
+          vertex="1" parent="1">
+          <mxGeometry x="195" y="480" width="190" height="40" as="geometry" />
+        </mxCell>
+
+        <mxCell id="vm_core" value="core-benchmark-01"
+          style="rounded=1;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontStyle=1;fontSize=18;"
+          vertex="1" parent="1">
+          <mxGeometry x="420" y="480" width="190" height="40" as="geometry" />
+        </mxCell>
+
+        <mxCell id="vm_minion" value="minion-benchmark-01"
+          style="rounded=1;whiteSpace=wrap;html=1;fillColor=#d5e8d4;strokeColor=#82b366;fontStyle=1;fontSize=18;"
+          vertex="1" parent="1">
+          <mxGeometry x="850" y="480" width="190" height="40" as="geometry" />
+        </mxCell>
+
+        <mxCell id="vm_netsim" value="netsim-benchmark-01"
+          style="rounded=1;whiteSpace=wrap;html=1;fillColor=#d5e8d4;strokeColor=#82b366;fontStyle=1;fontSize=18;"
+          vertex="1" parent="1">
+          <mxGeometry x="1070" y="480" width="190" height="40" as="geometry" />
+        </mxCell>
+
+        <!-- ═══════════════════════════════════════════════════════════════ -->
+        <!-- Subnet buses                                                    -->
+        <!-- ═══════════════════════════════════════════════════════════════ -->
+
+        <!-- Management: 192.0.2.192/26 (orange) — full width -->
+        <mxCell id="bus_mgmt" value="192.0.2.192/26"
+          style="endArrow=none;dashed=1;strokeColor=#E4540C;strokeWidth=2;fillColor=none;
+                 fontColor=#E4540C;fontStyle=1;fontSize=16;align=left;verticalAlign=bottom;"
+          edge="1" parent="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="40"   y="160" as="sourcePoint" />
+            <mxPoint x="1420" y="160" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+
+        <!-- DB subnet: 192.0.2.0/26 (blue) — PostgreSQL ↔ Elasticsearch ↔ Core -->
+        <mxCell id="bus_db" value="192.0.2.0/26"
+          style="endArrow=none;dashed=1;strokeColor=#0063AF;strokeWidth=2;fillColor=none;
+                 fontColor=#0063AF;fontStyle=1;fontSize=16;align=left;verticalAlign=bottom;"
+          edge="1" parent="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="40"  y="370" as="sourcePoint" />
+            <mxPoint x="600" y="370" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+
+        <!-- Kafka subnet: 192.0.2.64/26 (purple) — Core ↔ Kafka ↔ Minion -->
+        <mxCell id="bus_kafka_net" value="192.0.2.64/26"
+          style="endArrow=none;dashed=1;strokeColor=#7B00A0;strokeWidth=2;fillColor=none;
+                 fontColor=#7B00A0;fontStyle=1;fontSize=16;align=left;verticalAlign=bottom;"
+          edge="1" parent="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="640"  y="370" as="sourcePoint" />
+            <mxPoint x="1020" y="370" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+
+        <!-- Simulation subnet: 192.0.2.128/26 (green) — Minion ↔ SNMP Simulator -->
+        <mxCell id="bus_sim" value="192.0.2.128/26"
+          style="endArrow=none;dashed=1;strokeColor=#008A00;strokeWidth=2;fillColor=none;
+                 fontColor=#008A00;fontStyle=1;fontSize=16;align=left;verticalAlign=bottom;"
+          edge="1" parent="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="1060" y="370" as="sourcePoint" />
+            <mxPoint x="1320" y="370" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+
+        <!-- ═══════════════════════════════════════════════════════════════ -->
+        <!-- Management connections (orange)                                 -->
+        <!-- ═══════════════════════════════════════════════════════════════ -->
+
+        <!-- Monitoring → management  (exits bottom, ens0) -->
+        <mxCell id="e_mon_mgmt" value="ens0&#xa;192.0.2.200"
+          style="endArrow=none;strokeColor=#E4540C;exitX=0.5;exitY=1;exitDx=0;exitDy=0;
+                 fontSize=13;fontColor=#E4540C;align=right;"
+          edge="1" source="vm_mon" parent="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="750" y="160" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+
+        <!-- PostgreSQL → management  (ens1) -->
+        <mxCell id="e_pgsql_mgmt" value="ens1&#xa;192.0.2.196"
+          style="endArrow=none;strokeColor=#E4540C;exitX=0.5;exitY=0;exitDx=0;exitDy=0;
+                 fontSize=13;fontColor=#E4540C;align=right;"
+          edge="1" source="vm_pgsql" parent="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="105" y="160" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+
+        <!-- Elasticsearch → management  (ens1) -->
+        <mxCell id="e_es_mgmt" value="ens1&#xa;192.0.2.202"
+          style="endArrow=none;strokeColor=#E4540C;exitX=0.5;exitY=0;exitDx=0;exitDy=0;
+                 fontSize=13;fontColor=#E4540C;align=right;"
+          edge="1" source="vm_es" parent="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="290" y="160" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+
+        <!-- Core → management  (ens1) -->
+        <mxCell id="e_core_mgmt" value="ens1&#xa;192.0.2.197"
+          style="endArrow=none;strokeColor=#E4540C;exitX=0.5;exitY=0;exitDx=0;exitDy=0;
+                 fontSize=13;fontColor=#E4540C;align=right;"
+          edge="1" source="vm_core" parent="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="515" y="160" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+
+        <!-- Kafka VM → management  (exits top, ens1) -->
+        <mxCell id="e_kafka_mgmt" value="ens1&#xa;192.0.2.198"
+          style="endArrow=none;strokeColor=#E4540C;exitX=0.5;exitY=0;exitDx=0;exitDy=0;
+                 fontSize=13;fontColor=#E4540C;align=right;"
+          edge="1" source="vm_kafka" parent="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="750" y="160" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+
+        <!-- Minion → management  (ens1) -->
+        <mxCell id="e_minion_mgmt" value="ens1&#xa;192.0.2.199"
+          style="endArrow=none;strokeColor=#E4540C;exitX=0.5;exitY=0;exitDx=0;exitDy=0;
+                 fontSize=13;fontColor=#E4540C;align=right;"
+          edge="1" source="vm_minion" parent="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="945" y="160" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+
+        <!-- SNMP Simulator → management  (ens1) -->
+        <mxCell id="e_netsim_mgmt" value="ens1&#xa;192.0.2.201"
+          style="endArrow=none;strokeColor=#E4540C;exitX=0.5;exitY=0;exitDx=0;exitDy=0;
+                 fontSize=13;fontColor=#E4540C;align=right;"
+          edge="1" source="vm_netsim" parent="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="1165" y="160" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+
+        <!-- ═══════════════════════════════════════════════════════════════ -->
+        <!-- DB subnet connections (blue)                                    -->
+        <!-- ═══════════════════════════════════════════════════════════════ -->
+
+        <!-- PostgreSQL → DB subnet  (ens0) -->
+        <mxCell id="e_pgsql_db" value="ens0&#xa;192.0.2.4"
+          style="endArrow=none;strokeColor=#0063AF;exitX=0.4;exitY=0;exitDx=0;exitDy=0;
+                 fontSize=13;fontColor=#0063AF;align=right;"
+          edge="1" source="vm_pgsql" parent="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="93" y="370" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+
+        <!-- Elasticsearch → DB subnet  (ens0) -->
+        <mxCell id="e_es_db" value="ens0&#xa;192.0.2.6"
+          style="endArrow=none;strokeColor=#0063AF;exitX=0.4;exitY=0;exitDx=0;exitDy=0;
+                 fontSize=13;fontColor=#0063AF;align=right;"
+          edge="1" source="vm_es" parent="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="277" y="370" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+
+        <!-- Core → DB subnet  (ens2, exits upper-left) -->
+        <mxCell id="e_core_db" value="ens2&#xa;192.0.2.5"
+          style="endArrow=none;strokeColor=#0063AF;exitX=0.2;exitY=0;exitDx=0;exitDy=0;
+                 fontSize=13;fontColor=#0063AF;align=right;"
+          edge="1" source="vm_core" parent="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="476" y="370" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+
+        <!-- ═══════════════════════════════════════════════════════════════ -->
+        <!-- Kafka subnet connections (purple)                               -->
+        <!-- ═══════════════════════════════════════════════════════════════ -->
+
+        <!-- Core → Kafka subnet  (ens0, exits upper-right) -->
+        <mxCell id="e_core_kafka" value="ens0&#xa;192.0.2.69"
+          style="endArrow=none;strokeColor=#7B00A0;exitX=0.8;exitY=0;exitDx=0;exitDy=0;
+                 fontSize=13;fontColor=#7B00A0;align=left;"
+          edge="1" source="vm_core" parent="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="554" y="370" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+
+        <!-- Kafka VM → Kafka subnet  (exits bottom, ens0) -->
+        <mxCell id="e_kafka_net" value="ens0&#xa;192.0.2.68"
+          style="endArrow=none;strokeColor=#7B00A0;exitX=0.5;exitY=1;exitDx=0;exitDy=0;
+                 fontSize=13;fontColor=#7B00A0;align=right;"
+          edge="1" source="vm_kafka" parent="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="750" y="370" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+
+        <!-- Minion → Kafka subnet  (ens2, exits upper-left) -->
+        <mxCell id="e_minion_kafka" value="ens2&#xa;192.0.2.70"
+          style="endArrow=none;strokeColor=#7B00A0;exitX=0.2;exitY=0;exitDx=0;exitDy=0;
+                 fontSize=13;fontColor=#7B00A0;align=right;"
+          edge="1" source="vm_minion" parent="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="906" y="370" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+
+        <!-- ═══════════════════════════════════════════════════════════════ -->
+        <!-- Simulation subnet connections (green)                           -->
+        <!-- ═══════════════════════════════════════════════════════════════ -->
+
+        <!-- Minion → Sim subnet  (ens0, exits upper-right) -->
+        <mxCell id="e_minion_sim" value="ens0&#xa;192.0.2.133"
+          style="endArrow=none;strokeColor=#008A00;exitX=0.8;exitY=0;exitDx=0;exitDy=0;
+                 fontSize=13;fontColor=#008A00;align=left;"
+          edge="1" source="vm_minion" parent="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="984" y="370" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+
+        <!-- SNMP Simulator → Sim subnet  (ens0) -->
+        <mxCell id="e_netsim_sim" value="ens0&#xa;192.0.2.134"
+          style="endArrow=none;strokeColor=#008A00;exitX=0.5;exitY=0;exitDx=0;exitDy=0;
+                 fontSize=13;fontColor=#008A00;align=right;"
+          edge="1" source="vm_netsim" parent="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="1165" y="370" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>

--- a/assets/ck1m.svg
+++ b/assets/ck1m.svg
@@ -1,0 +1,139 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1460 560">
+  <rect width="1460" height="560" fill="white"/>
+
+  <!-- ═══════════════════════════════════════════════════════════════════ -->
+  <!-- Connection lines — drawn before VM boxes so boxes cover endpoints  -->
+  <!-- ═══════════════════════════════════════════════════════════════════ -->
+
+  <!-- Management connections (orange) -->
+  <line x1="750"  y1="60"  x2="750"  y2="160" stroke="#E4540C" stroke-width="1.5"/>
+  <line x1="105"  y1="480" x2="105"  y2="160" stroke="#E4540C" stroke-width="1.5"/>
+  <line x1="290"  y1="480" x2="290"  y2="160" stroke="#E4540C" stroke-width="1.5"/>
+  <line x1="515"  y1="480" x2="515"  y2="160" stroke="#E4540C" stroke-width="1.5"/>
+  <line x1="750"  y1="230" x2="750"  y2="160" stroke="#E4540C" stroke-width="1.5"/>
+  <line x1="945"  y1="480" x2="945"  y2="160" stroke="#E4540C" stroke-width="1.5"/>
+  <line x1="1165" y1="480" x2="1165" y2="160" stroke="#E4540C" stroke-width="1.5"/>
+
+  <!-- DB subnet connections (blue) -->
+  <line x1="93"  y1="480" x2="93"  y2="370" stroke="#0063AF" stroke-width="1.5"/>
+  <line x1="277" y1="480" x2="277" y2="370" stroke="#0063AF" stroke-width="1.5"/>
+  <line x1="476" y1="480" x2="476" y2="370" stroke="#0063AF" stroke-width="1.5"/>
+
+  <!-- Kafka subnet connections (purple) -->
+  <line x1="554" y1="480" x2="554" y2="370" stroke="#7B00A0" stroke-width="1.5"/>
+  <line x1="750" y1="270" x2="750" y2="370" stroke="#7B00A0" stroke-width="1.5"/>
+  <line x1="906" y1="480" x2="906" y2="370" stroke="#7B00A0" stroke-width="1.5"/>
+
+  <!-- Simulation subnet connections (green) -->
+  <line x1="984"  y1="480" x2="984"  y2="370" stroke="#008A00" stroke-width="1.5"/>
+  <line x1="1153" y1="480" x2="1153" y2="370" stroke="#008A00" stroke-width="1.5"/>
+
+  <!-- ═══════════════════════════════════════════════════════════════════ -->
+  <!-- Subnet buses                                                        -->
+  <!-- ═══════════════════════════════════════════════════════════════════ -->
+
+  <!-- Management: 192.0.2.192/26 (orange) -->
+  <line x1="40" y1="160" x2="1420" y2="160" stroke="#E4540C" stroke-width="2" stroke-dasharray="8,4"/>
+  <text x="42" y="150" fill="#E4540C" font-size="16" font-weight="bold" font-family="monospace">192.0.2.192/26</text>
+
+  <!-- DB subnet: 192.0.2.0/26 (blue) -->
+  <line x1="40" y1="370" x2="600" y2="370" stroke="#0063AF" stroke-width="2" stroke-dasharray="8,4"/>
+  <text x="42" y="360" fill="#0063AF" font-size="16" font-weight="bold" font-family="monospace">192.0.2.0/26</text>
+
+  <!-- Kafka subnet: 192.0.2.64/26 (purple) -->
+  <line x1="640" y1="370" x2="1020" y2="370" stroke="#7B00A0" stroke-width="2" stroke-dasharray="8,4"/>
+  <text x="642" y="360" fill="#7B00A0" font-size="16" font-weight="bold" font-family="monospace">192.0.2.64/26</text>
+
+  <!-- Simulation subnet: 192.0.2.128/26 (green) -->
+  <line x1="1060" y1="370" x2="1320" y2="370" stroke="#008A00" stroke-width="2" stroke-dasharray="8,4"/>
+  <text x="1062" y="360" fill="#008A00" font-size="16" font-weight="bold" font-family="monospace">192.0.2.128/26</text>
+
+  <!-- ═══════════════════════════════════════════════════════════════════ -->
+  <!-- Interface labels — placed near the bus end of each connection      -->
+  <!-- ═══════════════════════════════════════════════════════════════════ -->
+
+  <!-- Management labels (orange) -->
+  <!-- Monitoring ens0 — wire runs above the bus (y=60→160), labels sit on that wire -->
+  <text x="753"  y="100" fill="#E4540C" font-size="13" font-family="sans-serif">ens0</text>
+  <text x="753"  y="113" fill="#E4540C" font-size="11" font-family="monospace">192.0.2.200</text>
+  <!-- PostgreSQL ens1 -->
+  <text x="108"  y="175" fill="#E4540C" font-size="13" font-family="sans-serif">ens1</text>
+  <text x="108"  y="188" fill="#E4540C" font-size="11" font-family="monospace">192.0.2.196</text>
+  <!-- Elasticsearch ens1 -->
+  <text x="293"  y="175" fill="#E4540C" font-size="13" font-family="sans-serif">ens1</text>
+  <text x="293"  y="188" fill="#E4540C" font-size="11" font-family="monospace">192.0.2.202</text>
+  <!-- Core ens1 -->
+  <text x="518"  y="175" fill="#E4540C" font-size="13" font-family="sans-serif">ens1</text>
+  <text x="518"  y="188" fill="#E4540C" font-size="11" font-family="monospace">192.0.2.197</text>
+  <!-- Kafka ens1 (above box — IP above label, both on the wire) -->
+  <text x="753"  y="215" fill="#E4540C" font-size="11" font-family="monospace">192.0.2.198</text>
+  <text x="753"  y="228" fill="#E4540C" font-size="13" font-family="sans-serif">ens1</text>
+  <!-- Minion ens1 -->
+  <text x="948"  y="175" fill="#E4540C" font-size="13" font-family="sans-serif">ens1</text>
+  <text x="948"  y="188" fill="#E4540C" font-size="11" font-family="monospace">192.0.2.199</text>
+  <!-- SNMP Simulator ens1 -->
+  <text x="1168" y="175" fill="#E4540C" font-size="13" font-family="sans-serif">ens1</text>
+  <text x="1168" y="188" fill="#E4540C" font-size="11" font-family="monospace">192.0.2.201</text>
+
+  <!-- DB subnet labels (blue) -->
+  <!-- PostgreSQL ens0 -->
+  <text x="79"  y="385" fill="#0063AF" font-size="13" font-family="sans-serif">ens0</text>
+  <text x="79"  y="398" fill="#0063AF" font-size="11" font-family="monospace">192.0.2.4</text>
+  <!-- Elasticsearch ens0 -->
+  <text x="263" y="385" fill="#0063AF" font-size="13" font-family="sans-serif">ens0</text>
+  <text x="263" y="398" fill="#0063AF" font-size="11" font-family="monospace">192.0.2.6</text>
+  <!-- Core ens2 -->
+  <text x="462" y="385" fill="#0063AF" font-size="13" font-family="sans-serif">ens2</text>
+  <text x="462" y="398" fill="#0063AF" font-size="11" font-family="monospace">192.0.2.5</text>
+
+  <!-- Kafka subnet labels (purple) -->
+  <!-- Core ens0 -->
+  <text x="557" y="385" fill="#7B00A0" font-size="13" font-family="sans-serif">ens0</text>
+  <text x="557" y="398" fill="#7B00A0" font-size="11" font-family="monospace">192.0.2.69</text>
+  <!-- Kafka ens0 -->
+  <text x="753" y="385" fill="#7B00A0" font-size="13" font-family="sans-serif">ens0</text>
+  <text x="753" y="398" fill="#7B00A0" font-size="11" font-family="monospace">192.0.2.68</text>
+  <!-- Minion ens2 -->
+  <text x="892" y="385" fill="#7B00A0" font-size="13" font-family="sans-serif">ens2</text>
+  <text x="892" y="398" fill="#7B00A0" font-size="11" font-family="monospace">192.0.2.70</text>
+
+  <!-- Simulation subnet labels (green) -->
+  <!-- Minion ens0 -->
+  <text x="987"  y="385" fill="#008A00" font-size="13" font-family="sans-serif">ens0</text>
+  <text x="987"  y="398" fill="#008A00" font-size="11" font-family="monospace">192.0.2.133</text>
+  <!-- SNMP Simulator ens0 -->
+  <text x="1156" y="385" fill="#008A00" font-size="13" font-family="sans-serif">ens0</text>
+  <text x="1156" y="398" fill="#008A00" font-size="11" font-family="monospace">192.0.2.134</text>
+
+  <!-- ═══════════════════════════════════════════════════════════════════ -->
+  <!-- VM boxes — rendered on top of connection lines                     -->
+  <!-- ═══════════════════════════════════════════════════════════════════ -->
+
+  <!-- Monitoring -->
+  <rect x="655" y="20" width="190" height="40" rx="6" fill="#fff2cc" stroke="#d6b656" stroke-width="1.5"/>
+  <text x="750" y="45" text-anchor="middle" font-size="18" font-weight="bold" font-family="sans-serif">mon-benchmark-01</text>
+
+  <!-- Kafka VM -->
+  <rect x="655" y="230" width="190" height="40" rx="6" fill="#fff2cc" stroke="#d6b656" stroke-width="1.5"/>
+  <text x="750" y="255" text-anchor="middle" font-size="18" font-weight="bold" font-family="sans-serif">kafka-benchmark-01</text>
+
+  <!-- PostgreSQL -->
+  <rect x="10" y="480" width="190" height="40" rx="6" fill="#dae8fc" stroke="#6c8ebf" stroke-width="1.5"/>
+  <text x="105" y="505" text-anchor="middle" font-size="18" font-weight="bold" font-family="sans-serif">db-benchmark-01</text>
+
+  <!-- Elasticsearch -->
+  <rect x="195" y="480" width="190" height="40" rx="6" fill="#dae8fc" stroke="#6c8ebf" stroke-width="1.5"/>
+  <text x="290" y="505" text-anchor="middle" font-size="18" font-weight="bold" font-family="sans-serif">es-benchmark-01</text>
+
+  <!-- Core -->
+  <rect x="420" y="480" width="190" height="40" rx="6" fill="#dae8fc" stroke="#6c8ebf" stroke-width="1.5"/>
+  <text x="515" y="505" text-anchor="middle" font-size="18" font-weight="bold" font-family="sans-serif">core-benchmark-01</text>
+
+  <!-- Minion -->
+  <rect x="850" y="480" width="190" height="40" rx="6" fill="#d5e8d4" stroke="#82b366" stroke-width="1.5"/>
+  <text x="945" y="505" text-anchor="middle" font-size="18" font-weight="bold" font-family="sans-serif">minion-benchmark-01</text>
+
+  <!-- SNMP Simulator -->
+  <rect x="1070" y="480" width="190" height="40" rx="6" fill="#d5e8d4" stroke="#82b366" stroke-width="1.5"/>
+  <text x="1165" y="505" text-anchor="middle" font-size="18" font-weight="bold" font-family="sans-serif">netsim-benchmark-01</text>
+</svg>

--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -143,12 +143,34 @@ locals {
           address = local.node_address[key][subnet]
           # A named route resolving to nothing is dropped; the precondition
           # below fails the plan and a null next hop would only obscure it.
-          routes = [
-            for r in(try(n.cfg.routes[subnet], null) == null ? [] : [
-              try(local.named_routes[n.cfg.routes[subnet]], n.cfg.routes[subnet])
-            ]) : r
-            if !(contains(keys(local.named_routes), try(tostring(n.cfg.routes[subnet]), "")) && try(r.via, null) == null)
-          ]
+          # A public node also gets a default route out the public subnet.
+          # Without it the instance keeps two default routes -- mgmt at metric
+          # 100, public at 200 -- so traffic arriving on the Elastic IP is
+          # answered out the management NIC toward the NAT gateway, and the
+          # client never sees a matching reply.
+          #
+          # cloud-init already installs a policy rule for the public address,
+          # which is why SSH works: sshd's reply carries that source and the
+          # rule matches. Docker-published ports do not. Their reply is routed
+          # while its source is still the container's address, so no rule
+          # matches and it falls back to the mgmt default. Traefik on 443 was
+          # unreachable while port 22 was fine.
+          #
+          # `ip route replace 0.0.0.0/0 via <gw>` installs at metric 0, ahead of
+          # both, and the kernel picks the interface from the gateway's subnet.
+          # Attached to the first NIC only; the module flattens every
+          # interface's routes into one unit, so it runs once.
+          routes = concat(
+            [
+              for r in(try(n.cfg.routes[subnet], null) == null ? [] : [
+                try(local.named_routes[n.cfg.routes[subnet]], n.cfg.routes[subnet])
+              ]) : r
+              if !(contains(keys(local.named_routes), try(tostring(n.cfg.routes[subnet]), "")) && try(r.via, null) == null)
+            ],
+            try(n.cfg.public_ip, false) && si == 0 ? [
+              { to = "0.0.0.0/0", via = cidrhost(var.public_subnet_cidr, 1) }
+            ] : []
+          )
         } if !contains(["external", "lab"], subnet)
       ]
     }


### PR DESCRIPTION
Found while trying to open the dashboard on the first end-to-end AWS run. `https://<eip>/` timed out; `ssh <eip>` worked.

## Cause

The jump host has two NICs and two default routes — mgmt at metric 100, public at 200. Traffic arriving on the Elastic IP was answered out the **management** NIC toward the NAT gateway, so the client never saw a matching reply.

```
inbound  client → EIP → ens6 → DNAT → container 172.17.0.5
reply    container → routed on dest=client → default = ens5 (metric 100)
                   → NAT gateway → client sees nothing
```

cloud-init already installs a policy rule for the public address, and that is **why SSH worked and hid this**: sshd's reply carries `198.51.100.4` as its source, so the rule matches. Docker-published ports do not — their reply is routed while its source is still the *container's* address, so no rule matches and it falls back to the mgmt default.

Port 22 fine, ports 80 and 443 silent. That asymmetry is what made it confusing.

## Fix

A public node now gets a default route via its public subnet's gateway:

```
ip route replace 0.0.0.0/0 via 198.51.100.1
```

Installs at metric 0, ahead of both, and the kernel picks the interface from the gateway's subnet. Uses the existing `modules/cloud-init` static-route mechanism — no new machinery.

This is the right default for that node anyway: it holds the Elastic IP, so its egress belongs on the internet gateway rather than the NAT.

## Verification

Proved on the running lab **before** writing the change — adding a host route for the client via the public NIC turned the timeout into `HTTP 200`.

Rendering confirms scope:

```
monitoring  [{to = "0.0.0.0/0",   via = "198.51.100.1"}]
minion      [{to = "10.42.0.0/16", via = "192.0.2.152"}]
core, database, elasticsearch, kafka, netsim   []
```

`fmt`, `validate-aws`, `tflint-aws` and `validate-topology` pass.

## Applying

Replaces the jump host — its user-data changes and `user_data_replace_on_change` is set. The other six instances and the Elastic IP are untouched. Plan against a live lab: `delete,create module.compute.aws_instance.lab["monitoring"]` plus the inventory file.