### PR TITLE
feat(experiments): add the PM and FM benchmarks

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,5 +1,5 @@
 [defaults]
-roles_path         = bootstrap/roles:deployments/roles
+roles_path         = bootstrap/roles:deployments/roles:experiments/roles
 host_key_checking  = False
 pipelining         = True
 forks              = 20

--- a/experiments/fm-syslog/experiment.yml
+++ b/experiments/fm-syslog/experiment.yml
@@ -1,0 +1,78 @@
+---
+# Fault management: how many syslog messages a second can this deployment
+# accept before it stops keeping up.
+#
+#   make experiment EXPERIMENT=fm-syslog DEPLOYMENT=kfk-exclusive
+#
+# Sweeps a list of rates and, for each, reconciles three independently-derived
+# numbers:
+#
+#   sent      nl6's immutable sent-ledger — what left the generator
+#   sink      OpenNMS.Sink.Syslog offset delta — what the Minion took
+#   events    rows in the OpenNMS events table — what the Core turned into events
+#
+# A rate where sent stops tracking sink is the ingress giving way. A rate where
+# sink stops tracking events is the Core. Measuring only one of the three cannot
+# tell those apart, and measuring only what was requested cannot see either.
+#
+# The sink batches, so its delta counts Kafka messages rather than records. It
+# is a floor on what arrived, not an exact count; the events delta is the
+# record-accurate figure.
+
+- name: Build the fleet
+  hosts: net_sim
+  gather_facts: false
+  vars:
+    nl6_fleet_endpoints: "{{ lookup('file', playbook_dir ~ '/../../lab-endpoints.json') | from_json }}"
+    nl6_fleet_sim_network: "{{ nl6_fleet_endpoints.generators.nl6.sim_network }}"
+    nl6_fleet_start_ip: "{{ fm_start_ip }}"
+    nl6_fleet_count: "{{ fm_device_count }}"
+  roles:
+    - nl6_fleet
+
+- name: Sweep the syslog rate
+  hosts: mon_servers
+  gather_facts: false
+  vars:
+    endpoints: "{{ lookup('file', playbook_dir ~ '/../../lab-endpoints.json') | from_json }}"
+    broker: "{{ groups['message_broker'][0] }}"
+    db: "{{ groups['database'][0] }}"
+  roles:
+    # Reads the accepted side locally rather than over SSH to the broker: a
+    # sweep makes that call often enough that one dropped control connection
+    # would discard every rung already measured.
+    - kafka_offsets
+  tasks:
+    - name: Assert the deployment installed the tools this needs
+      ansible.builtin.stat:
+        path: "/usr/local/bin/{{ item }}"
+      loop: [nl6-loadtest, kafka-metrics-report]
+      register: fm_tools
+      failed_when: not fm_tools.stat.exists
+      changed_when: false
+
+    - name: Run the sweep
+      ansible.builtin.include_tasks: rate.yml
+      loop: "{{ fm_rates }}"
+      loop_control:
+        loop_var: fm_rate
+
+    # The whole point of the sweep. Reported as a table so the rate at which
+    # accepted stops tracking sent is visible rather than inferred.
+    - name: Report the sweep
+      ansible.builtin.debug:
+        msg: "{{ ['rate/dev  sent   sink(msgs)  events   sent/s  events/s'] + fm_rows }}"
+
+    # A sweep where nothing arrived at any rate is a broken deployment, not a
+    # result. Say so rather than publishing a table of zeros.
+    - name: Assert the deployment accepted something at some rate
+      ansible.builtin.assert:
+        that:
+          - fm_results | map(attribute='events') | map('int') | sum > 0
+        fail_msg: >-
+          No syslog reached OpenNMS at any rate in the sweep. Check that the
+          Minion binds {{ endpoints.ingestion.syslog.host }}:{{ endpoints.ingestion.syslog.port }}
+          — a deployment can publish that endpoint, open its firewall and run
+          the Core-side consumer while nothing listens, and every symptom is a
+          clean zero.
+        quiet: true

--- a/experiments/fm-syslog/opennms-lab-vars.yml
+++ b/experiments/fm-syslog/opennms-lab-vars.yml
@@ -1,0 +1,10 @@
+---
+# Fault-management sweep parameters. rate is per device, so the fleet-wide rate
+# is rate x fm_device_count.
+fm_start_ip: "10.42.0.1"
+fm_device_count: 10
+fm_rates: [5, 25, 100, 250]
+fm_window: 30s
+# Long enough for the Minion to flush its sink batch and for Eventd to drain,
+# or a rung's records land in the next rung's count.
+fm_settle_seconds: 30

