### PR TITLE
feat: let the measurement and load tools read the endpoints manifest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,7 @@ ansible-inventory.yml
 # what machines exist, ansible writes what listens where. Same lifecycle, so
 # same treatment.
 lab-endpoints.yml
+lab-endpoints.json
 
 # Repo-local Ansible Vault master key — minted by init_secrets, NEVER commit
 vault_pass.secret

--- a/deployments/roles/kafka_metrics_report/files/kafka_metrics_report.py
+++ b/deployments/roles/kafka_metrics_report/files/kafka_metrics_report.py
@@ -54,8 +54,14 @@ def parse_args(argv=None):
         description="Count OpenNMS metric samples on a Kafka topic and render a report.",
         epilog="Reads a bounded slice and exits; it never tails.",
     )
-    p.add_argument("--bootstrap", required=True, help="Kafka bootstrap servers, host:port")
-    p.add_argument("--topic", default="metrics", help="metric topic (default: metrics)")
+    p.add_argument("--bootstrap", help="Kafka bootstrap servers, host:port; overrides --endpoints")
+    p.add_argument("--topic", help="metric topic; overrides --endpoints (default: metrics)")
+    p.add_argument(
+        "--endpoints",
+        type=Path,
+        default=Path("/etc/lab-endpoints.json"),
+        help="deployment manifest to take the broker and topic from (default: /etc/lab-endpoints.json)",
+    )
     p.add_argument("--group", default="kafka-metrics-report", help="consumer group id")
     p.add_argument("--bucket-seconds", type=int, default=10, help="timeline bucket width (default: 10)")
     p.add_argument("--timeout", type=float, default=30.0, help="seconds to wait for a poll before giving up")
@@ -68,7 +74,37 @@ def parse_args(argv=None):
     )
     p.add_argument("--html", type=Path, default=Path("metrics-report.html"), help="HTML report path")
     p.add_argument("--json", dest="json_out", type=Path, default=Path("metrics-report.json"), help="JSON sidecar path")
-    return p.parse_args(argv)
+    args = p.parse_args(argv)
+    resolve_endpoints(args, p)
+    return args
+
+
+def resolve_endpoints(args, parser):
+    """Fill unset broker and topic from the deployment manifest.
+
+    An explicit flag always wins, so a run can point at something the manifest
+    does not describe. The manifest is only consulted for what was not given,
+    which is also what keeps a wrapper that still passes --bootstrap working
+    unchanged.
+    """
+    manifest = {}
+    if args.endpoints and args.endpoints.exists():
+        try:
+            manifest = json.loads(args.endpoints.read_text())
+        except (OSError, ValueError) as e:
+            parser.error(f"could not read {args.endpoints}: {e}")
+
+    kafka = manifest.get("measurement", {}).get("kafka", {})
+    args.bootstrap = args.bootstrap or kafka.get("bootstrap")
+    args.topic = args.topic or kafka.get("topics", {}).get("metrics") or "metrics"
+    args.deployment = manifest.get("deployment")
+
+    if not args.bootstrap:
+        parser.error(
+            f"no broker: pass --bootstrap, or point --endpoints at a manifest "
+            f"that names one ({args.endpoints} is absent or has no "
+            f"measurement.kafka.bootstrap). Generate one with `make endpoints`."
+        )
 
 
 def bounded_slice(consumer, topic, start_offsets=None, replay_bounds=None):
@@ -203,6 +239,7 @@ def summarise(samples, records, resources_total, errors, args, bounds):
     span = spans["accepted"]
     return {
         "label": args.label,
+        "deployment": args.deployment,
         "topic": args.topic,
         "generated": datetime.now(UTC).isoformat(timespec="seconds"),
         "bucket_seconds": args.bucket_seconds,

--- a/deployments/roles/kafka_metrics_report/templates/kafka-metrics-report.j2
+++ b/deployments/roles/kafka_metrics_report/templates/kafka-metrics-report.j2
@@ -11,8 +11,17 @@ set -euo pipefail
 
 HOME_DIR="{{ kafka_metrics_report_home }}"
 
-exec "${HOME_DIR}/venv/bin/python" "${HOME_DIR}/kafka_metrics_report.py" \
-  --bootstrap "{{ kafka_metrics_report_bootstrap }}" \
-  --topic "{{ kafka_metrics_report_topic }}" \
-  --bucket-seconds "{{ kafka_metrics_report_bucket_seconds }}" \
-  "$@"
+# The manifest is the source when it exists. The templated values remain as a
+# fallback so this keeps working on a lab deployed before `make endpoints`
+# existed, or one whose manifest has not been distributed yet.
+MANIFEST=/etc/lab-endpoints.json
+
+if [ -f "$MANIFEST" ]; then
+  set -- --bucket-seconds "{{ kafka_metrics_report_bucket_seconds }}" "$@"
+else
+  set -- --bootstrap "{{ kafka_metrics_report_bootstrap }}" \
+         --topic "{{ kafka_metrics_report_topic }}" \
+         --bucket-seconds "{{ kafka_metrics_report_bucket_seconds }}" "$@"
+fi
+
+exec "${HOME_DIR}/venv/bin/python" "${HOME_DIR}/kafka_metrics_report.py" "$@"

--- a/deployments/roles/nl6_loadtest/files/nl6_loadtest.py
+++ b/deployments/roles/nl6_loadtest/files/nl6_loadtest.py
@@ -47,7 +47,13 @@ def parse_args(argv=None):
         description="Run one nl6 load-test scenario and report its sent-ledger.",
         epilog="One scenario runs at a time, fleet-wide. nl6 state is in memory and does not survive a restart.",
     )
