### PR TITLE
ci(dependabot): scan Terraform modules, not just the provider roots

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,20 @@
 ---
 version: 2
 updates:
-  # Glob covers every Terraform root under terraform/ (azure, kvm, proxmox,
-  # vmware) and self-heals when a new platform directory is added.
+  # Terraform declares required_providers in the provider root *and* again in
+  # every module it calls, and `terraform init` intersects all of them. Update
+  # only the root and the intersection can empty out: aws went to "~> 5.0,
+  # ~> 6.56" and init failed before validate ran (#188). Within one major the
+  # same drift is silent rather than fatal, which is worse — azure sat at root
+  # ~> 4.65 against modules ~> 4.0 for some time.
+  #
+  # So all three globs are needed, not just the first. They self-heal when a
+  # new platform directory or module is added.
   - package-ecosystem: "terraform"
     directories:
-      - "/terraform/*"
+      - "/terraform/*"             # provider roots: aws, azure, kvm, proxmox, vmware
+      - "/terraform/*/modules/*"   # each provider's own modules
+      - "/terraform/modules/*"     # modules shared across providers
     schedule:
       interval: "weekly"
 

--- a/terraform/azure/modules/compute/main.tf
+++ b/terraform/azure/modules/compute/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.0"
+      version = "~> 4.65"
     }
   }
 }

--- a/terraform/azure/modules/network/main.tf
+++ b/terraform/azure/modules/network/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.0"
+      version = "~> 4.65"
     }
   }
 }


### PR DESCRIPTION
Closes #191
Refs #188

## What

Widens the Dependabot Terraform glob from one pattern to three, and aligns the azure module constraints that had already drifted.

```diff
 directories:
-  - "/terraform/*"
+  - "/terraform/*"             # provider roots: aws, azure, kvm, proxmox, vmware
+  - "/terraform/*/modules/*"   # each provider's own modules
+  - "/terraform/modules/*"     # modules shared across providers
```

## Why

`/terraform/*` reaches the five provider roots and none of the modules beneath them. Every root here re-declares `required_providers` in each module it calls, so Dependabot has been bumping the root and leaving the copies behind.

`terraform init` **intersects** every constraint for a provider across the root and its modules, so the drift lands one of two ways:

- **Across a major it is fatal.** #188 raised `hashicorp/aws` in `providers.tf` alone; `modules/compute` and `modules/network` stayed at `~> 5.0`; the intersection with `~> 6.56` is empty, and `Validate (AWS)` failed before `terraform validate` ever ran.
- **Within a major it is silent, which is worse.** `terraform/azure` sat at root `~> 4.65` against modules `~> 4.0` — an intersection that resolves fine, while the module declarations quietly meant nothing.

Only the fatal case ever got noticed.

## Coverage

18 directories hold `.tf` files. The old glob reached 5:

| Glob | Reaches |
|---|---|
| `/terraform/*` | 5 provider roots |
| `/terraform/*/modules/*` | 8 per-provider modules |
| `/terraform/modules/*` | 4 shared modules (cloud-init, diagram, inventory, topology-inventory) |

The self-healing property of the original is kept: a new platform directory is picked up, and now a new module is too.

## Also here

The azure `~> 4.0` → `~> 4.65` alignment. It is the instance of this bug already in the tree rather than a future one, so it belongs with the fix rather than waiting for Dependabot to notice once the glob lands.

## Verification

```
make validate-aws     -> Success! The configuration is valid.
make validate-azure   -> Success! The configuration is valid.
make fmt              -> clean
make lint-yaml        -> clean
```

Each glob was expanded against the tree to confirm it resolves to directories that actually contain manifests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)