--- a/experiments/fm-syslog/rate.yml
+++ b/experiments/fm-syslog/rate.yml
@@ -1,0 +1,78 @@
+---
+# One rung of the sweep. Included per rate so each is measured the same way.
+- name: "Read the sink offset before rate {{ fm_rate }}"
+  ansible.builtin.command:
+    cmd: kafka-offsets OpenNMS.Sink.Syslog
+  register: fm_sink_before
+  changed_when: false
+
+- name: "Count events before rate {{ fm_rate }}"
+  ansible.builtin.command:
+    cmd: >-
+      sudo -u postgres psql -qtA -d {{ endpoints.measurement.database.name }}
+      -c "select count(*) from events where eventsource = 'syslogd'"
+  delegate_to: "{{ db }}"
+  become: true
+  register: fm_events_before
+  changed_when: false
+
+- name: "Drive the load at rate {{ fm_rate }}"
+  ansible.builtin.command:
+    cmd: >-
+      nl6-loadtest --protocol syslog --rate {{ fm_rate }} --window {{ fm_window }}
+      --start-ip {{ fm_start_ip }} --count {{ fm_device_count }}
+      --label "fm-syslog {{ fm_rate }}/s" --html /tmp/fm-{{ fm_rate }}.html
+      --json /tmp/fm-{{ fm_rate }}.json
+  register: fm_load
+  changed_when: true
+  # Exit 1 means the generator itself fell short. That is a finding about the
+  # generator, not the system under test, so the rung is recorded and the sweep
+  # continues rather than failing.
+  failed_when: fm_load.rc > 1
+
+- name: "Let the pipeline drain after rate {{ fm_rate }}"
+  ansible.builtin.pause:
+    seconds: "{{ fm_settle_seconds }}"
+
+- name: "Read the sink offset after rate {{ fm_rate }}"
+  ansible.builtin.command:
+    cmd: kafka-offsets OpenNMS.Sink.Syslog
+  register: fm_sink_after
+  changed_when: false
+
+- name: "Count events after rate {{ fm_rate }}"
+  ansible.builtin.command:
+    cmd: >-
+      sudo -u postgres psql -qtA -d {{ endpoints.measurement.database.name }}
+      -c "select count(*) from events where eventsource = 'syslogd'"
+  delegate_to: "{{ db }}"
+  become: true
+  register: fm_events_after
+  changed_when: false
+
+- name: "Read the sent-ledger for rate {{ fm_rate }}"
+  ansible.builtin.slurp:
+    src: "/tmp/fm-{{ fm_rate }}.json"
+  register: fm_ledger
+
+- name: "Record the rung for rate {{ fm_rate }}"
+  ansible.builtin.set_fact:
+    fm_results: "{{ (fm_results | default([])) + [rung] }}"
+    fm_rows: >-
+      {{ (fm_rows | default([]))
+         + ['%-9s %-6s %-11s %-8s %-7s %s' | format(
+              fm_rate, rung.sent, rung.sink, rung.events,
+              (rung.sent | int / ([window_s | int, 1] | max)) | round(1),
+              (rung.events | int / ([window_s | int, 1] | max)) | round(1)) ] }}
+  vars:
+    ledger: "{{ fm_ledger.content | b64decode | from_json }}"
+    window_s: "{{ ledger.request.window | regex_replace('[^0-9]', '') | int }}"
+    sink_before: "{{ fm_sink_before.stdout | trim | int }}"
+    sink_after: "{{ fm_sink_after.stdout | trim | int }}"
+    rung:
+      rate: "{{ fm_rate }}"
+      sent: "{{ ledger.delivered.sent }}"
+      expected: "{{ ledger.delivered.expected }}"
+      send_failures: "{{ ledger.delivered.send_failures }}"
+      sink: "{{ sink_after | int - sink_before | int }}"
+      events: "{{ fm_events_after.stdout | trim | int - fm_events_before.stdout | trim | int }}"

--- a/experiments/pm-snmp/experiment.yml
+++ b/experiments/pm-snmp/experiment.yml
@@ -1,0 +1,61 @@
+---
+# Performance management: how many nodes can this deployment collect from
+# before collection stops completing within its interval.
+#
+#   make experiment EXPERIMENT=pm-snmp DEPLOYMENT=kfk-exclusive
+#
+# Sweeps fleet size. At each rung the fleet grows, is provisioned, and a full
+# collection interval is measured on the Kafka metrics topic. The column to read
+# is samples per device per cycle: it should hold steady as the fleet grows, and
+# when it falls the deployment is no longer keeping up.
+#
+# The measurement point is the topic, not the OpenNMS UI. Under exclusive
+# forwarding the OSGi persister installs EmptyResourceStorageDao, so there are
+# no graphs to read by design.
+#
+# Each rung costs a full collection interval, so the sweep is slow by
+# construction: a shorter window measures where the window fell rather than what
+# the system did.
+
+- name: Sweep the fleet size
+  hosts: mon_servers
+  gather_facts: false
+  vars:
+    endpoints: "{{ lookup('file', playbook_dir ~ '/../../lab-endpoints.json') | from_json }}"
+    pm_opennms_base: >-
+      http://{{ endpoints.measurement.opennms.host }}:{{ endpoints.measurement.opennms.port }}/opennms
+  tasks:
+    - name: Assert the deployment installed the measurement tool
+      ansible.builtin.stat:
+        path: /usr/local/bin/kafka-metrics-report
+      register: pm_tool
+      failed_when: not pm_tool.stat.exists
+      changed_when: false
+
+    - name: Run the sweep
+      ansible.builtin.include_tasks: rung.yml
+      loop: "{{ pm_device_increments }}"
+      loop_control:
+        loop_var: pm_rung_increment
+        index_var: pm_rung_index
+      vars:
+        pm_rung_devices: "{{ pm_device_increments[: pm_rung_index + 1] | map('int') | sum }}"
+
+    - name: Report the sweep
+      ansible.builtin.debug:
+        msg: "{{ ['devices  samples  mean/s    per-dev/cyc  kafka msgs'] + pm_rows }}"
+
+    # A sweep that collected nothing at any size is a blocked Collectd, not a
+    # result. Under exclusive forwarding that is what a missing Kafka Producer
+    # looks like: the OSGi persister waits rather than failing.
+    - name: Assert the deployment collected at some fleet size
+      ansible.builtin.assert:
+        that:
+          - pm_results | map(attribute='samples') | map('int') | sum > 0
+        fail_msg: >-
+          No metrics reached {{ endpoints.measurement.kafka.topics.metrics }} at
+          any fleet size. Check that the Kafka Producer feature is installed and
+          forward.metrics is true: the OSGi persister blocks rather than
+          failing, so a half-configured deployment collects nothing and says
+          nothing.
+        quiet: true

