### PR TITLE
docs(deployments): document the Ansible overlay and rewrite the README

### DIFF
--- a/deployments/README.md
+++ b/deployments/README.md
@@ -1,26 +1,28 @@
 # Deployment Library
 
-A **deployment** is a "topology under test": which components run, how many nodes
-of each, and how they are grouped — expressed as provider-agnostic data. One
-deployment can be provisioned onto any Terraform provider and can host many
-**experiments** (the workloads run against it).
+A **deployment** is a "topology under test": which components run, how many nodes of each, and how they are grouped, expressed as provider-agnostic data.
+One deployment can be provisioned onto any Terraform provider and can host many **experiments** (the workloads run against it).
+
+The split matters.
+A deployment describes the *system under test*; an experiment describes the *load*.
+Keeping them apart is what lets one topology serve several benchmarks instead of being rebuilt for each.
 
 ```
 deployments/
   <slug>/
-    topology.yml     # the provider-agnostic spec (source of truth)
+    topology.yml            # the provider-agnostic spec (source of truth)
+    opennms-lab-vars.yml    # optional Ansible overlay (kvm/aws only)
+    playbook.yml            # optional playbook replacement (kvm/aws only)
+  roles/                    # repo-local Ansible roles, on ansible.cfg's roles_path
   bin/
-    topology-descriptor.py   # derive the canonical descriptor from a spec
+    topology-descriptor.py  # derive the canonical descriptor from a spec
 ```
 
 ## Status (Phase 2)
 
-The specs and tooling here are live. The Terraform **consumption** of a spec —
-translating it into a provider's `local.topology` so `make deploy DEPLOYMENT=…
-PROVIDER=…` provisions it — lands in Phase 2b, once the Phase 1 `for_each`
-refactor (topology-as-data) is merged per provider. Until then, `make
-deployments` / `make deployment` list and validate the library, and the
-descriptor tool works standalone.
+The specs and tooling here are live.
+The Terraform **consumption** of a spec, translating it into a provider's `local.topology` so `make deploy DEPLOYMENT=… PROVIDER=…` provisions it, lands in Phase 2b, once the Phase 1 `for_each` refactor (topology-as-data) is merged per provider.
+Until then, `make deployments` and `make deployment` list and validate the library, and the descriptor tool works standalone.
 
 ## Spec schema (`topology.yml`)
 
@@ -47,9 +49,9 @@ roles:                         # keyed by component role
     groups: [mon_servers, docker_engine, grafana]
 ```
 
-### Roles → component codes
+### Roles to component codes
 
-Each role maps to a stable 2–3 char code used in the canonical descriptor:
+Each role maps to a stable 2–3 character code used in the canonical descriptor:
 
 | role | code | role | code |
 |---|---|---|---|
@@ -61,41 +63,38 @@ Each role maps to a stable 2–3 char code used in the canonical descriptor:
 | `rrd` | `rr` | `riptide` | `rp` |
 | `rustfs` | `rs` | `loadgen` (nl6) | `nl6` |
 
-`monitoring` is always-present infrastructure (Grafana/Prometheus/Jaeger) and is
-**excluded** from the descriptor. `loadgen` is the nl6 generator — included by
-default; opt out by omitting the role or setting `count: 0`. Opting out means
-also removing any `routes: { sim: net_sim }` from the spec, since that named
-route resolves to the generator (see below).
+`monitoring` is always-present infrastructure (Grafana, Prometheus, Jaeger) and is **excluded** from the descriptor.
+`loadgen` is the nl6 generator, included by default; opt out by omitting the role or setting `count: 0`.
+Opting out means also removing any `routes: { sim: net_sim }` from the spec, since that named route resolves to the generator (see below).
 
