### PR TITLE
feat: strip telemetry config from the nl6 role and guard the sim network

### DIFF
--- a/bootstrap/roles/nl6/defaults/main.yml
+++ b/bootstrap/roles/nl6/defaults/main.yml
@@ -1,18 +1,25 @@
 ---
+# The generator's bootstrap role installs nl6, exposes its API and makes its
+# simulated network reachable. It has no opinion about telemetry.
+#
+# What is exported, to which collectors, and how many devices exist are
+# properties of the experiment, not of the deployment: the experiment creates
+# its fleet through the nl6 API and supplies the protocols and collectors in the
+# device payload. Configuration seeded at container start would apply to
+# nothing, because no devices are auto-created.
+
 # Standalone fallback only. The lab pins the version in
 # group_vars/net_sim/vars.yml, which overrides this.
 nl6_image: "ghcr.io/labmonkeys-space/nl6:v0.9.0"
-nl6_auto_start_ip: "10.42.0.1"
-# Permanently 0, and deliberately so. Devices are created through the nl6 API
-# by the experiment that needs them, because how many devices exist is a
-# property of the workload and has to be recorded on the result. An empty fleet
-# after deployment is the intended state, not a defect.
-nl6_auto_count: 0
-nl6_auto_netmask: "16"
+
 nl6_web_port: 8080
+
+# The contract between the layers, published in lab-endpoints.yml. The Minion's
+# net_sim route and the DOCKER-USER forwarding rules both cover this CIDR, so
+# device addresses an experiment creates must fall inside it. Outside it there
+# is no route and no matching rule, and telemetry is discarded without a trace.
 nl6_sim_network: "10.42.0.0/16"
+
+# Overridden per host by the inventory (nl6_net_interface is a host var derived
+# from the sim NIC's position in the spec's subnet list).
 nl6_net_interface: "enp2s0"
-nl6_flow_collector: "192.0.2.144:9999"
-nl6_flow_protocol: "ipfix"
-nl6_trap_collector: "192.0.2.144:10162"
-nl6_syslog_collector: "192.0.2.144:10514"

--- a/bootstrap/roles/nl6/templates/nl6.service.j2
+++ b/bootstrap/roles/nl6/templates/nl6.service.j2
@@ -14,14 +14,7 @@ ExecStart=/usr/bin/docker run \
   --network host \
   --device /dev/net/tun:/dev/net/tun \
   {{ nl6_image }} \
-  -auto-start-ip {{ nl6_auto_start_ip }} \
-  -auto-count {{ nl6_auto_count }} \
-  -auto-netmask {{ nl6_auto_netmask }} \
-  -port {{ nl6_web_port }} \
-  -flow-collector {{ nl6_flow_collector }} \
-  -flow-protocol {{ nl6_flow_protocol }} \
-  -trap-collector {{ nl6_trap_collector }} \
-  -syslog-collector {{ nl6_syslog_collector }}
+  -port {{ nl6_web_port }}
 ExecStop=/usr/bin/docker stop nl6
 
 [Install]

--- a/deployments/roles/nl6_loadtest/defaults/main.yml
+++ b/deployments/roles/nl6_loadtest/defaults/main.yml
@@ -10,10 +10,14 @@ nl6_loadtest_owner: root
 # sim network the generator is measuring on.
 nl6_loadtest_url: "http://{{ hostvars[groups['net_sim'][0]].ansible_host }}:{{ nl6_web_port | default(8080) }}"
 
-# Participants are derived the same way the nl6 role creates them, so the
-# driver stays in step with the fleet that actually exists.
-nl6_loadtest_start_ip: "{{ nl6_auto_start_ip | default('10.42.0.1') }}"
-nl6_loadtest_count: "{{ nl6_auto_count | default(1) }}"
+# Run parameters, not deployment facts. The generator no longer seeds a fleet,
+# so there is nothing on the nl6 side to stay in step with: an experiment
+# creates the devices it needs through the API and drives exactly those.
+#
+# start_ip must fall inside the deployment's sim_network, which the driver
+# reads from the manifest and asserts. These are only defaults for a probe run.
+nl6_loadtest_start_ip: "10.42.0.1"
+nl6_loadtest_count: 1
 
 # Defaults for a run; all overridable on the command line.
 nl6_loadtest_protocol: syslog

--- a/deployments/roles/nl6_loadtest/files/nl6_loadtest.py
+++ b/deployments/roles/nl6_loadtest/files/nl6_loadtest.py
@@ -122,15 +122,30 @@ def api(url, path, method="GET", body=None, timeout=30):
         raise SystemExit(f"nl6 {method} {path} unreachable at {url}: {e.reason}") from e
 
 
