### PR TITLE
feat: derive broker and database addresses from the inventory

### DIFF
--- a/bootstrap/roles/kafka_ui/defaults/main.yml
+++ b/bootstrap/roles/kafka_ui/defaults/main.yml
@@ -5,5 +5,16 @@ kafka_ui_cpus: "0.5"
 kafka_ui_memory: 512m
 kafka_ui_tz: UTC
 kafka_ui_cluster_name: opennms-benchmark
-kafka_ui_bootstrap_servers: 192.0.2.76:9092
+# Derived, not hardcoded. This was a second copy of the broker address,
+# independent of kafka_bootstrap_servers and never noticed by #161. It lives in
+# a bootstrap role, which cannot read opennms-lab-vars.yml at all (#197), so it
+# could not simply reference that variable. hostvars comes from the inventory
+# and is available to every play, bootstrap included.
+# Guarded on the group existing, and falling back to lab_mgmt_ip rather than
+# ansible_host: the inventory sets ansible_host to the jump host's public
+# address on whichever node carries public_ip.
+kafka_ui_bootstrap_servers: >-
+  {{ (hostvars[groups['message_broker'][0]].lab_kafka_ip
+      | default(hostvars[groups['message_broker'][0]].lab_mgmt_ip, true)) ~ ':9092'
+     if groups.get('message_broker') else '' }}
 kafka_ui_context_path: /kafka

--- a/opennms-lab-vars.yml
+++ b/opennms-lab-vars.yml
@@ -7,7 +7,21 @@ opennms_distribution: Horizon
 opennms_version: "36.0.2"
 opennms_pkg_version: "{{ opennms_version }}*"
 
-opennms_datasource_db_host: 192.0.2.196
+# The db subnet exists precisely so database traffic does not share the
+# management path a benchmark also uses. This pointed at the database node's
+# *mgmt* address, so the dedicated network was provisioned and idle while
+# OpenNMS talked to PostgreSQL over mgmt. Two experiments already used the
+# db-subnet address, so the tree disagreed with itself.
+#
+# Safe to move: postgres_listen_addresses is "*" and postgres_hba_permissions_v4
+# covers 192.0.2.0/24, which spans both subnets.
+#
+# Guarded and falling back to lab_mgmt_ip for the same reasons as
+# kafka_bootstrap_servers below.
+opennms_datasource_db_host: >-
+  {{ (hostvars[groups['database'][0]].lab_db_ip
+      | default(hostvars[groups['database'][0]].lab_mgmt_ip, true))
+     if groups.get('database') else '' }}
 opennms_datasource_db_port: 5432
 opennms_datasource_db_name: onms_benchmark
 opennms_datasource_db_user: opennms
@@ -62,7 +76,34 @@ postgres_user: postgres
 postgres_listen_addresses: "*"
 postgres_hba_permissions_v4: "192.0.2.0/24"
 
-kafka_bootstrap_servers: "192.0.2.76:9092"
+# Derived from the inventory, not hardcoded. The literal that stood here was
+# correct only by coincidence of the kvm allocation rule: kafka sits at index 2
+# of local.role_order, so the offset is 4 + 2*4 and cidrhost("192.0.2.64/26", 12)
+# lands on .76. Re-space role_order and the literal was silently wrong (#161).
+#
+# lab_kafka_ip is exported by the spec-driven providers. The fallback is
+# lab_mgmt_ip rather than ansible_host: the inventory sets ansible_host to the
+# jump host's *public* address on whichever node carries public_ip, so a spec
+# giving public_ip to the broker would otherwise hand OpenNMS a public address.
+# lab_mgmt_ip is unconditionally the in-lab address, which is what the fallback
+# means. Legacy providers lose the subnet separation, which is acceptable
+# because only kvm and aws consume deployment specs.
+#
+# Guarded on the group existing. mimir-single, vm-single and vm-cluster-es
+# declare a core and no broker, and the group is simply absent there; an
+# unguarded subscript turns a deployment that used to complete into a fatal
+# template error. Those specs should really set opennms_message_broker: none,
+# since an empty broker address is not a working configuration either — but
+# failing the deploy is a regression and rendering nothing is not.
+#
+# Only the first broker is listed. kafka-cluster-min provisions three, and
+# kafka_server_properties builds advertised.listeners from this value, which
+# has to be the local broker rather than a list. Splitting the client-facing
+# list from the per-host advertised address is a separate change.
+kafka_bootstrap_servers: >-
+  {{ (hostvars[groups['message_broker'][0]].lab_kafka_ip
+      | default(hostvars[groups['message_broker'][0]].lab_mgmt_ip, true)) ~ ':9092'
+     if groups.get('message_broker') else '' }}
 
 opennms_properties_webapp:
   opennms.web.base-url: https://%x%c/