-Keep `loadgen` at `count: 1`. A named route's next hop is a single address, so
-only one node can serve it, and nl6 starts every generator at the same
-`nl6_auto_start_ip` — a second generator duplicates the first rather than
-extending it. Not currently enforced; see #173.
+Keep `loadgen` at `count: 1`.
+A named route's next hop is a single address, so only one node can serve it, and nl6 starts every generator at the same `nl6_auto_start_ip`, so a second generator duplicates the first rather than extending it.
+Not currently enforced; see #173.
 
 ### Size classes (provider translates to concrete resources)
 
 | class | vCPU | RAM | notes |
 |---|---|---|---|
-| `tiny` | 2 | 2 GiB | **shape/wiring test beds only.** Enough to start a service, not to measure one — a 2 GiB Elasticsearch gets a ~1 GiB heap. Never use in an A–H benchmark topology |
+| `tiny` | 2 | 2 GiB | **shape/wiring test beds only.** Enough to start a service, not to measure one: a 2 GiB Elasticsearch gets a ~1 GiB heap. Never use in a benchmark topology |
 | `small` | 2 | 4 GiB | db, kafka, minion, netsim, mon |
 | `medium` | 2 | 8 GiB | |
 | `large` | 4 | 8 GiB | elasticsearch |
 | `xlarge` | 4 | 16 GiB | core |
 
-Each provider owns the class → SKU/flavour mapping (Azure `Standard_D*`, Hetzner
-`cx*`, or explicit `cores`/`memory` for libvirt/proxmox). Disk sizes come from
-the provider's `disk_sizes_gb` keyed by role.
+Each provider owns the class to SKU/flavour mapping (Azure `Standard_D*`, Hetzner `cx*`, or explicit `cores`/`memory` for libvirt and proxmox).
+Disk sizes come from the provider's `disk_sizes_gb`, keyed by role.
+
+Size is part of the experiment, not decoration.
+A component that gains work relative to `baseline` usually needs a class with it: `kfk-exclusive` raises `kafka` to `medium` because that broker carries the entire metric stream on top of the IPC traffic, and a broker that saturates first makes the benchmark measure Kafka instead of OpenNMS.
 
 ### Subnets
 
-`mgmt` (management + Ansible/SSH), `db`, `kafka`, `sim` (SNMP simulation),
-`external` (DHCP bridge for the monitoring jump host), `lab` (the physical
-bridge LAN, statically addressed). Interface order in `subnets` fixes NIC order
-on the VM.
+`mgmt` (management plus Ansible/SSH), `db`, `kafka`, `sim` (SNMP simulation), `external` (DHCP bridge for the monitoring jump host), `lab` (the physical bridge LAN, statically addressed).
+Interface order in `subnets` fixes NIC order on the VM.
 
-Addresses on the internal subnets are derived by the provider from per-role
-blocks — do not assume them. Two escape hatches exist for hosts that something
-outside the lab has to reach:
+Addresses on the internal subnets are derived by the provider from per-role blocks.
+Do not assume them.
+Two escape hatches exist for hosts that something outside the lab has to reach:
 
 ```yaml
 roles:
@@ -107,35 +106,67 @@ roles:
     routes: { sim: net_sim }                             # …or a named shared route
 ```
 
-The two forms are validated differently. A **named** route resolves its next hop
-from a role inside the same spec, so the provider fails the plan unless that role
-is present *and* attached to the subnet the route needs — `net_sim` requires a
-`loadgen` with a `sim` NIC. An **inline** `{ to, via }` deliberately points
-outside the topology and is not checked; use it when the next hop is a machine
-the spec does not provision.
+The two forms are validated differently.
+A **named** route resolves its next hop from a role inside the same spec, so the provider fails the plan unless that role is present *and* attached to the subnet the route needs: `net_sim` requires a `loadgen` with a `sim` NIC.
+An **inline** `{ to, via }` deliberately points outside the topology and is not checked; use it when the next hop is a machine the spec does not provision.
 
