### PR TITLE
fix(deployments): give kfk-exclusive's monitoring node a Kafka NIC

### DIFF
--- a/deployments/kfk-exclusive/topology.yml
+++ b/deployments/kfk-exclusive/topology.yml
@@ -38,8 +38,13 @@ roles:
     subnets: [mgmt, sim]
     groups: [net_sim, docker_engine]
   monitoring:
+    # baseline gives monitoring [mgmt, external]. This profile adds kafka,
+    # because the metrics topic is the only measurement point the deployment
+    # has and kafka_metrics_report runs here. Without the NIC the consumer
+    # resolves the broker's address, routes it out the external gateway and
+    # fails with a transport error that reads like a broken broker.
     count: 1
     size: small
-    subnets: [mgmt, external]
+    subnets: [mgmt, kafka, external]
     public_ip: true
     groups: [mon_servers, docker_engine, grafana]


### PR DESCRIPTION
Closes #195

## What

`monitoring` gets `[mgmt, kafka, external]` instead of `[mgmt, external]`.

## Why

`kafka_metrics_report` runs on the monitoring node, and the broker is on the kafka subnet. The node had no interface there, so the address routed out the external gateway:

```
$ ip route get 192.0.2.76
192.0.2.76 via 192.168.11.1 dev enp2s0     # external gateway

$ kafka-metrics-report
KafkaError{code=_TRANSPORT,val=-195,
  str="Failed to get metadata: Local: Broker transport failure"}
```

librdkafka reports it as a transport failure, which reads like a broken broker rather than a missing NIC.

This is a deliberate divergence from `baseline`, not a copying oversight: `baseline` has nothing on the monitoring node that needs the broker, and here the metrics topic is the deployment's only measurement point.

## Verification — a real lab

Found by the first `make deploy PROVIDER=kvm DEPLOYMENT=kfk-exclusive`. After the fix and a rebuild:

```
$ ip -4 -br addr
enp1s0  UP  192.0.2.212/26     # mgmt
enp2s0  UP  192.0.2.84/26      # kafka   <- new
enp3s0  UP  192.168.11.48/24   # external

$ cat < /dev/null > /dev/tcp/192.0.2.76/9092
OPEN

$ kafka-metrics-report --label "first lab run"
samples   322
mean      2.01/s over 160.4s
peak      7.43/s
```

`make validate-topology` passes; the descriptor is unchanged (`1pg-1kf-1on-1mn-nl6`) since subnets do not affect it.

## Trap worth knowing, not fixed here

**Editing `subnets` on a live lab does not work.** Terraform updates the domain in place and attaches the NIC, but the guest's cloud-init network config was written once at first boot. The new interface never comes up and the existing ones shift position — here external moved `enp2s0` → `enp3s0`, the jump host became undiscoverable, and every later play failed:

```
warning: could not discover external IP after 2 minutes; jump host not configured
mon-benchmark-01 : ok=0 changed=0 unreachable=0 failed=1
```

Destroy and redeploy fixes it. Whether Terraform should force replacement on a NIC-set change, or whether this only needs documenting, is left to #195.

🤖 Generated with [Claude Code](https://claude.com/claude-code)