### PR DESCRIPTION
Refs #161

## What

Replaces three hardcoded addresses with values derived from the inventory export added in #200.

| Variable | Was | Now |
|---|---|---|
| `kafka_bootstrap_servers` | `192.0.2.76:9092` | derived → `192.0.2.76:9092` (unchanged) |
| `kafka_ui_bootstrap_servers` | `192.0.2.76:9092` (second copy) | derived → same |
| `opennms_datasource_db_host` | `192.0.2.196` (**mgmt**) | derived → `192.0.2.4` (**db subnet**) |

## Two findings behind this

**A second hardcoded broker address.** `bootstrap/roles/kafka_ui/defaults/main.yml` carried `192.0.2.76:9092` independently of `kafka_bootstrap_servers`, which #161 never noticed. It sits in a bootstrap role, which cannot read `opennms-lab-vars.yml` at all (#197) — that's *why* it was a separate literal rather than a reference. `hostvars` comes from the inventory and is available to every play, so both now resolve the same way.

**The db subnet was provisioned and idle.** `opennms_datasource_db_host` pointed at the database node's **mgmt** address, while the topology gives both `core` and `database` a NIC on the dedicated `db` subnet. That network exists to keep database traffic off the management path a benchmark also uses. Two experiments already used `192.0.2.4`, so the tree disagreed with itself.

No PostgreSQL change needed: `postgres_listen_addresses` is already `"*"` and `postgres_hba_permissions_v4` already covers `192.0.2.0/24`, spanning both subnets.

## Verification — the two cases prove different things

**Kafka is identical to the literal it replaces**, which shows the derivation is correct *and* that nothing changed:

```
$ ansible -i ansible-inventory.yml core -m debug -a "msg={{ kafka_bootstrap_servers }}" -e @opennms-lab-vars.yml
core-benchmark-01 | SUCCESS => "192.0.2.76:9092"
```

**The database moved, and the lab shows the traffic followed:**

```
$ ansible … -a "msg={{ opennms_datasource_db_host }}"
core-benchmark-01 | SUCCESS => "192.0.2.4"

# on db-benchmark-01, established connections into Postgres
192.0.2.4:5432 <- 192.0.2.8:38380
192.0.2.4:5432 <- 192.0.2.8:38384      both ends on the db subnet
```

Previously those would have read `192.0.2.196 <- 192.0.2.200`, both mgmt.

Full `make deploy PROVIDER=kvm DEPLOYMENT=kfk-exclusive`: **0 failures**, 6 hosts. `lint-yaml` and `lint-ansible` clean.

## Deliberately not collapsed: syslog and trap ports

The pinned collection writes both inline in its firewall tasks, not as variables:

```yaml
# <collection>/roles/opennms_minion/tasks/50-firewall.yml
- name: Allow all receiving syslog messages on port 10514/udp
    port: '10514'
```

`opennms_core/tasks/50-firewall.yml` carries the trap literal a third time. So a single definition needs a collection change and a pin bump — a deliberate decision, not an incidental edit. Changing either port here would open one port and listen on another, and it fails silently: traffic dropped before anything logs a rejection, benchmark reports a clean zero.

They will instead be **published as constants and asserted** against what the collection opens, converting a silent mismatch into a loud one without touching the pin.

## Fallback behaviour

The `| default(…ansible_host)` fallback keeps providers that render fixed topologies working. They lose the subnet separation, which is acceptable: only `kvm` and `aws` consume deployment specs, and only those run benchmarks that care.

🤖 Generated with [Claude Code](https://claude.com/claude-code)