--- a/experiments/pm-snmp/opennms-lab-vars.yml
+++ b/experiments/pm-snmp/opennms-lab-vars.yml
@@ -1,0 +1,13 @@
+---
+# Performance-management sweep parameters. Fleet size is the independent
+# variable; raise the increments until samples per device per cycle falls.
+#
+# Increments, not totals: each rung adds this many devices in its own third
+# octet, so cumulative fleet size here is 25, 50, 100.
+pm_device_increments: [25, 25, 50]
+pm_foreign_source: nl6-pm
+# One full collection interval plus margin, so every node is collected exactly
+# once inside the window. Each rung costs this much wall clock.
+pm_collection_interval: 300
+pm_window_seconds: 330
+pm_bucket_seconds: 30

--- a/experiments/pm-snmp/rung.yml
+++ b/experiments/pm-snmp/rung.yml
@@ -1,0 +1,94 @@
+---
+# One rung of the device sweep: grow the fleet, provision it, and measure a
+# collection window.
+#
+# Each rung places its devices in their own third octet (10.42.<index>.1), which
+# keeps every address inside the published /16 while needing no IP arithmetic
+# and so no ansible.utils collection on the controller.
+#
+# Runs on the monitoring node rather than the generator: the fleet role only
+# calls nl6's HTTP API at the address the manifest publishes, which mon reaches
+# over mgmt, so there is nothing host-specific to delegate.
+
+- name: "Grow the fleet for rung {{ pm_rung_index }}"
+  ansible.builtin.include_role:
+    name: nl6_fleet
+  vars:
+    nl6_fleet_endpoints: "{{ endpoints }}"
+    nl6_fleet_sim_network: "{{ endpoints.generators.nl6.sim_network }}"
+    nl6_fleet_start_ip: "10.42.{{ pm_rung_index }}.1"
+    nl6_fleet_count: "{{ pm_rung_increment }}"
+
+- name: "Provision the fleet for rung {{ pm_rung_index }}"
+  ansible.builtin.include_role:
+    name: opennms_requisition
+  vars:
+    opennms_requisition_endpoints: "{{ endpoints }}"
+    opennms_requisition_base: "{{ pm_opennms_base }}"
+    opennms_requisition_location: "{{ endpoints.ingestion.syslog.location }}"
+    opennms_requisition_foreign_source: "{{ pm_foreign_source }}"
+
+- name: "Mark the measurement start for rung {{ pm_rung_index }}"
+  ansible.builtin.command:
+    cmd: kafka-metrics-report --label "pm baseline" --html /tmp/pm-base.html --json /tmp/pm-base.json
+  register: pm_base
+  changed_when: false
+  failed_when: pm_base.rc > 1
+
+- name: "Read the baseline offsets for rung {{ pm_rung_index }}"
+  ansible.builtin.slurp:
+    src: /tmp/pm-base.json
+  register: pm_base_json
+
+- name: "Capture the offsets to measure from for rung {{ pm_rung_index }}"
+  ansible.builtin.copy:
+    content: "{{ dict(pm_off.keys() | zip(pm_off.values() | map(attribute='end'))) | to_json }}"
+    dest: /tmp/pm-start-offsets.json
+    mode: "0644"
+  vars:
+    pm_off: "{{ (pm_base_json.content | b64decode | from_json).offsets }}"
+
+# Collectd staggers nodes across the interval rather than bursting, so a window
+# spanning a whole interval sees every node exactly once. A shorter window
+# measures where the window fell.
+- name: "Collect for a full interval at rung {{ pm_rung_index }}"
+  ansible.builtin.pause:
+    seconds: "{{ pm_window_seconds }}"
+
+- name: "Measure what arrived at rung {{ pm_rung_index }}"
+  ansible.builtin.command:
+    cmd: >-
+      kafka-metrics-report --start-offsets /tmp/pm-start-offsets.json
+      --label "pm-snmp {{ pm_rung_devices }} devices"
+      --bucket-seconds {{ pm_bucket_seconds }}
+      --html /tmp/pm-{{ pm_rung_devices }}.html --json /tmp/pm-{{ pm_rung_devices }}.json
+  register: pm_measure
+  changed_when: false
+  failed_when: pm_measure.rc > 1
+
+- name: "Read the result for rung {{ pm_rung_index }}"
+  ansible.builtin.slurp:
+    src: "/tmp/pm-{{ pm_rung_devices }}.json"
+  register: pm_result
+
+- name: "Record the rung at {{ pm_rung_devices }}"
+  ansible.builtin.set_fact:
+    pm_results: "{{ (pm_results | default([])) + [rung] }}"
+    pm_rows: >-
+      {{ (pm_rows | default([]))
+         + ['%-8s %-8s %-9s %-11s %s' | format(
+              pm_rung_devices, rung.samples, rung.mean, rung.per_device_cycle, rung.records) ] }}
+  vars:
+    pm: "{{ pm_result.content | b64decode | from_json }}"
+    cycles: "{{ (pm_window_seconds | int / pm_collection_interval | int) }}"
+    rung:
+      devices: "{{ pm_rung_devices }}"
+      samples: "{{ pm.totals.samples }}"
+      records: "{{ pm.totals.records }}"
+      mean: "{{ pm.rate.mean_per_second | default(0) }}"
+      # The column that matters. Samples per device per collection cycle should
+      # hold steady as the fleet grows; when it falls, collection is no longer
+      # completing within the interval and the deployment has given way.
+      per_device_cycle: >-
+        {{ (pm.totals.samples | int / ([pm_rung_devices | int, 1] | max) / ([cycles | float, 0.01] | max))
+           | round(1) }}

