### PR TITLE
feat(terraform): export every node address into the inventory, not just mgmt

### DIFF
--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -190,6 +190,16 @@ locals {
         # an experiment ledger — can tell that a run happened on infrastructure
         # that cannot produce valid numbers.
         { lab_cost_profile = var.cost_profile },
+        # Every address the node holds, not just the mgmt one, so a consumer
+        # needing a peer on the kafka or sim network can derive it instead of
+        # hardcoding it (#161). mgmt is excluded because the inventory template
+        # already emits it as lab_mgmt_ip. Nulls are dropped rather than
+        # rendered empty, since "" reads as an answer.
+        {
+          for subnet, addr in local.node_address[key] :
+          "lab_${subnet}_ip" => addr
+          if addr != null && subnet != "mgmt"
+        },
         n.prole == "netsim" ? {
           nl6_net_interface = try("ens${index([for i in local.topology[key].interfaces : i.subnet], "sim") + 5}", "")
         } : {}

--- a/terraform/kvm/main.tf
+++ b/terraform/kvm/main.tf
@@ -210,10 +210,29 @@ locals {
       ansible_host = try([for i in local.topology[key].interfaces : i.address if i.subnet == "mgmt"][0],
       try([for i in local.topology[key].interfaces : i.address if i.subnet == "lab"][0], ""))
       groups = try(n.cfg.groups, [])
-      # nl6 runs on the netsim host; expose its sim NIC name for the generator.
-      host_vars = n.prole == "netsim" ? {
-        nl6_net_interface = try([for i in local.topology[key].interfaces : i.iface_name if i.subnet == "sim"][0], "")
-      } : {}
+      host_vars = merge(
+        # Every address the node holds, not just the mgmt one. Without this,
+        # Ansible can see a host but not which address it answers on for any
+        # given subnet, so anything needing a peer on the kafka or sim network
+        # has to hardcode it and be right by coincidence of the allocation rule
+        # below. Three consumers already do: kafka_bootstrap_servers, the nl6
+        # collector endpoints, and the device payload an experiment builds
+        # (#161).
+        #
+        # mgmt is excluded because the inventory template already emits it as
+        # lab_mgmt_ip; emitting it here too would duplicate the YAML key.
+        # Null addresses are dropped rather than rendered empty: external and
+        # lab subnets are DHCP or unpinned, and "" reads as an answer.
+        {
+          for subnet, addr in local.node_address[key] :
+          "lab_${subnet}_ip" => addr
+          if addr != null && subnet != "mgmt"
+        },
+        # nl6 runs on the netsim host; expose its sim NIC name for the generator.
+        n.prole == "netsim" ? {
+          nl6_net_interface = try([for i in local.topology[key].interfaces : i.iface_name if i.subnet == "sim"][0], "")
+        } : {}
+      )
     }
   }
 


### PR DESCRIPTION
Refs #161

## What

Both spec-driven providers already compute `local.node_address` keyed by subnet. Both export only the `mgmt` entry. This exports the rest as `lab_<subnet>_ip` host vars.

## Why

Ansible could see a host but not which address it answers on for any other network, so anything needing a peer on the kafka or sim subnet had to hardcode it. **Three consumers already do:**

| Consumer | Literal | Needs |
|---|---|---|
| `kafka_bootstrap_servers` | `192.0.2.76:9092` | kafka-subnet address |
| nl6 collector defaults | `192.0.2.144:{9999,10162,10514}` | sim-subnet address |
| an experiment's device payload | would be the same | sim-subnet address |

Every one is correct **by coincidence of the allocation rule**, not by derivation. `kafka` sits at index 2 of `local.role_order`, so the offset is `4 + 2×4 = 12` and `cidrhost("192.0.2.64/26", 12)` lands on `.76`. Re-space `role_order` and all of them are silently wrong, with nothing failing at plan time.

## Scope: the export half of #161 only

#161 also covers converging the kvm and azure allocation schemes. That is entangled with draft PR #126 (last touched 2026-07-23) and **stays open**. The export is separable, and the `publish-deployment-endpoints` work cannot start without it — Ansible is the only layer that knows both addresses and ports, and it currently knows neither address.

## No consumer is changed here

Deriving `kafka_bootstrap_servers` would break azure, which has no such export. Consumers move with the endpoints work, which is scoped to the spec-driven providers.

Two deliberate exclusions:

- **`mgmt`**, because the inventory template already emits `lab_mgmt_ip` (consumed by `etc_hosts` and `traefik`); emitting it here too would duplicate the YAML key.
- **null addresses**, because `external` and `lab` are DHCP or unpinned, and `""` reads as an answer rather than an absence.

## Verification — the derived values equal the hardcoded ones

Generated inventory after a real deploy:

```yaml
core-benchmark-01:    lab_mgmt_ip: 192.0.2.200  lab_db_ip: 192.0.2.8   lab_kafka_ip: 192.0.2.72
db-benchmark-01:      lab_mgmt_ip: 192.0.2.196  lab_db_ip: 192.0.2.4
kafka-benchmark-01:   lab_mgmt_ip: 192.0.2.204  lab_kafka_ip: 192.0.2.76     ← matches the literal
minion-benchmark-01:  lab_mgmt_ip: 192.0.2.208  lab_kafka_ip: 192.0.2.80  lab_sim_ip: 192.0.2.144   ← matches
mon-benchmark-01:     lab_mgmt_ip: 192.0.2.212  lab_kafka_ip: 192.0.2.84
netsim-benchmark-01:  lab_mgmt_ip: 192.0.2.216  lab_sim_ip: 192.0.2.152
```

`lab_kafka_ip: 192.0.2.76` and `lab_sim_ip: 192.0.2.144` are exactly the two literals in the tree today. The derived values agree with the hardcoded ones, which is the proof that the export is correct **and** that this changes no behaviour.

```
make fmt / validate-kvm / validate-aws     pass
make validate-topology                     all 20 rendered topologies valid
make deploy PROVIDER=kvm DEPLOYMENT=…      0 failures across 6 hosts
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)