-Both preconditions are plan-time only. `make validate-topology` renders every
-spec and asserts the same invariants without a hypervisor, so run it before
-pushing; it is not yet a CI gate (#173).
+Both preconditions are plan-time only.
+`make validate-topology` renders every spec and asserts the same invariants without a hypervisor, so run it before pushing.
+It is not yet a CI gate (#173), so CI will not catch a spec that validates against the schema but cannot be provisioned.
 
-A `lab` NIC needs the provider to know the bridge LAN: `subnet_lab` (CIDR, for
-the prefix and gateway) and `lab_nameservers` (a physical LAN, unlike the
-libvirt NAT networks, usually runs no resolver on its gateway). Pinned
-addresses are the deployment's contract with whatever is off-box — the reason to
-use them is a generator or client that cannot discover the lab's addressing.
+A `lab` NIC needs the provider to know the bridge LAN: `subnet_lab` (CIDR, for the prefix and gateway) and `lab_nameservers` (a physical LAN, unlike the libvirt NAT networks, usually runs no resolver on its gateway).
+Pinned addresses are the deployment's contract with whatever is off-box.
+The reason to use them is a generator or client that cannot discover the lab's addressing.
+
+## Ansible overlay
+
+A topology says which machines exist.
+Some deployments also need to say how the stack on those machines is configured, and two optional files do that:
+
+| File | Effect |
+|---|---|
+| `opennms-lab-vars.yml` | layered after the root `opennms-lab-vars.yml` as a second `--extra-vars` |
+| `playbook.yml` | **replaces** `opennms-playbook.yml` for this deployment |
+
+**Both are honoured for `kvm` and `aws` only.**
+On `azure`, `proxmox` and `vmware` they are silently ignored, so a deployment that depends on them provisions and then comes up misconfigured with no warning.
+Say so in the spec's `description` and in the index row below.
+
+Two things to know before writing an overlay:
+
+**Ansible replaces dicts, it does not merge them.**
+`ansible.cfg` sets no `hash_behaviour`, so a dict in the overlay replaces whatever it shadows, wholesale.
+That is exactly what you want for `opennms_properties_timeseries` (replacing it is how the collection's RRDTool defaults are removed) and a trap for `kafka_server_properties` (a partial override drops the KRaft settings and the broker will not start).
+Restate the full dict, or do not touch it.
+
+**A replacement playbook should import, not duplicate.**
+`playbook.yml` substitutes for the whole stock playbook, so copying its plays guarantees drift.
+Import it and add only what is new:
+
+```yaml
+- name: Deploy the stock OpenNMS stack
+  ansible.builtin.import_playbook: ../../opennms-playbook.yml
+
+- name: Something this deployment needs
+  hosts: core
+  become: true
+  roles:
+    - some_repo_local_role
+```
+
+Repo-local roles live in `deployments/roles/` and resolve by bare name, because `ansible.cfg` already has that directory on `roles_path`.
+Reach for one only when the pinned `indigo423.opennms` collection cannot express the setting as a variable.
 
 ## Identifier scheme
 
-- **slug** — the human handle (kebab-case), equals the directory name; used as
-  hostname prefix, Terraform workspace, and Grafana label.
-- **canonical descriptor** — machine-derived from the spec, `<count><code>`
-  tokens in a fixed order joined by `-` (e.g. `3es-3mm-1pg-3sn-3kf-1on-2mn-nl6`).
-  Used as the reproducibility fingerprint on results. Generate with:
+- **slug** is the human handle (kebab-case), equals the directory name, and is used as hostname prefix, Terraform workspace, and Grafana label.
+- **canonical descriptor** is machine-derived from the spec: `<count><code>` tokens in a fixed order joined by `-`, for example `3es-3mm-1pg-3sn-3kf-1on-2mn-nl6`.
+  It is the reproducibility fingerprint recorded on results.
 
-  ```bash
-  make deployment DEPLOYMENT=mimir-ha        # or:
-  python3 deployments/bin/topology-descriptor.py deployments/mimir-ha/topology.yml
-  ```
+```bash
+make deployment DEPLOYMENT=mimir-ha        # or:
+python3 deployments/bin/topology-descriptor.py deployments/mimir-ha/topology.yml
+```
 
 Descriptor component order: `es mm vm ch ak rp rs rr pg sn kf on mn nl6`.
 
@@ -144,22 +175,29 @@ Descriptor component order: `es mm vm ch ak rp rs rr pg sn kf on mn nl6`.
 | slug | descriptor | notes |
 |---|---|---|
 | `baseline` | `1es-1pg-1kf-1on-1mn-nl6` | the current single-node lab (reference) |
-| `mimir-ha` (A) | `3es-3mm-1pg-3sn-3kf-1on-2mn-nl6` | full HA Mimir + Sentinel |
-| `rrd-minimal` (B) | `1rr-1pg-1kf-1on-1mn` | RRDTool on core, minimal |
-| `vm-cluster-es` (C) | `1es-3vm-1pg-1on` | VictoriaMetrics cluster + ES flows |
-| `es-nostore` (D) | `1es-1pg-1kf-1on-1mn` | ES flows, no metrics TSDB |
-| `vm-cluster-minion` (E) | `3vm-1pg-1kf-1on-1mn` | VictoriaMetrics cluster + minion |
-| `vm-single` (F) | `1vm-1pg-1on` | single VictoriaMetrics |
-| `mimir-single` (G) | `1mm-1pg-1on` | single Mimir |
-| `clickhouse-akvorado` (H) | `1ch-1ak` | standalone flow-engine (no OpenNMS) |
-| `clickhouse-riptide` (R) | `1ch-1rp` | standalone riptide flow engine (no OpenNMS); both nodes on the physical `lab` bridge so an off-hypervisor generator can reach the UDP ingest |
-| `es-cluster-min` | `3es` | **component test bed**, not A–H — verifies Elasticsearch cluster formation on a footprint that fits the lab (28 GB) |
-| `kafka-cluster-min` | `3kf` | **component test bed**, not A–H — verifies KRaft cluster formation (shared cluster ID, quorum, RF 3) at 28 GB |
-| `mimir-cluster-min` | `3mm-1rs` | **component test bed**, not A–H — verifies Mimir cluster formation against shared object storage at 36 GB |
-| `mimir-ha-min` | `3es-3mm-1rs-1pg-3sn-3kf-1on-2mn-nl6` | **shape test bed**, not A–H — Deployment A's wiring at 50 GB on `tiny` nodes; proves the HA topology, measures nothing |
+| `mimir-ha` | `3es-3mm-1pg-3sn-3kf-1on-2mn-nl6` | full HA Mimir plus Sentinel |
+| `rrd-minimal` | `1rr-1pg-1kf-1on-1mn` | RRDTool on core, minimal |
+| `vm-cluster-es` | `1es-3vm-1pg-1on` | VictoriaMetrics cluster plus ES flows |
+| `es-nostore` | `1es-1pg-1kf-1on-1mn` | ES flows, no metrics TSDB |
+| `kfk-exclusive` | `1pg-1kf-1on-1mn-nl6` | Kafka-exclusive metric forwarding: `baseline` minus Elasticsearch, no local TSDB. Ships an overlay and a `playbook.yml`, so **kvm/aws only** |
+| `vm-cluster-minion` | `3vm-1pg-1kf-1on-1mn` | VictoriaMetrics cluster plus minion |
+| `vm-single` | `1vm-1pg-1on` | single VictoriaMetrics |
+| `mimir-single` | `1mm-1pg-1on` | single Mimir |
+| `clickhouse-akvorado` | `1ch-1ak` | standalone flow engine (no OpenNMS) |
+| `clickhouse-riptide` | `1ch-1rp` | standalone riptide flow engine (no OpenNMS); both nodes on the physical `lab` bridge so an off-hypervisor generator can reach the UDP ingest |
+| `es-cluster-min` | `3es` | **component test bed**, verifies Elasticsearch cluster formation on a footprint that fits the lab (28 GB) |
+| `kafka-cluster-min` | `3kf` | **component test bed**, verifies KRaft cluster formation (shared cluster ID, quorum, RF 3) at 28 GB |
+| `mimir-cluster-min` | `3mm-1rs` | **component test bed**, verifies Mimir cluster formation against shared object storage at 36 GB |
+| `mimir-ha-min` | `3es-3mm-1rs-1pg-3sn-3kf-1on-2mn-nl6` | **shape test bed**, the HA wiring at 50 GB on `tiny` nodes; proves the topology, not suited for measuring |
 
-**Interpretation notes:** B lists RRDTool without a Core, but RRD is a Core
-storage strategy, so `baseline`/B include `core` with the RRD strategy set at the
-Ansible layer. Components beyond the current lab (mimir, victoriametrics,
-clickhouse, akvorado, sentinel) are valid spec data now; their Ansible roles and
-provider translation arrive in Phase 3 (component breadth).
+**Reading the index.**
+`rrd-minimal` lists RRDTool without a Core, but RRD is a Core storage strategy, so it and `baseline` both include `core` with the strategy set at the Ansible layer.
+`kfk-exclusive` lists no TSDB component at all for the same reason inverted: its metrics leave via the Kafka Producer, so the `metrics` topic is the store.
+
+**Test beds are not benchmarks.**
+The four entries marked above exist to prove a component forms a cluster or a topology wires up on hardware that fits the lab.
+They are sized to boot, not to measure, and a number taken from one means nothing.
+
+**Not every component deploys yet.**
+Specs naming mimir, victoriametrics, clickhouse, akvorado or sentinel are valid data now, but their Ansible roles and provider translation are still to come.
+Such a spec will validate and will not yet deploy.


### PR DESCRIPTION
Closes #189

## What

Documents the two optional per-deployment files `deploy.sh` honours but the README never mentioned, and rewrites the surrounding document so the index reads honestly.

## The gap this closes

| File | Effect | Where |
|---|---|---|
| `deployments/<slug>/opennms-lab-vars.yml` | layered after the root vars as a second `--extra-vars` | `deploy.sh:115` |
| `deployments/<slug>/playbook.yml` | **replaces** `opennms-playbook.yml` | `deploy.sh:405` |

`kfk-exclusive` (#184) is the first deployment to ship both.

The new section covers what goes wrong, not just what the files do:

- **kvm/aws only.** Silently ignored on azure, proxmox and vmware, so a deployment that depends on them provisions and comes up misconfigured with nothing to indicate it.
- **Ansible replaces dicts, it does not merge them.** The mechanism that removes the collection's RRDTool defaults, and equally the reason a partial `kafka_server_properties` override drops the KRaft settings and the broker will not start.
- **A replacement playbook should `import_playbook`, not copy plays**, with the pattern shown.
- Where repo-local roles live, and when reaching for one is justified.

## Corrections to the index

**The A–H letters were half-removed.** `rrd-minimal (B)` was left alone carrying a letter while the `tiny` size-class row and the interpretation note still referred to "A–H" that no row displayed. Letters are gone; both references now name the deployment.

**A restored caveat.** The note had lost the line that mimir, victoriametrics, clickhouse, akvorado and sentinel are valid spec data with no Ansible roles yet — so the index read as though `mimir-single` or `vm-cluster-es` would deploy. It does not now.

**Three interpretation notes replace one:** why `rrd-minimal` and `kfk-exclusive` both list a storage arrangement their descriptor does not show, and why a number taken from a test bed means nothing.

**Sizing framed as an experimental variable**, using `kfk-exclusive`'s kafka `small` → `medium` as the worked example.

## Style

One sentence per line (repo-markdown convention), no em-dashes, tables unpadded — the padded separator rows had already drifted out of alignment and every new row would mean re-padding the block. Compact cells render identically.

## Verification

```
make validate-deployments   -> all deployment specs valid
```

Every `deployments/*/topology.yml` appears in the index, and no index row lacks a directory (both cross-checked).

## Note for review

This is a **rewrite, not a patch** — 114 insertions, 76 deletions. It replaces work that was in the working tree rather than building on it, keeping that edit's direction (letters out, prose unwrapped) but reflowing the whole document. Worth a read against `main` rather than a skim of the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)