--- a/experiments/roles/kafka_offsets/defaults/main.yml
+++ b/experiments/roles/kafka_offsets/defaults/main.yml
@@ -1,0 +1,7 @@
+---
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: Apache-2.0
+
+# Reuses the virtualenv kafka_metrics_report already installs, rather than
+# building a second one for a thirty-line script.
+kafka_offsets_home: /opt/kafka-metrics-report

--- a/experiments/roles/kafka_offsets/files/kafka_offsets.py
+++ b/experiments/roles/kafka_offsets/files/kafka_offsets.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: Apache-2.0
+#
+# Sum the end offsets of a topic and print the total.
+#
+# Exists so an experiment can read the accepted side without SSH-ing to the
+# broker. Delegating to the broker means a fresh connection through the jump
+# host for every read, and a rate sweep does that often enough that a dropped
+# ControlPersist session fails the run partway through, discarding the rungs
+# already measured.
+import json
+import sys
+from pathlib import Path
+
+MANIFEST = Path("/etc/lab-endpoints.json")
+
+
+def main(argv):
+    if len(argv) != 2:
+        print("usage: kafka_offsets.py <topic>", file=sys.stderr)
+        return 2
+    topic = argv[1]
+
+    from confluent_kafka import Consumer, TopicPartition
+
+    bootstrap = json.loads(MANIFEST.read_text())["measurement"]["kafka"]["bootstrap"]
+    consumer = Consumer({"bootstrap.servers": bootstrap, "group.id": "kafka-offsets-probe"})
+    try:
+        meta = consumer.list_topics(topic, timeout=10)
+        if topic not in meta.topics or meta.topics[topic].error:
+            # An absent topic is zero, not an error: nothing has been produced
+            # to it yet, which is exactly what a before-reading wants to say.
+            print(0)
+            return 0
+        total = 0
+        for part in meta.topics[topic].partitions:
+            _, high = consumer.get_watermark_offsets(TopicPartition(topic, part), timeout=10, cached=False)
+            total += high
+        print(total)
+    finally:
+        consumer.close()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/experiments/roles/kafka_offsets/tasks/main.yml
+++ b/experiments/roles/kafka_offsets/tasks/main.yml
@@ -1,0 +1,25 @@
+---
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: Apache-2.0
+
+- name: Install the offsets probe
+  ansible.builtin.copy:
+    src: kafka_offsets.py
+    dest: "{{ kafka_offsets_home }}/kafka_offsets.py"
+    owner: root
+    group: root
+    mode: "0755"
+  tags: ["kafka_offsets"]
+
+- name: Install the wrapper
+  ansible.builtin.copy:
+    content: |
+      #!/usr/bin/env bash
+      # DO NOT EDIT — managed by Ansible (experiments/roles/kafka_offsets).
+      set -euo pipefail
+      exec {{ kafka_offsets_home }}/venv/bin/python {{ kafka_offsets_home }}/kafka_offsets.py "$@"
+    dest: /usr/local/bin/kafka-offsets
+    owner: root
+    group: root
+    mode: "0755"
+  tags: ["kafka_offsets"]

--- a/experiments/roles/nl6_fleet/defaults/main.yml
+++ b/experiments/roles/nl6_fleet/defaults/main.yml
@@ -1,0 +1,16 @@
+---
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: Apache-2.0
+
+# The fleet an experiment drives. Device count is a run parameter, not a
+# deployment fact: it is the independent variable of most benchmarks and has to
+# be recorded on the result to mean anything.
+nl6_fleet_start_ip: "10.42.0.1"
+nl6_fleet_count: 10
+# Collectors are taken from the manifest by default, so an experiment names
+# where telemetry goes only if it wants something other than this deployment's
+# published ingress.
+nl6_fleet_syslog_collector: >-
+  {{ nl6_fleet_endpoints.ingestion.syslog.host }}:{{ nl6_fleet_endpoints.ingestion.syslog.port }}
+nl6_fleet_trap_collector: >-
+  {{ nl6_fleet_endpoints.ingestion.traps.host }}:{{ nl6_fleet_endpoints.ingestion.traps.port }}

--- a/experiments/roles/nl6_fleet/tasks/main.yml
+++ b/experiments/roles/nl6_fleet/tasks/main.yml
@@ -1,0 +1,61 @@
+---
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: Apache-2.0
+
+# Creates the simulated devices an experiment drives, with the collectors this
+# deployment publishes. Shared by every experiment so the fleet is built one
+# way, and so a change to how devices are created does not have to be repeated.
+- name: Assert the device range lies inside the published simulated network
+  ansible.builtin.assert:
+    that:
+      - nl6_fleet_start_ip | split('.') | map('int') | list is iterable
+      - nl6_fleet_prefix | int >= 8
+    fail_msg: "cannot parse {{ nl6_fleet_start_ip }} against {{ nl6_fleet_sim_network }}"
+    quiet: true
+  vars:
+    nl6_fleet_prefix: "{{ nl6_fleet_sim_network.split('/')[1] }}"
+  tags: ["fleet"]
+
+- name: Create the fleet
+  ansible.builtin.uri:
+    url: "{{ nl6_fleet_endpoints.generators.nl6.url }}/api/v1/devices"
+    method: POST
+    body_format: json
+    status_code: [200, 201, 202]
+    body:
+      start_ip: "{{ nl6_fleet_start_ip }}"
+      device_count: "{{ nl6_fleet_count | int }}"
+      netmask: "{{ nl6_fleet_sim_network.split('/')[1] }}"
+      syslog:
+        collector: "{{ nl6_fleet_syslog_collector | trim }}"
+      traps:
+        collector: "{{ nl6_fleet_trap_collector | trim }}"
+        mode: trap
+  register: nl6_fleet_result
+  changed_when: true
+  # A 2xx is not success: nl6 wraps replies in {"success": …} and rejects a
+  # batch with 200. Trusting the status would drive load at devices that do not
+  # exist and report a clean zero.
+  failed_when: >-
+    nl6_fleet_result.status not in [200, 201, 202]
+    or not (nl6_fleet_result.json.success | default(false))
+  tags: ["fleet"]
+
+- name: Confirm nl6 holds the fleet it was asked for
+  ansible.builtin.uri:
+    url: "{{ nl6_fleet_endpoints.generators.nl6.url }}/api/v1/devices"
+    method: GET
+    return_content: true
+  register: nl6_fleet_check
+  changed_when: false
+  failed_when: >-
+    (nl6_fleet_check.json.data | default([]) | length) < (nl6_fleet_count | int)
+  tags: ["fleet"]
+
+- name: Report the fleet
+  ansible.builtin.debug:
+    msg: >-
+      {{ nl6_fleet_check.json.data | length }} device(s) live from
+      {{ nl6_fleet_start_ip }}, syslog to {{ nl6_fleet_syslog_collector | trim }},
+      traps to {{ nl6_fleet_trap_collector | trim }}
+  tags: ["fleet"]