-    p.add_argument("--url", required=True, help="nl6 base URL, e.g. http://192.0.2.144:8080")
+    p.add_argument("--url", help="nl6 base URL, e.g. http://192.0.2.144:8080; overrides --endpoints")
+    p.add_argument(
+        "--endpoints",
+        type=Path,
+        default=Path("/etc/lab-endpoints.json"),
+        help="deployment manifest to take the nl6 URL and simulated network from",
+    )
     p.add_argument("--protocol", required=True, choices=PROTOCOLS)
     p.add_argument("--rate", type=int, required=True, help=f"events/second per device (1-{MAX_RATE})")
     p.add_argument("--window", required=True, help="measurement window as a Go duration, e.g. 30s, 5m")
@@ -65,6 +71,36 @@ def parse_args(argv=None):
         p.error(f"--rate must be 1..{MAX_RATE} (nl6 limit), got {args.rate}")
     if args.count < 1:
         p.error("--count must be at least 1")
+    resolve_endpoints(args, p)
+    return args
+
+
+def resolve_endpoints(args, parser):
+    """Fill the nl6 URL from the deployment manifest, and read the sim network.
+
+    An explicit --url always wins, so a run can target an nl6 the manifest does
+    not describe. sim_network has no flag: it is the deployment's contract, not
+    a run parameter, and a run that disagrees with it is wrong rather than
+    unusual.
+    """
+    manifest = {}
+    if args.endpoints and args.endpoints.exists():
+        try:
+            manifest = json.loads(args.endpoints.read_text())
+        except (OSError, ValueError) as e:
+            parser.error(f"could not read {args.endpoints}: {e}")
+
+    nl6 = manifest.get("generators", {}).get("nl6", {})
+    args.url = args.url or nl6.get("url")
+    args.sim_network = nl6.get("sim_network")
+    args.deployment = manifest.get("deployment")
+
+    if not args.url:
+        parser.error(
+            f"no nl6 endpoint: pass --url, or point --endpoints at a manifest "
+            f"that names one ({args.endpoints} is absent or has no "
+            f"generators.nl6.url). Generate one with `make endpoints`."
+        )
     return args
 
 