-def participants(start_ip, count):
+def participants(start_ip, count, sim_network=None):
     """Expand a start address and a count into consecutive addresses.
 
-    The lab configures nl6 with -auto-start-ip and -auto-count, so deriving the
-    participant list the same way keeps the driver in step with the fleet the
-    role actually created, without querying an endpoint for it.
+    Asserts the whole range falls inside the deployment's simulated network.
+    Outside it the Minion has no route and the generator host has no matching
+    DOCKER-USER rule, so nl6 sends happily and nothing arrives: the sent-ledger
+    shows a clean run while the system under test appears to have dropped every
+    record. That is the most misleading failure this driver can produce, and it
+    is cheap to refuse.
     """
     first = ipaddress.ip_address(start_ip)
-    return [str(first + i) for i in range(count)]
+    addresses = [first + i for i in range(count)]
+    if sim_network:
+        net = ipaddress.ip_network(sim_network, strict=False)
+        outside = [a for a in (addresses[0], addresses[-1]) if a not in net]
+        if outside:
+            raise SystemExit(
+                f"device range {addresses[0]}..{addresses[-1]} is not inside the "
+                f"deployment's simulated network {net}. "
+                f"{', '.join(str(a) for a in outside)} would have no route from the "
+                f"Minion and no forwarding rule on the generator, so the load would "
+                f"be sent and silently discarded. Choose a range inside {net}."
+            )
+    return [str(a) for a in addresses]
 
 
 def go_seconds(duration):
@@ -161,7 +176,7 @@ def go_seconds(duration):
 
 def run_scenario(args):
     body = {
-        "participants": participants(args.start_ip, args.count),
+        "participants": participants(args.start_ip, args.count, args.sim_network),
         "protocol": args.protocol,
         "rate": args.rate,
         "window": args.window,


### PR DESCRIPTION
Refs #161 · sections 5 and 6 of `publish-deployment-endpoints`, completing it at 31/31

## What

The generator's bootstrap role installed nl6 **and** decided what it exported and to where. The service definition goes from eight flags to one:

```diff
   {{ nl6_image }} \
-  -auto-start-ip … -auto-count … -auto-netmask … \
-  -port {{ nl6_web_port }} \
-  -flow-collector … -flow-protocol … -trap-collector … -syslog-collector …
+  -port {{ nl6_web_port }}
```

## Why those settings were doing nothing

With the fleet created through the nl6 API by the experiment that needs it, and `-auto-count` permanently `0`, nothing is auto-created at container start — so seeded collectors seed nothing. They were three plausible-looking addresses and an export protocol that a reader would take for the values in use.

Which protocols are tested and where their output goes is a property of the experiment. It supplies both in the device payload, which carries `traps` and `syslog` blocks as well as `flow`.

## The guard (section 6)

`nl6_sim_network` stays, and becomes the contract between the layers. The Minion's named route and the `DOCKER-USER` forwarding rules both cover that CIDR.

Outside it there is no route and no matching rule: **nl6 sends happily, nothing arrives, and the sent-ledger shows a clean run while the system under test appears to have dropped every record.** That is the most misleading failure this driver can produce, so it now refuses — reading `sim_network` from the manifest, which #203 taught it to do.

Both ends of the range are checked, catching a start inside the network whose count runs off the end.

## Verification — on the lab

```
$ sudo grep -A7 ExecStart /etc/systemd/system/nl6.service
  ghcr.io/labmonkeys-space/nl6:v0.21.0 \
  -port 8080

$ systemctl is-active nl6                        active
$ curl …/api/v1/version                          {"version":"v0.21.0"}
$ curl -o /dev/null -w '%{http_code}' …/scenarios 200
```

Guard, against the live manifest:

```
$ sudo nl6-loadtest … --start-ip 10.99.0.1 --count 3
device range 10.99.0.1..10.99.0.3 is not inside the deployment's simulated network
10.42.0.0/16. … the load would be sent and silently discarded.
exit=1                                    ← refused before submitting anything

$ sudo nl6-loadtest … --start-ip 10.42.0.1 --count 3
scenario s-000001 … no participants armed; {'device not found': 3}
                                          ← reaches nl6; empty fleet is intended
```

Boundary cases exercised directly: range running off the end **refused**, last address of the network **accepted**, unknown `sim_network` **permissive** rather than fatal.

Full deploy: **0 failures**. `lint-python`, `lint-yaml`, `lint-ansible` clean.

## Note

`nl6_loadtest`'s `start_ip` and `count` stop deriving from the role — there is no seeded fleet to stay in step with, and they are run parameters rather than deployment facts. The containment assertion is what keeps them honest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)