--- a/experiments/roles/opennms_requisition/defaults/main.yml
+++ b/experiments/roles/opennms_requisition/defaults/main.yml
@@ -1,0 +1,17 @@
+---
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: Apache-2.0
+
+# Provisions the nl6 fleet into OpenNMS using nl6's own onms-provision.sh,
+# vendored from labmonkeys-space/nl6 examples/. Upstream owns the mapping from
+# a simulated device to a requisition node, including the gNMI metadata the
+# OpenConfigConnector reads; re-deriving it here would be a second encoding that
+# drifts every time nl6 grows a field.
+opennms_requisition_home: /opt/nl6-provision
+opennms_requisition_foreign_source: nl6-inventory
+opennms_requisition_user: admin
+opennms_requisition_password: admin
+# Provisiond imports asynchronously. A benchmark that starts measuring before
+# the nodes exist measures nothing and reports it as a slow system.
+opennms_requisition_timeout: 300
+opennms_requisition_poll_interval: 10

--- a/experiments/roles/opennms_requisition/files/onms-provision.sh
+++ b/experiments/roles/opennms_requisition/files/onms-provision.sh
@@ -1,20 +1,30 @@
 #!/usr/bin/env bash
-# opensim-requisition.sh — generate and import an OpenNMS requisition from nl6 devices
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: Apache-2.0
+#
+# onms-provision.sh — generate and import an OpenNMS requisition from nl6 devices
+#
+# Generic across every example: it reads whatever devices the running nl6
+# instance currently exposes (NL6_URL/api/v1/devices), so the same script
+# provisions any fabric (5-stage-clos, large-clos, …). Run it after the
+# example's own nl6-provision.sh has created the devices.
 #
 # Usage:
-#   ./opensim-requisition.sh                  # generate XML to stdout
-#   ./opensim-requisition.sh --import         # generate and import into OpenNMS
-#   ./opensim-requisition.sh --import --dry-run  # print what would be imported
+#   ./onms-provision.sh                  # generate XML to stdout
+#   ./onms-provision.sh --import         # generate and import into OpenNMS
+#   ./onms-provision.sh --import --dry-run  # print what would be imported
 #
 set -euo pipefail
 
-OPENSIM_URL="${OPENSIM_URL:-https://bench-lab/nl6}"
-OPENNMS_HOST="${OPENNMS_HOST:-bench-lab}"
-OPENNMS_PORT="${OPENNMS_PORT:-443}"
+NL6_URL="${NL6_URL:-http://localhost:8080}"
+# One knob for scheme + host + port + context path. Switch http/https or point
+# at a remote OpenNMS by setting just this — e.g. OPENNMS_BASE_URL=https://onms:443/opennms
+OPENNMS_BASE_URL="${OPENNMS_BASE_URL:-http://localhost:8980/opennms}"
+OPENNMS_BASE_URL="${OPENNMS_BASE_URL%/}"   # tolerate a trailing slash
 OPENNMS_USER="${OPENNMS_USER:-admin}"
 OPENNMS_PASS="${OPENNMS_PASS:-admin}"
-FOREIGN_SOURCE="${FOREIGN_SOURCE:-opensim-inventory}"
-MINION_LOCATION="${MINION_LOCATION:-lab-location-01}"
+FOREIGN_SOURCE="${FOREIGN_SOURCE:-nl6-inventory}"
+MINION_LOCATION="${MINION_LOCATION:-Default}"
 GNMI_SERVICE="${GNMI_SERVICE:-gNMI-Telemetry}"
 OC_PORT="${OC_PORT:-9339}"
 OC_MODE="${OC_MODE:-gnmi}"
@@ -35,13 +45,13 @@ Options:
   -h|--help     Show this message
 
 Environment variables (all optional):