@@ -190,6 +226,7 @@ def summarise(sid, report, armed, args):
     return {
         "scenario_id": sid,
         "label": args.label,
+        "deployment": args.deployment,
         "protocol": summary.get("protocol", args.protocol),
         "phase": summary.get("phase", "unknown"),
         "generated": datetime.now(UTC).isoformat(timespec="seconds"),

--- a/deployments/roles/nl6_loadtest/templates/nl6-loadtest.j2
+++ b/deployments/roles/nl6_loadtest/templates/nl6-loadtest.j2
@@ -13,8 +13,12 @@ set -euo pipefail
 
 HOME_DIR="{{ nl6_loadtest_home }}"
 
+# The manifest is the source when it exists; the templated URL remains as a
+# fallback for a lab deployed before `make endpoints` existed.
+MANIFEST=/etc/lab-endpoints.json
+[ -f "$MANIFEST" ] || set -- --url "{{ nl6_loadtest_url }}" "$@"
+
 exec python3 "${HOME_DIR}/nl6_loadtest.py" \
-  --url "{{ nl6_loadtest_url }}" \
   --start-ip "{{ nl6_loadtest_start_ip }}" \
   --count "{{ nl6_loadtest_count }}" \
   --protocol "{{ nl6_loadtest_protocol }}" \

--- a/endpoints-playbook.yml
+++ b/endpoints-playbook.yml
@@ -111,7 +111,39 @@
         mode: "0644"
       tags: ["endpoints"]
 
+    # A JSON sibling so tools can read the manifest with the standard library.
+    # nl6_loadtest deliberately has no third-party dependencies, and requiring a
+    # YAML parser on a lab node to answer "where do I send traps" would be a
+    # dependency bought for nothing. Same content, rendered once.
+    - name: Publish the machine-readable sibling
+      ansible.builtin.copy:
+        content: "{{ lookup('file', endpoints_file) | from_yaml | to_nice_json }}\n"
+        dest: "{{ endpoints_file | splitext | first }}.json"
+        mode: "0644"
+      tags: ["endpoints"]
+
     - name: Report where it landed
       ansible.builtin.debug:
-        msg: "endpoints published to {{ endpoints_file }}"
+        msg: "endpoints published to {{ endpoints_file }} (+ .json)"
+      tags: ["endpoints"]
+
+# Distribution, not generation. The tools that consume the manifest run on the
+# monitoring node, while generation happens on the control machine, so the file
+# has to travel. Kept as its own play so the generation play above stays
+# localhost-only and can be reasoned about as read-only.
+- name: Distribute the manifest to the hosts that consume it
+  hosts: mon_servers
+  become: true
+  gather_facts: false
+  tasks:
+    - name: Install the endpoints manifest
+      ansible.builtin.copy:
+        src: "{{ item }}"
+        dest: "/etc/lab-endpoints{{ item | splitext | last }}"
+        owner: root
+        group: root
+        mode: "0644"
+      loop:
+        - "{{ playbook_dir }}/lab-endpoints.yml"
+        - "{{ playbook_dir }}/lab-endpoints.json"
       tags: ["endpoints"]


### PR DESCRIPTION
Refs #161 · section 4 of `publish-deployment-endpoints`

## What

`kafka_metrics_report` and `nl6_loadtest` had their endpoints baked in at install time by a Jinja template, so each could only ever serve the deployment that installed it. Both now take `--endpoints` (defaulting to `/etc/lab-endpoints.json`).

```
precedence:  explicit flag  >  manifest  >  templated fallback
```

## Task 4.3 — nothing regresses

The templated values remain for a lab deployed before the manifest existed, or one whose manifest has not been distributed. Both wrappers pass them only when `/etc/lab-endpoints.json` is absent.

Exercised for both tools across all four cases:

| | `kafka_metrics_report` | `nl6_loadtest` |
|---|---|---|
| manifest only | `192.0.2.76:9092`, topic `metrics` | `http://192.0.2.216:8080`, sim `10.42.0.0/16` |
| explicit override | `10.0.0.9:9092`, topic `other` | `http://10.0.0.9:8080` |
| no manifest, no flag | exits naming `make endpoints` | exits naming `make endpoints` |
| no manifest, with flag | works | works |

## Two design points

**Distribution is a separate play.** The manifest is generated on the control machine; the tools run on the monitoring node, so it has to travel. Keeping that out of the generation play leaves generation localhost-only and still reasonable about as read-only.

**A JSON sibling is published alongside the YAML.** `nl6_loadtest` deliberately has no third-party dependencies, and requiring a YAML parser on a lab node to answer "where do I send traps" would be a dependency bought for nothing. Same content, rendered once from the same file.

## Both reports now name their system under test

Taken from the manifest. A result that does not say which deployment produced it is hard to trust later, and the manifest is the first thing that makes naming it free.

`nl6_loadtest` also reads `sim_network`. It gets no flag: the simulated network is the deployment's contract rather than a run parameter, and a run that disagrees with it is wrong rather than unusual. The containment assertion that uses it is section 6.

## Verification — on the lab

```
$ ls /etc/lab-endpoints.*
/etc/lab-endpoints.json   /etc/lab-endpoints.yml

# no endpoint argument at all
$ sudo kafka-metrics-report --label "via manifest"
samples   28,835
mean      2.55/s over 11,320.6s
deployment: kfk-exclusive | topic: metrics

# no --url
$ sudo nl6-loadtest --protocol syslog --rate 5 --window 5s
scenario  s-000001  config_sha256=a6f2175bd3291b31
no participants armed; excluded_by_reason={'device not found': 1}
```

That last line is the correct outcome: the driver resolved the generator from the manifest, reached the scenarios API, and refused because the fleet is empty — the intended post-deploy state, since experiments create their own fleet.

Full deploy: **0 failures**. `lint-python`, `lint-yaml`, `lint-shell`, `lint-ansible` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)