### PR TITLE
fix(bootstrap): pin nl6 where the bootstrap play can actually read it

### DIFF
--- a/bootstrap/roles/nl6/defaults/main.yml
+++ b/bootstrap/roles/nl6/defaults/main.yml
@@ -1,6 +1,12 @@
 ---
+# Standalone fallback only. The lab pins the version in
+# group_vars/net_sim/vars.yml, which overrides this.
 nl6_image: "ghcr.io/labmonkeys-space/nl6:v0.9.0"
 nl6_auto_start_ip: "10.42.0.1"
+# Permanently 0, and deliberately so. Devices are created through the nl6 API
+# by the experiment that needs them, because how many devices exist is a
+# property of the workload and has to be recorded on the result. An empty fleet
+# after deployment is the intended state, not a defect.
 nl6_auto_count: 0
 nl6_auto_netmask: "16"
 nl6_web_port: 8080

--- a/group_vars/net_sim/vars.yml
+++ b/group_vars/net_sim/vars.yml
@@ -1,0 +1,12 @@
+---
+# Lab pin for the network simulator.
+#
+# Kept in group_vars, not in opennms-lab-vars.yml, because deploy.sh runs the
+# bootstrap play with no --extra-vars at all. A pin in that file never reaches
+# the nl6 role, so the role default wins silently: the lab ran v0.9.0 for as
+# long as the root file claimed v0.21.0 (#197).
+#
+# group_vars sits beside ansible-inventory.yml, so Ansible loads it for every
+# play that uses the inventory, bootstrap included. It also stays below
+# extra_vars in precedence, which leaves roles free to merge against it.
+nl6_image: "ghcr.io/labmonkeys-space/nl6:v0.21.0"

--- a/opennms-lab-vars.yml
+++ b/opennms-lab-vars.yml
@@ -1,7 +1,4 @@
 ---
-nl6_image: "ghcr.io/labmonkeys-space/nl6:v0.21.0"
-nl6_auto_count: 0
-
 opennms_distribution: Horizon
 # The OpenNMS apt "stable" dist retains only the current point release —
 # superseded versions are removed, so a stale pin fails with


### PR DESCRIPTION
Closes #197

## What

Moves the nl6 image pin to `group_vars/net_sim/vars.yml` and deletes `nl6_auto_count` from `opennms-lab-vars.yml`.

## Why

`deploy.sh:382-386` runs `bootstrap/site.yml` with **no `--extra-vars`**, so nothing in `opennms-lab-vars.yml` reaches a bootstrap role. The pin declared v0.21.0 while the role default supplied v0.9.0, and the lab had been running twelve releases behind what the repo appeared to specify.

`group_vars/` sits beside `ansible-inventory.yml`, so Ansible loads it for every play using that inventory, bootstrap included.

## Why not just pass `--extra-vars` to bootstrap

That was the obvious one-liner and it is a trap. `group_vars/grafana/vars.yml` already records why:

> *"Kept in group_vars (not extra_vars) so the grafana.grafana collection's `set_fact` can merge these with `grafana_ini_default` via recursive combine."*

`extra_vars` is the highest precedence tier and cannot be merged against. Passing the root vars file to bootstrap would fix this one variable by silently breaking that mechanism for every other one. Fixed the channel instead.

## `nl6_auto_count` is deleted, not moved

How many simulated devices exist is a property of the **workload**, not the system under test, and it has to be recorded on the result to mean anything. Devices are created through the nl6 API by the experiment that needs them, which records the count in its own report by construction.

The role default stays `0` permanently and now says so, because an empty fleet after deployment is the intended state rather than a defect.

## One-step, deliberately

The channel fix and the twelve-release bump land together. Separating them would give a cleaner bisect at the cost of a commit whose entire content is "no behaviour change". All eight CLI flags the role passes are unchanged across the jump, so the upgrade risk is low.

## Verification — on the lab

**Before:**
```
$ ansible -i ansible-inventory.yml net_sim -m debug -a "msg={{ nl6_image | default('UNDEFINED') }}"
netsim-benchmark-01 | SUCCESS => "UNDEFINED at inventory scope"

$ curl http://<netsim>:8080/api/v1/version        {"version":"v0.9.0"}
$ curl -o /dev/null -w '%{http_code}' .../api/v1/scenarios      404
```

**After** (`make destroy` + `make deploy PROVIDER=kvm DEPLOYMENT=kfk-exclusive`, 0 failures across 6 hosts):
```
$ ansible -i ansible-inventory.yml net_sim -m debug -a "msg={{ nl6_image }}"
netsim-benchmark-01 | SUCCESS => "ghcr.io/labmonkeys-space/nl6:v0.21.0"

$ curl http://<netsim>:8080/api/v1/version        {"version":"v0.21.0"}
$ curl -o /dev/null -w '%{http_code}' .../api/v1/scenarios      200
```

That 404 → 200 also **unblocks #194** — the load-test driver targets an API v0.9.0 did not have.

No regression: the metrics consumer still reports normally on the rebuilt lab (328 samples over 255s).

## Follow-up not in scope

A lint rule asserting no key in `opennms-lab-vars.yml` matches a `bootstrap/roles/*` variable prefix would close the class rather than this instance. `grafana_datasources` is currently defined in both channels with the same value, waiting to diverge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)