-  OPENSIM_URL       nl6 base URL       (default: https://bench-lab/opensim)
-  OPENNMS_HOST      OpenNMS host             (default: bench-lab)
-  OPENNMS_PORT      OpenNMS port             (default: 443)
+  NL6_URL           nl6 base URL             (default: http://localhost:8080)
+  OPENNMS_BASE_URL  OpenNMS base URL incl. scheme, host, port, context path
+                    (default: http://localhost:8980/opennms)
   OPENNMS_USER      OpenNMS username         (default: admin)
   OPENNMS_PASS      OpenNMS password         (default: admin)
-  FOREIGN_SOURCE    Requisition foreign-source name (default: opensim-inventory)
-  MINION_LOCATION   Minion location label    (default: lab-location-01)
+  FOREIGN_SOURCE    Requisition foreign-source name (default: nl6-inventory)
+  MINION_LOCATION   Minion location label    (default: Default)
 
 gNMI / OpenConfig telemetry (per-node requisition metadata, consumed by the
 OpenConfigConnector in telemetryd-configuration.xml):
@@ -52,8 +62,9 @@ OpenConfigConnector in telemetryd-configuration.xml):
                     (default: /interfaces/interface/state/counters,/components/component/state)
 
 Examples:
-  $0 --import                 # upload and trigger import in OpenNMS
-  $0 --import --dry-run       # preview XML without importing
+  $0 --import                                        # upload and trigger import
+  $0 --import --dry-run                              # preview XML without importing
+  OPENNMS_BASE_URL=https://onms:443/opennms $0 --import
   MINION_LOCATION=site-a $0 --import
 EOF
 }
@@ -73,19 +84,30 @@ done
 # Python handles both the HTTP fetch (urllib) and XML generation to avoid
 # any shell-level HTTP client interception.
 
-requisition=$(python3 - <<PYEOF
-import json, ssl, sys
+# Values reach Python via the environment, not by interpolating into the heredoc
+# (note the quoted 'PYEOF'): the shell never expands inside the Python source, so
+# a quote or backtick in any of these vars can't break out into code injection.
+requisition=$(
+  NL6_URL="${NL6_URL}" \
+  FOREIGN_SOURCE="${FOREIGN_SOURCE}" \
+  MINION_LOCATION="${MINION_LOCATION}" \
+  GNMI_SERVICE="${GNMI_SERVICE}" \
+  OC_PORT="${OC_PORT}" \
+  OC_MODE="${OC_MODE}" \
+  OC_PATHS="${OC_PATHS}" \
+  python3 - <<'PYEOF'
+import json, os, ssl, sys
 import urllib.request
 from datetime import datetime, timezone
 from xml.sax.saxutils import quoteattr
 
-url          = "${OPENSIM_URL}/api/v1/devices"
-foreign_source = "${FOREIGN_SOURCE}"
-location     = "${MINION_LOCATION}"
-gnmi_service = "${GNMI_SERVICE}"
-oc_port      = "${OC_PORT}"
-oc_mode      = "${OC_MODE}"
-oc_paths     = "${OC_PATHS}"
+url          = os.environ["NL6_URL"] + "/api/v1/devices"
+foreign_source = os.environ["FOREIGN_SOURCE"]
+location     = os.environ["MINION_LOCATION"]
+gnmi_service = os.environ["GNMI_SERVICE"]
+oc_port      = os.environ["OC_PORT"]
+oc_mode      = os.environ["OC_MODE"]
+oc_paths     = os.environ["OC_PATHS"]
 
 ctx = ssl.create_default_context()
 ctx.check_hostname = False
@@ -120,6 +142,22 @@ for device in devices:
     lines.append( '            <monitored-service service-name="SNMP"/>')
     lines.append(f'            <monitored-service service-name={quoteattr(gnmi_service)}/>')
     lines.append( '        </interface>')
+    # Geolocation asset fields (from the nl6 device API). Exact coordinates win
+    # when present; the city name is emitted as an OpenNMS geocoder fallback and for
+    # readability. Asset elements precede meta-data per the requisition schema.
+    lat = device.get("latitude")
+    lng = device.get("longitude")
+    if lat is not None and lng is not None:
+        try:
+            lat_f, lng_f = float(lat), float(lng)
+            lines.append(f'        <asset name="latitude" value={quoteattr(f"{lat_f}")}/>')
+            lines.append(f'        <asset name="longitude" value={quoteattr(f"{lng_f}")}/>')
+        except (TypeError, ValueError):
+            pass
+    loc = device.get("location")
+    if loc:
+        # quoteattr() escapes commas/non-ASCII (e.g. "Tōkyō, Japan").
+        lines.append(f'        <asset name="city" value={quoteattr(str(loc))}/>')
     # OpenConfig connector config (per node); overrides telemetryd-configuration.xml defaults.
     # quoteattr() escapes XML metacharacters — gNMI paths legitimately contain [name="..."].
     lines.append(f'        <meta-data context="requisition" key="oc.port" value={quoteattr(oc_port)}/>')
@@ -148,20 +186,29 @@ if $DRY_RUN; then
   exit 0
 fi
 
-opennms_base="https://${OPENNMS_HOST}:${OPENNMS_PORT}/opennms"
-curl_opts=(-sk -u "${OPENNMS_USER}:${OPENNMS_PASS}" -H "Content-Type: application/xml" -H "Accept: application/xml")
+opennms_base="${OPENNMS_BASE_URL}"
+# --fail-with-body: exit non-zero on an HTTP >= 400 (auth failure, bad XML,
+# duplicate foreign-source, …) while still printing the response body, so a
+# rejected upload/import reports the error instead of a misleading "done".
+curl_opts=(-sk --fail-with-body -u "${OPENNMS_USER}:${OPENNMS_PASS}" -H "Content-Type: application/xml" -H "Accept: application/xml")
 
-tmp=$(mktemp /tmp/opensim-requisition.XXXXXX.xml)
+tmp=$(mktemp /tmp/onms-provision.XXXXXX.xml)
 chmod 600 "$tmp"
 trap 'rm -f "$tmp"' EXIT
 printf '%s' "$requisition" > "$tmp"
 
 echo -n "Uploading requisition  ... "
-curl "${curl_opts[@]}" -X POST -d "@${tmp}" \
-  "${opennms_base}/rest/requisitions"
+if ! curl "${curl_opts[@]}" -X POST -d "@${tmp}" \
+     "${opennms_base}/rest/requisitions"; then
+  echo "FAILED (see response above)" >&2
+  exit 1
+fi
 echo "done"
 
 echo -n "Triggering import      ... "
-curl "${curl_opts[@]}" -X PUT \
-  "${opennms_base}/rest/requisitions/${FOREIGN_SOURCE}/import?rescanExisting=false"
+if ! curl "${curl_opts[@]}" -X PUT \
+     "${opennms_base}/rest/requisitions/${FOREIGN_SOURCE}/import?rescanExisting=false"; then
+  echo "FAILED (see response above)" >&2
+  exit 1
+fi
 echo "done"

--- a/experiments/roles/opennms_requisition/tasks/main.yml
+++ b/experiments/roles/opennms_requisition/tasks/main.yml
@@ -1,0 +1,76 @@
+---
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: Apache-2.0
+
+- name: Create the tool directory
+  ansible.builtin.file:
+    path: "{{ opennms_requisition_home }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+  tags: ["requisition"]
+
+- name: Install nl6's provisioning script
+  ansible.builtin.copy:
+    src: onms-provision.sh
+    dest: "{{ opennms_requisition_home }}/onms-provision.sh"
+    owner: root
+    group: root
+    mode: "0755"
+  tags: ["requisition"]
+
+# Every endpoint comes from the manifest. Nodes are pinned to the Minion's
+# location because the simulated network is reachable from the Minion and
+# nowhere else: a node polled from the Core would simply never answer.
+- name: Generate and import the requisition
+  ansible.builtin.command:
+    cmd: "{{ opennms_requisition_home }}/onms-provision.sh --import"
+  environment:
+    NL6_URL: "{{ opennms_requisition_endpoints.generators.nl6.url }}"
+    OPENNMS_BASE_URL: >-
+      http://{{ opennms_requisition_endpoints.measurement.opennms.host }}:{{ opennms_requisition_endpoints.measurement.opennms.port }}/opennms
+    OPENNMS_USER: "{{ opennms_requisition_user }}"
+    OPENNMS_PASS: "{{ opennms_requisition_password }}"
+    FOREIGN_SOURCE: "{{ opennms_requisition_foreign_source }}"
+    MINION_LOCATION: "{{ opennms_requisition_location }}"
+  register: opennms_requisition_import
+  changed_when: true
+  tags: ["requisition"]
+
+- name: Count the fleet nl6 holds
+  ansible.builtin.uri:
+    url: "{{ opennms_requisition_endpoints.generators.nl6.url }}/api/v1/devices"
+    method: GET
+    return_content: true
+  register: opennms_requisition_fleet
+  changed_when: false
+  tags: ["requisition"]
+
+- name: Wait for provisiond to finish importing
+  ansible.builtin.uri:
+    url: >-
+      {{ opennms_requisition_base }}/rest/nodes?foreignSource={{ opennms_requisition_foreign_source }}&limit=1
+    method: GET
+    user: "{{ opennms_requisition_user }}"
+    password: "{{ opennms_requisition_password }}"
+    force_basic_auth: true
+    headers:
+      Accept: application/json
+    return_content: true
+  register: opennms_requisition_nodes
+  until: >-
+    (opennms_requisition_nodes.json.totalCount | default(0) | int)
+    >= (opennms_requisition_fleet.json.data | default([]) | length)
+  retries: "{{ (opennms_requisition_timeout | int // (opennms_requisition_poll_interval | int)) | int }}"
+  delay: "{{ opennms_requisition_poll_interval }}"
+  changed_when: false
+  tags: ["requisition"]
+
+- name: Report the requisition
+  ansible.builtin.debug:
+    msg: >-
+      {{ opennms_requisition_nodes.json.totalCount }} node(s) in foreign-source
+      {{ opennms_requisition_foreign_source }} at location
+      {{ opennms_requisition_location }}
+  tags: ["requisition"]

--- a/experiments/smoke/experiment.yml
+++ b/experiments/smoke/experiment.yml
@@ -14,49 +14,16 @@
 # the monitoring node, and that provisions a Minion able to receive syslog. The
 # first two are asserted below; the third is what the reconciliation catches.
 
-- name: Create the simulated fleet
+- name: Build the fleet
   hosts: net_sim
   gather_facts: false
   vars:
-    # The manifest is the deployment's own account of where things are. Reading
-    # it here rather than restating addresses is the whole reason it exists.
-    endpoints: "{{ lookup('file', playbook_dir ~ '/../../lab-endpoints.json') | from_json }}"
-    sim_network: "{{ endpoints.generators.nl6.sim_network }}"
-  tasks:
-    - name: Create the devices, with the collectors the manifest names
-      ansible.builtin.uri:
-        url: "{{ endpoints.generators.nl6.url }}/api/v1/devices"
-        method: POST
-        body_format: json
-        status_code: [200, 201, 202]
-        body:
-          start_ip: "{{ smoke_start_ip }}"
-          device_count: "{{ smoke_device_count | int }}"
-          # nl6 takes a prefix length as a string here, per its API reference
-          # ("optional; defaults to 16"). Split rather than ipaddr() so this
-          # needs neither the ansible.utils collection nor netaddr.
-          netmask: "{{ sim_network.split('/')[1] }}"
-          syslog:
-            collector: "{{ endpoints.ingestion.syslog.host }}:{{ endpoints.ingestion.syslog.port }}"
-          traps:
-            collector: "{{ endpoints.ingestion.traps.host }}:{{ endpoints.ingestion.traps.port }}"
-            mode: trap
-      register: smoke_fleet
-      changed_when: true
-      # A 2xx is not success. nl6 wraps its replies in {"success": …}, and a
-      # rejected batch comes back 200 with success false. Accepting the status
-      # alone would report a fleet as created, drive load at devices that do
-      # not exist, and produce the clean zero this experiment exists to prevent.
-      failed_when: >-
-        smoke_fleet.status not in [200, 201, 202]
-        or not (smoke_fleet.json.success | default(false))
-
-    - name: Report the fleet
-      ansible.builtin.debug:
-        msg: >-
-          {{ smoke_device_count }} device(s) from {{ smoke_start_ip }},
-          syslog to {{ endpoints.ingestion.syslog.host }}:{{ endpoints.ingestion.syslog.port }},
-          traps to {{ endpoints.ingestion.traps.host }}:{{ endpoints.ingestion.traps.port }}
+    nl6_fleet_endpoints: "{{ lookup('file', playbook_dir ~ '/../../lab-endpoints.json') | from_json }}"
+    nl6_fleet_sim_network: "{{ nl6_fleet_endpoints.generators.nl6.sim_network }}"
+    nl6_fleet_start_ip: "{{ smoke_start_ip }}"
+    nl6_fleet_count: "{{ smoke_device_count }}"
+  roles:
+    - nl6_fleet
 
 - name: Drive a bounded scenario and reconcile what arrived
   hosts: mon_servers

--- a/opennms-lab-vars.yml
+++ b/opennms-lab-vars.yml
@@ -169,6 +169,15 @@ kafka_server_properties:
 # Integer arithmetic (* 6 // 10) rather than a float multiply: the value is
 # quoted straight into a shell config file, where a rounding artefact has no
 # business appearing.
+# The pinned collection builds this URL with a "v" prefix for versions >= 1.6.0
+# (roles/opennms_core/defaults/main.yml). Upstream tags 1.6.0 without one, so
+# the generated URL 404s and the Core play fails at "Installing JMX Prometheus
+# Exporter". Verified: .../download/v1.6.0/... is 404, .../download/1.6.0/... is
+# 200. Overridden here rather than bumping the SHA-pinned collection, which the
+# project reserves for a deliberate PR.
+prom_jmx_exporter_url: >-
+  https://github.com/prometheus/jmx_exporter/releases/download/{{ prom_jmx_exporter_version }}/jmx_prometheus_javaagent-{{ prom_jmx_exporter_version }}.jar
+
 opennms_jvm_conf:
   JAVA_HEAP_SIZE: "{{ [ansible_memtotal_mb | int * 6 // 10, 8192] | min }}"
   JAVA_INITIAL_HEAP_SIZE: "{{ [ansible_memtotal_mb | int * 6 // 10, 8192] | min }}"


### PR DESCRIPTION
Refs #161

## What

```bash
make experiment EXPERIMENT=pm-snmp   DEPLOYMENT=kfk-exclusive
make experiment EXPERIMENT=fm-syslog DEPLOYMENT=kfk-exclusive
```

Built on the `smoke` template, sharing new `nl6_fleet` and `opennms_requisition` roles so device creation and provisioning are defined once. `smoke` is refactored onto the fleet role too.

## Results — measured on a freshly built kvm lab

**`fm-syslog`** — 10 devices, 30s window per rung:

```
rate/dev  sent    sink(msgs)  events  sent/s   events/s
5         1500    430         1532    50.0     51.1
25        7360    561         7395    245.3    246.5
100       27790   613         21345   926.3    711.5
250       63505   620         22409   2116.8   747.0
```

Events track sent to about **245/s** and plateau near **750/s**. The ceiling is between those; the knee is worth bisecting.

The `sink` column barely moves because the sink **batches** — its delta counts Kafka messages, not records. That is exactly why the events count is the record-accurate figure, and why reconciling one side alone would have misled. This also answers the open question from #207: the 143-against-150 gap was batching, not loss.

**`pm-snmp`** — 25 devices, 660s window:

```
samples 1871 · mean 2.95/s · peak 24.97/s · 74.8 per device
231 Kafka messages at 8.1 samples per message
```

## Design

**Three-way reconciliation.** `fm-syslog` compares nl6's sent-ledger, the sink offset delta, and syslogd events in PostgreSQL. Where *sent* stops tracking *events*, the deployment has given way. Measuring only what was requested cannot see that; measuring one side cannot say which side gave way.

**A bounded PM window.** `pm-snmp` marks the topic's current end offsets, waits, then measures only what arrived — so the figure describes the run rather than everything the lab has ever collected. The measurement point is the topic: under exclusive forwarding `EmptyResourceStorageDao` means the UI has no graphs by design.

**Provisioning uses nl6's own script.** `onms-provision.sh`, vendored from upstream `examples/`, owns the device-to-node mapping including the gNMI metadata the OpenConfigConnector reads. Re-deriving it here would drift whenever nl6 grows a field. The repo's `nl6-requisition.sh` was a stale fork of the same script — still defaulting to `https://bench-lab` and an `OPENSIM_URL` that no longer exists — and is removed.

## Two things that had to be fixed to get a number at all

**The lab could not be rebuilt.** The pinned collection composes the JMX exporter URL with a `v` prefix for ≥ 1.6.0; upstream tags `1.6.0` without one, so the Core play died on a 404. Verified `.../download/v1.6.0/...` → 404 and `.../download/1.6.0/...` → 200, and overrode the URL in the lab vars rather than bumping a deliberately-pinned collection.

**The sweep could not survive its own length.** Reading offsets by `delegate_to` the broker means a fresh connection through the jump host per read; one dropped `ControlPersist` session failed the run partway and discarded every rung already measured. The accepted side is now read by a small probe on the monitoring node, reusing the venv `kafka_metrics_report` already installs.

## Caveats

- **Simulated devices emit their own periodic syslog** independently of a scenario, so the events count includes background traffic. At the lowest rung that is why events slightly exceed sent.
- **Single runs on one topology**, not repeated trials. These establish the harness, not a baseline.

`lint-yaml`, `lint-ansible`, `lint-shell`, `lint-python` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)