### PR TITLE
feat(experiments): measure node coverage, reset the fleet, sweep traps

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -10,4 +10,10 @@ deprecation_warnings = False
 #   export ANSIBLE_VAULT_PASSWORD_FILE=~/.config/ansible-opennms/vault-pass
 
 [ssh_connection]
-ssh_args = -o ForwardAgent=yes -o ControlMaster=auto -o ControlPersist=60s -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null
+# ControlPersist outlives the longest task, deliberately. Experiments have
+# tasks that run for minutes (draining a pipeline, driving a scenario) while a
+# delegated host sits untouched; at 60s that host's control master expired and
+# the next call found a dead socket, failing the run as "unreachable" halfway
+# through a sweep. ServerAlive keeps the jump-host hop from being reaped too.
+ssh_args = -o ForwardAgent=yes -o ControlMaster=auto -o ControlPersist=600s -o ServerAliveInterval=30 -o ServerAliveCountMax=10 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null
+retries = 3

--- a/deployments/roles/kafka_metrics_report/files/kafka_metrics_report.py
+++ b/deployments/roles/kafka_metrics_report/files/kafka_metrics_report.py
@@ -48,6 +48,9 @@ SERIES = {
 # buckets the timeline falls back to observed keys only and says so.
 MAX_DENSE_BUCKETS = 20_000
 
+# Above this, the sidecar records only the count, not the ids.
+MAX_NODE_IDS = 1_000
+
 
 def parse_args(argv=None):
     p = argparse.ArgumentParser(
@@ -152,6 +155,7 @@ def consume(consumer, topic, bounds, timeout):
 
     remaining = {p for p, b in bounds.items() if b["end"] > b["start"]}
     samples, records, resources_total = [], 0, 0
+    nodes = set()
     errors = Counter()
 
     while remaining:
@@ -192,12 +196,54 @@ def consume(consumer, topic, bounds, timeout):
                     errors["no_collection_timestamp"] += 1
                 else:
                     samples.append((cs.timestamp / 1000.0, ts_ms / 1000.0, n))
+                    # Counted here, not above: a node whose records were all
+                    # excluded contributes nothing to the numerator, so counting
+                    # it in the denominator would bias the per-node rate down
+                    # and read as a system slowing.
+                    for r in cs.resource:
+                        nid = resource_node(r)
+                        if nid is UNKNOWN_SHAPE:
+                            errors["unknown_resource_shape"] += 1
+                        elif nid is not None:
+                            nodes.add(nid)
 
         if msg.offset() >= bounds[part]["end"] - 1:
             remaining.discard(part)
             consumer.pause([TopicPartition(topic, part)])
 
-    return samples, records, resources_total, errors
+    return samples, records, resources_total, sorted(nodes), errors
+
+
+# Returned when a resource carries a shape this code does not know, so the
+# caller can count it rather than silently undercounting nodes.
+UNKNOWN_SHAPE = object()
+
+
+def resource_node(resource):
+    """The node a CollectionSetResource was *collected* from.
+
+    Answers "how many nodes were actually collected", which a sample count
+    cannot: a fleet whose per-device rate falls could be a system that stopped
+    keeping up, or one that only ever collected a subset. Those are identical in
+    totals and completely different here.
+
+    Response-time resources are excluded deliberately. Pollerd latency travels
+    this same topic under exclusive forwarding, so counting it would let a fleet
+    that is polled but never collected read as full collection coverage, which
+    is the confusion this function exists to remove.
+
+    Returns None for a resource that is deliberately not counted, UNKNOWN_SHAPE
+    for one this code cannot interpret, and the node id otherwise. A node id of
+    0 is a real id, so callers must test against None rather than truthiness.
+    """
+    which = resource.WhichOneof("resource")
+    if which == "response":
+        return None
+    if which == "node":
+        return resource.node.node_id
+    if which in ("interface", "generic"):
+        return getattr(resource, which).node.node_id
+    return UNKNOWN_SHAPE
 
 
 def timeline(samples, index, width, errors=None):
@@ -221,7 +267,7 @@ def timeline(samples, index, width, errors=None):
     return [{"t": t, "rate": buckets.get(t, 0) / width} for t in keys]
 
 
-def summarise(samples, records, resources_total, errors, args, bounds):
+def summarise(samples, records, resources_total, nodes, errors, args, bounds):
     total = sum(row[2] for row in samples)
     series = {
         name: timeline(samples, idx, args.bucket_seconds, errors)
@@ -247,6 +293,10 @@ def summarise(samples, records, resources_total, errors, args, bounds):
             "samples": total,
             "records": records,
             "resources": resources_total,
+            # How many distinct nodes appeared at all. Paired with a fleet size
+            # this separates "the system slowed down" from "the system only
+            # collected part of the fleet", which totals alone cannot.
+            "nodes_seen": len(nodes),
             "samples_per_record": round(total / records, 2) if records else 0,
         },
         "rate": {
@@ -255,6 +305,10 @@ def summarise(samples, records, resources_total, errors, args, bounds):
             "span_seconds": round(span, 1),
             "collection_span_seconds": round(spans["collection"], 1),
         },
+        # Capped: a large fleet would otherwise write tens of thousands of ids
+        # into a sidecar whose other fields are scalars, and every rung slurps
+        # this file back. nodes_seen carries the number that matters.
+        "node_ids": nodes if len(nodes) <= MAX_NODE_IDS else [],
         "offsets": bounds,
         "warnings": dict(errors),
         "series": series,
@@ -453,6 +507,7 @@ TEMPLATE = """<!DOCTYPE html>
   <tr><td>Numeric samples</td><td>{samples}</td></tr>
   <tr><td>Kafka records read</td><td>{records}</td></tr>
   <tr><td>Resources</td><td>{resources}</td></tr>
+  <tr><td>Distinct nodes seen</td><td>{nodes_seen}</td></tr>
   <tr><td>Samples per record</td><td>{per_record}</td></tr>
   <tr><td>Mean samples/second</td><td>{mean}</td></tr>
   <tr><td>Peak samples/second</td><td>{peak}</td></tr>
@@ -507,6 +562,7 @@ WARNING_TEXT = {
     "no_record_timestamp": "records carried no broker timestamp and were excluded",
     "no_collection_timestamp": "records carried no collection timestamp and were excluded",
     "sparse_timeline": "timestamps spanned an implausible range, so the timeline shows only observed buckets",
+    "unknown_resource_shape": "resources carried a shape this build cannot interpret, so their nodes were not counted",
 }
 
 
@@ -534,6 +590,7 @@ def render_html(report, svg, geom):
         samples=f"{report['totals']['samples']:,}",
         records=f"{report['totals']['records']:,}",
         resources=f"{report['totals']['resources']:,}",
+        nodes_seen=f"{report['totals']['nodes_seen']:,}",
         per_record=f"{report['totals']['samples_per_record']:,.2f}",
         # A slice too short to have a span has no rate; "n/a" says that, where
         # 0.0 would read as a run that collected nothing.
@@ -569,11 +626,11 @@ def main(argv=None):
     )
     try:
         bounds = bounded_slice(consumer, args.topic, start_offsets, replay_bounds)
-        samples, records, resources, errors = consume(consumer, args.topic, bounds, args.timeout)
+        samples, records, resources, nodes, errors = consume(consumer, args.topic, bounds, args.timeout)
     finally:
         consumer.close()
 
-    report = summarise(samples, records, resources, errors, args, bounds)
+    report = summarise(samples, records, resources, nodes, errors, args, bounds)
     svg, geom = svg_chart(report)
     args.json_out.write_text(json.dumps(report, indent=2))
     args.html.write_text(render_html(report, svg, geom))
@@ -581,6 +638,7 @@ def main(argv=None):
     r = report["rate"]
     mean = "n/a" if r["mean_per_second"] is None else f"{r['mean_per_second']:,.2f}/s"
     print(f"samples   {report['totals']['samples']:,}")
+    print(f"nodes     {report['totals']['nodes_seen']:,} distinct")
     print(f"mean      {mean} over {r['span_seconds']:,.1f}s")
     print(f"peak      {r['peak_per_second']:,.2f}/s")
     print(f"report    {args.html}")

--- a/deployments/roles/nl6_loadtest/files/nl6_loadtest.py
+++ b/deployments/roles/nl6_loadtest/files/nl6_loadtest.py
@@ -288,6 +288,10 @@ def summarise(sid, report, armed, args):
         "request": {
             "rate": args.rate,
             "window": args.window,
+            # Recorded in seconds as well, so a consumer computing a rate does
+            # not have to re-parse a Go duration. Stripping non-digits from
+            # "2m" yields 2 and reports rates 60x too high.
+            "window_seconds": window_s,
             "drain": args.drain,
             "seed": args.seed,
             "devices": n,

--- a/experiments/fm-snmptrap/experiment.yml
+++ b/experiments/fm-snmptrap/experiment.yml
@@ -41,6 +41,10 @@
   vars:
     endpoints: "{{ lookup('file', playbook_dir ~ '/../../lab-endpoints.json') | from_json }}"
     db: "{{ groups['database'][0] }}"
+    # Published by the deployment, not retyped here. A topic name typed into an
+    # experiment reads as zero arrivals when it is wrong, which is
+    # indistinguishable from an ingress that accepted nothing.
+    sink_topic: "{{ endpoints.ingestion.traps.sink_topic }}"
   roles:
     # Reads the accepted side locally rather than over SSH to the broker: a
     # sweep makes that call often enough that one dropped control connection
@@ -55,6 +59,32 @@
       failed_when: not ft_tools.stat.exists
       changed_when: false
 
+    # The simulated fleet emits syslog continuously, not only during a
+    # scenario. Measured at ~10/s for 10 devices, that is ~950 events across a
+    # rung's bracket: larger than the low rungs' entire offered load, and
+    # constant rather than rate-dependent, so it reads as every rung receiving
+    # more than was sent to it. It is not in nl6's ledger, so the two sides
+    # cannot reconcile until it is measured here and taken back out per rung.
+    - name: Measure the idle background event rate
+      ansible.builtin.shell:
+        cmd: |
+          set -eu
+          q="select count(*) from events where eventsource = 'trapd'"
+          a=$(sudo -u postgres psql -qtA -d {{ endpoints.measurement.database.name }} -c "$q")
+          sleep {{ ft_baseline_seconds }}
+          b=$(sudo -u postgres psql -qtA -d {{ endpoints.measurement.database.name }} -c "$q")
+          echo $(( (b - a) * 1000 / {{ ft_baseline_seconds }} ))
+      delegate_to: "{{ db }}"
+      become: true
+      register: ft_baseline
+      changed_when: false
+      failed_when: ft_baseline.stdout is not match('^[0-9]+$')
+
+    # Milli-events per second, kept integer so the rung arithmetic stays exact.
+    - name: Record the background rate
+      ansible.builtin.set_fact:
+        ft_background_mps: "{{ ft_baseline.stdout | trim | int }}"
+
     - name: Run the sweep
       ansible.builtin.include_tasks: rate.yml
       loop: "{{ ft_rates }}"
@@ -65,7 +95,7 @@
     # accepted stops tracking sent is visible rather than inferred.
     - name: Report the sweep
       ansible.builtin.debug:
-        msg: "{{ ['rate/dev  sent   sink(msgs)  events   sent/s  events/s'] + (ft_rows | default([])) }}"
+        msg: "{{ ['rate/dev  sent   sink(msgs)  events_raw bkgnd  events   sent/s  events/s'] + (ft_rows | default([])) }}"
 
     # A sweep where nothing arrived at any rate is a broken deployment, not a
     # result. Say so rather than publishing a table of zeros.

--- a/experiments/fm-snmptrap/experiment.yml
+++ b/experiments/fm-snmptrap/experiment.yml
@@ -1,14 +1,14 @@
 ---
-# Fault management: how many syslog messages a second can this deployment
-# accept before it stops keeping up.
+# Fault management: how many SNMP traps a second can this deployment accept
+# before it stops keeping up.
 #
-#   make experiment EXPERIMENT=fm-syslog DEPLOYMENT=kfk-exclusive
+#   make experiment EXPERIMENT=fm-snmptrap DEPLOYMENT=kfk-exclusive
 #
 # Sweeps a list of rates and, for each, reconciles three independently-derived
 # numbers:
 #
 #   sent      nl6's immutable sent-ledger — what left the generator
-#   sink      OpenNMS.Sink.Syslog offset delta — what the Minion took
+#   sink      OpenNMS.Sink.Trap offset delta — what the Minion took
 #   events    rows in the OpenNMS events table — what the Core turned into events
 #
 # A rate where sent stops tracking sink is the ingress giving way. A rate where
@@ -25,8 +25,8 @@
   vars:
     nl6_fleet_endpoints: "{{ lookup('file', playbook_dir ~ '/../../lab-endpoints.json') | from_json }}"
     nl6_fleet_sim_network: "{{ nl6_fleet_endpoints.generators.nl6.sim_network }}"
-    nl6_fleet_start_ip: "{{ fm_start_ip }}"
-    nl6_fleet_count: "{{ fm_device_count }}"
+    nl6_fleet_start_ip: "{{ ft_start_ip }}"
+    nl6_fleet_count: "{{ ft_device_count }}"
   roles:
     # Reset first: ft/fm sweeps share the 10.42.0.x range with pm-snmp, so
     # without this a run can drive load at devices another experiment created
@@ -35,7 +35,7 @@
       tasks_from: reset
     - nl6_fleet
 
-- name: Sweep the syslog rate
+- name: Sweep the trap rate
   hosts: mon_servers
   gather_facts: false
   vars:
@@ -51,34 +51,34 @@
       ansible.builtin.stat:
         path: "/usr/local/bin/{{ item }}"
       loop: [nl6-loadtest, kafka-metrics-report]
-      register: fm_tools
-      failed_when: not fm_tools.stat.exists
+      register: ft_tools
+      failed_when: not ft_tools.stat.exists
       changed_when: false
 
     - name: Run the sweep
       ansible.builtin.include_tasks: rate.yml
-      loop: "{{ fm_rates }}"
+      loop: "{{ ft_rates }}"
       loop_control:
-        loop_var: fm_rate
+        loop_var: ft_rate
 
     # The whole point of the sweep. Reported as a table so the rate at which
     # accepted stops tracking sent is visible rather than inferred.
     - name: Report the sweep
       ansible.builtin.debug:
-        msg: "{{ ['rate/dev  sent   sink(msgs)  events   sent/s  events/s'] + (fm_rows | default([])) }}"
+        msg: "{{ ['rate/dev  sent   sink(msgs)  events   sent/s  events/s'] + (ft_rows | default([])) }}"
 
     # A sweep where nothing arrived at any rate is a broken deployment, not a
     # result. Say so rather than publishing a table of zeros.
     - name: Assert the deployment accepted something at some rate
       ansible.builtin.assert:
         that:
-          - (fm_results | default([])) | length > 0
-          - (fm_results | default([])) | map(attribute='sent') | map('int') | sum > 0
-          - (fm_results | default([])) | map(attribute='sink') | map('int') | sum > 0
-          - (fm_results | default([])) | map(attribute='events') | map('int') | sum > 0
+          - (ft_results | default([])) | length > 0
+          - (ft_results | default([])) | map(attribute='sent') | map('int') | sum > 0
+          - (ft_results | default([])) | map(attribute='sink') | map('int') | sum > 0
+          - (ft_results | default([])) | map(attribute='events') | map('int') | sum > 0
         fail_msg: >-
-          No syslog reached OpenNMS at any rate in the sweep. Check that the
-          Minion binds {{ endpoints.ingestion.syslog.host }}:{{ endpoints.ingestion.syslog.port }}
+          No traps reached OpenNMS at any rate in the sweep. Check that the
+          Minion binds {{ endpoints.ingestion.traps.host }}:{{ endpoints.ingestion.traps.port }}
           — a deployment can publish that endpoint, open its firewall and run
           the Core-side consumer while nothing listens, and every symptom is a
           clean zero.

--- a/experiments/fm-snmptrap/opennms-lab-vars.yml
+++ b/experiments/fm-snmptrap/opennms-lab-vars.yml
@@ -10,4 +10,8 @@ ft_start_ip: "10.42.0.1"
 ft_device_count: 10
 ft_rates: [5, 25, 100, 250]
 ft_window: 30s
-ft_settle_seconds: 30
+ft_settle_seconds: 60
+
+# Long enough that the count is not dominated by rounding, short enough
+# not to add a rung to the sweep.
+ft_baseline_seconds: 30

--- a/experiments/fm-snmptrap/opennms-lab-vars.yml
+++ b/experiments/fm-snmptrap/opennms-lab-vars.yml
@@ -1,0 +1,13 @@
+---
+# Trap sweep parameters. rate is per device, so the fleet-wide rate is
+# rate x ft_device_count.
+#
+# This path has carried no traffic before: the Minion's trap listener was only
+# bound in #207, and until then the deployment published a trap endpoint that
+# accepted nothing. Every symptom of that was a clean zero, which is why the
+# sweep reconciles sent against sink against events rather than trusting one.
+ft_start_ip: "10.42.0.1"
+ft_device_count: 10
+ft_rates: [5, 25, 100, 250]
+ft_window: 30s
+ft_settle_seconds: 30

--- a/experiments/fm-snmptrap/rate.yml
+++ b/experiments/fm-snmptrap/rate.yml
@@ -3,104 +3,104 @@
 # --require-topic: the probe reports an absent topic as zero by design, which
 # for a before-reading would make a wrong topic name indistinguishable from an
 # ingress that accepted nothing, at every rung, with the sweep still passing.
-- name: "Read the sink offset before rate {{ fm_rate }}"
+- name: "Read the sink offset before rate {{ ft_rate }}"
   ansible.builtin.command:
     cmd: kafka-offsets {{ sink_topic }} --require-topic
-  register: fm_sink_before
+  register: ft_sink_before
   changed_when: false
   # int() returns 0 for anything unparseable, which would read as "nothing
   # arrived" for the whole sweep rather than as a broken probe.
-  failed_when: fm_sink_before.stdout is not match('^[0-9]+$')
+  failed_when: ft_sink_before.stdout is not match('^[0-9]+$')
 
-- name: "Count events before rate {{ fm_rate }}"
+- name: "Count events before rate {{ ft_rate }}"
   ansible.builtin.command:
     cmd: >-
       sudo -u postgres psql -qtA -d {{ endpoints.measurement.database.name }}
-      -c "select count(*) from events where eventsource = 'syslogd'"
+      -c "select count(*) from events where eventsource = 'trapd'"
   delegate_to: "{{ db }}"
   become: true
-  register: fm_events_before
+  register: ft_events_before
   changed_when: false
 
-- name: "Drive the load at rate {{ fm_rate }}"
+- name: "Drive the load at rate {{ ft_rate }}"
   ansible.builtin.command:
     cmd: >-
-      nl6-loadtest --protocol syslog --rate {{ fm_rate }} --window {{ fm_window }}
-      --start-ip {{ fm_start_ip }} --count {{ fm_device_count }}
-      --label "fm-syslog {{ fm_rate }}/s" --html /tmp/fm-{{ fm_rate }}.html
-      --json /tmp/fm-{{ fm_rate }}.json
-  register: fm_load
+      nl6-loadtest --protocol snmp-trap --rate {{ ft_rate }} --window {{ ft_window }}
+      --start-ip {{ ft_start_ip }} --count {{ ft_device_count }}
+      --label "fm-snmptrap {{ ft_rate }}/s" --html /tmp/ft-{{ ft_rate }}.html
+      --json /tmp/ft-{{ ft_rate }}.json
+  register: ft_load
   changed_when: true
   # Exit 1 means the generator itself fell short. That is a finding about the
   # generator, not the system under test, so the rung is recorded and the sweep
   # continues rather than failing.
-  failed_when: fm_load.rc > 1
+  failed_when: ft_load.rc > 1
 
 # Polled by the probe, not paused here: drain time grows precisely at the rate
 # where the system stops keeping up, so a fixed wait under-reports the rung that
 # matters and spills its backlog into the next one. Ansible's until cannot
 # compare consecutive reads, so the waiting lives in the probe.
-- name: "Let the pipeline drain after rate {{ fm_rate }}"
+- name: "Let the pipeline drain after rate {{ ft_rate }}"
   ansible.builtin.command:
-    cmd: kafka-offsets {{ sink_topic }} --settle={{ fm_settle_seconds }}
-  register: fm_drain
+    cmd: kafka-offsets {{ sink_topic }} --settle={{ ft_settle_seconds }}
+  register: ft_drain
   changed_when: false
 
-- name: "Read the sink offset after rate {{ fm_rate }}"
+- name: "Read the sink offset after rate {{ ft_rate }}"
   ansible.builtin.command:
     cmd: kafka-offsets {{ sink_topic }}
-  register: fm_sink_after
+  register: ft_sink_after
   changed_when: false
   # int() returns 0 for anything unparseable, which would read as "nothing
   # arrived" for the whole sweep rather than as a broken probe.
-  failed_when: fm_sink_after.stdout is not match('^[0-9]+$')
+  failed_when: ft_sink_after.stdout is not match('^[0-9]+$')
 
-- name: "Count events after rate {{ fm_rate }}"
+- name: "Count events after rate {{ ft_rate }}"
   ansible.builtin.command:
     cmd: >-
       sudo -u postgres psql -qtA -d {{ endpoints.measurement.database.name }}
-      -c "select count(*) from events where eventsource = 'syslogd'"
+      -c "select count(*) from events where eventsource = 'trapd'"
   delegate_to: "{{ db }}"
   become: true
-  register: fm_events_after
+  register: ft_events_after
   changed_when: false
 
 # Guarded: nl6-loadtest can exit before writing its sidecar, and an unguarded
 # slurp would abort the loop and discard every rung already measured, which is
 # the opposite of tolerating rc 1 above.
-- name: "Read the sent-ledger for rate {{ fm_rate }}"
+- name: "Read the sent-ledger for rate {{ ft_rate }}"
   ansible.builtin.slurp:
-    src: "/tmp/fm-{{ fm_rate }}.json"
-  register: fm_ledger
+    src: "/tmp/ft-{{ ft_rate }}.json"
+  register: ft_ledger
   failed_when: false
 
-- name: "Record the rung for rate {{ fm_rate }}"
+- name: "Record the rung for rate {{ ft_rate }}"
   ansible.builtin.set_fact:
-    fm_results: "{{ (fm_results | default([])) + [rung] }}"
-    fm_rows: >-
-      {{ (fm_rows | default([]))
+    ft_results: "{{ (ft_results | default([])) + [rung] }}"
+    ft_rows: >-
+      {{ (ft_rows | default([]))
          + ['%-9s %-6s %-11s %-8s %-7s %s' | format(
-              fm_rate, rung.sent, rung.sink, rung.events,
+              ft_rate, rung.sent, rung.sink, rung.events,
               (rung.sent | int / ([window_s | int, 1] | max)) | round(1),
               (rung.events | int / ([window_s | int, 1] | max)) | round(1)) ] }}
   vars:
     ledger: >-
-      {{ (fm_ledger.content | default("") | b64decode | from_json)
-         if fm_ledger.content is defined else {"delivered": {}, "request": {}} }}
+      {{ (ft_ledger.content | default("") | b64decode | from_json)
+         if ft_ledger.content is defined else {"delivered": {}, "request": {}} }}
     # From the ledger, which records seconds because the driver already parses
     # Go durations. Stripping non-digits made "2m" yield 2 and reported rates
     # 60x too high. Guarded against zero: a malformed ledger must not divide.
     window_s: "{{ ledger.request.window_seconds | default(0) | float }}"
-    sink_before: "{{ fm_sink_before.stdout | trim | int }}"
-    sink_after: "{{ fm_sink_after.stdout | trim | int }}"
+    sink_before: "{{ ft_sink_before.stdout | trim | int }}"
+    sink_after: "{{ ft_sink_after.stdout | trim | int }}"
     rung:
-      rate: "{{ fm_rate }}"
+      rate: "{{ ft_rate }}"
       # Recorded, not left in a vars file: the table column is per-device, so
       # without this the fleet-wide offered rate is not recoverable from the
       # result at all.
-      devices: "{{ fm_device_count }}"
+      devices: "{{ ft_device_count }}"
       sent: "{{ ledger.delivered.sent | default(0) }}"
       expected: "{{ ledger.delivered.expected | default(0) }}"
       send_failures: "{{ ledger.delivered.send_failures | default(0) }}"
       sink: "{{ sink_after | int - sink_before | int }}"
-      events: "{{ fm_events_after.stdout | trim | int - fm_events_before.stdout | trim | int }}"
+      events: "{{ ft_events_after.stdout | trim | int - ft_events_before.stdout | trim | int }}"

--- a/experiments/fm-snmptrap/rate.yml
+++ b/experiments/fm-snmptrap/rate.yml
@@ -16,7 +16,7 @@
   ansible.builtin.command:
     cmd: >-
       sudo -u postgres psql -qtA -d {{ endpoints.measurement.database.name }}
-      -c "select count(*) from events where eventsource = 'trapd'"
+      -c "select count(*) || ' ' || extract(epoch from now()) from events where eventsource = 'trapd'"
   delegate_to: "{{ db }}"
   become: true
   register: ft_events_before
@@ -36,15 +36,16 @@
   # continues rather than failing.
   failed_when: ft_load.rc > 1
 
-# Polled by the probe, not paused here: drain time grows precisely at the rate
-# where the system stops keeping up, so a fixed wait under-reports the rung that
-# matters and spills its backlog into the next one. Ansible's until cannot
-# compare consecutive reads, so the waiting lives in the probe.
+# Fixed, not polled. Draining "until the count stops moving" cannot work
+# here: the simulated fleet emits continuously, so the count never stops. The
+# poll either ran to its cap or stopped on a coincidental lull, and the
+# resulting 7x swing in bracket length made the background correction below
+# swing with it. A fixed bracket makes that correction exact. The cost is that
+# a rung which needs longer than this to drain under-reports, which is visible
+# as sent and events diverging rather than hidden in a varying window.
 - name: "Let the pipeline drain after rate {{ ft_rate }}"
-  ansible.builtin.command:
-    cmd: kafka-offsets {{ sink_topic }} --settle={{ ft_settle_seconds }}
-  register: ft_drain
-  changed_when: false
+  ansible.builtin.pause:
+    seconds: "{{ ft_settle_seconds }}"
 
 - name: "Read the sink offset after rate {{ ft_rate }}"
   ansible.builtin.command:
@@ -59,7 +60,7 @@
   ansible.builtin.command:
     cmd: >-
       sudo -u postgres psql -qtA -d {{ endpoints.measurement.database.name }}
-      -c "select count(*) from events where eventsource = 'trapd'"
+      -c "select count(*) || ' ' || extract(epoch from now()) from events where eventsource = 'trapd'"
   delegate_to: "{{ db }}"
   become: true
   register: ft_events_after
@@ -79,8 +80,8 @@
     ft_results: "{{ (ft_results | default([])) + [rung] }}"
     ft_rows: >-
       {{ (ft_rows | default([]))
-         + ['%-9s %-6s %-11s %-8s %-7s %s' | format(
-              ft_rate, rung.sent, rung.sink, rung.events,
+         + ['%-9s %-6s %-11s %-10s %-6s %-8s %-7s %s' | format(
+              ft_rate, rung.sent, rung.sink, rung.events_raw, rung.background, rung.events,
               (rung.sent | int / ([window_s | int, 1] | max)) | round(1),
               (rung.events | int / ([window_s | int, 1] | max)) | round(1)) ] }}
   vars:
@@ -91,6 +92,12 @@
     # Go durations. Stripping non-digits made "2m" yield 2 and reported rates
     # 60x too high. Guarded against zero: a malformed ledger must not divide.
     window_s: "{{ ledger.request.window_seconds | default(0) | float }}"
+    # "<count> <epoch>" from one statement, so the count and the instant it
+    # describes cannot drift apart the way two separate reads would.
+    ev_before: "{{ ft_events_before.stdout.split()[0] }}"
+    ts_before: "{{ ft_events_before.stdout.split()[1] }}"
+    ev_after: "{{ ft_events_after.stdout.split()[0] }}"
+    ts_after: "{{ ft_events_after.stdout.split()[1] }}"
     sink_before: "{{ ft_sink_before.stdout | trim | int }}"
     sink_after: "{{ ft_sink_after.stdout | trim | int }}"
     rung:
@@ -103,4 +110,15 @@
       expected: "{{ ledger.delivered.expected | default(0) }}"
       send_failures: "{{ ledger.delivered.send_failures | default(0) }}"
       sink: "{{ sink_after | int - sink_before | int }}"
-      events: "{{ ft_events_after.stdout | trim | int - ft_events_before.stdout | trim | int }}"
+      # Raw, then what the idle fleet would have produced over the same
+      # bracket, then the difference. All three are kept: a correction large
+      # relative to the rung is itself the finding, and hiding it behind a
+      # single adjusted number is how a background-dominated rung passes for a
+      # measurement. Floored at zero, since noise can make it negative.
+      events_raw: "{{ ev_after | int - ev_before | int }}"
+      bracket_s: "{{ (ts_after | float - ts_before | float) | round(1) }}"
+      background: "{{ ((ft_background_mps | int * (ts_after | float - ts_before | float)) / 1000) | round | int }}"
+      events: >-
+        {{ [ (ev_after | int - ev_before | int)
+             - (((ft_background_mps | int * (ts_after | float - ts_before | float)) / 1000) | round | int),
+             0 ] | max }}

--- a/experiments/fm-syslog/experiment.yml
+++ b/experiments/fm-syslog/experiment.yml
@@ -41,6 +41,10 @@
   vars:
     endpoints: "{{ lookup('file', playbook_dir ~ '/../../lab-endpoints.json') | from_json }}"
     db: "{{ groups['database'][0] }}"
+    # Published by the deployment, not retyped here. A topic name typed into an
+    # experiment reads as zero arrivals when it is wrong, which is
+    # indistinguishable from an ingress that accepted nothing.
+    sink_topic: "{{ endpoints.ingestion.syslog.sink_topic }}"
   roles:
     # Reads the accepted side locally rather than over SSH to the broker: a
     # sweep makes that call often enough that one dropped control connection
@@ -55,6 +59,32 @@
       failed_when: not fm_tools.stat.exists
       changed_when: false
 
+    # The simulated fleet emits syslog continuously, not only during a
+    # scenario. Measured at ~10/s for 10 devices, that is ~950 events across a
+    # rung's bracket: larger than the low rungs' entire offered load, and
+    # constant rather than rate-dependent, so it reads as every rung receiving
+    # more than was sent to it. It is not in nl6's ledger, so the two sides
+    # cannot reconcile until it is measured here and taken back out per rung.
+    - name: Measure the idle background event rate
+      ansible.builtin.shell:
+        cmd: |
+          set -eu
+          q="select count(*) from events where eventsource = 'syslogd'"
+          a=$(sudo -u postgres psql -qtA -d {{ endpoints.measurement.database.name }} -c "$q")
+          sleep {{ fm_baseline_seconds }}
+          b=$(sudo -u postgres psql -qtA -d {{ endpoints.measurement.database.name }} -c "$q")
+          echo $(( (b - a) * 1000 / {{ fm_baseline_seconds }} ))
+      delegate_to: "{{ db }}"
+      become: true
+      register: fm_baseline
+      changed_when: false
+      failed_when: fm_baseline.stdout is not match('^[0-9]+$')
+
+    # Milli-events per second, kept integer so the rung arithmetic stays exact.
+    - name: Record the background rate
+      ansible.builtin.set_fact:
+        fm_background_mps: "{{ fm_baseline.stdout | trim | int }}"
+
     - name: Run the sweep
       ansible.builtin.include_tasks: rate.yml
       loop: "{{ fm_rates }}"
@@ -65,7 +95,7 @@
     # accepted stops tracking sent is visible rather than inferred.
     - name: Report the sweep
       ansible.builtin.debug:
-        msg: "{{ ['rate/dev  sent   sink(msgs)  events   sent/s  events/s'] + (fm_rows | default([])) }}"
+        msg: "{{ ['rate/dev  sent   sink(msgs)  events_raw bkgnd  events   sent/s  events/s'] + (fm_rows | default([])) }}"
 
     # A sweep where nothing arrived at any rate is a broken deployment, not a
     # result. Say so rather than publishing a table of zeros.

--- a/experiments/fm-syslog/opennms-lab-vars.yml
+++ b/experiments/fm-syslog/opennms-lab-vars.yml
@@ -7,4 +7,8 @@ fm_rates: [5, 25, 100, 250]
 fm_window: 30s
 # Long enough for the Minion to flush its sink batch and for Eventd to drain,
 # or a rung's records land in the next rung's count.
-fm_settle_seconds: 30
+fm_settle_seconds: 60
+
+# Long enough that the count is not dominated by rounding, short enough
+# not to add a rung to the sweep.
+fm_baseline_seconds: 30

--- a/experiments/fm-syslog/rate.yml
+++ b/experiments/fm-syslog/rate.yml
@@ -16,7 +16,7 @@
   ansible.builtin.command:
     cmd: >-
       sudo -u postgres psql -qtA -d {{ endpoints.measurement.database.name }}
-      -c "select count(*) from events where eventsource = 'syslogd'"
+      -c "select count(*) || ' ' || extract(epoch from now()) from events where eventsource = 'syslogd'"
   delegate_to: "{{ db }}"
   become: true
   register: fm_events_before
@@ -36,15 +36,16 @@
   # continues rather than failing.
   failed_when: fm_load.rc > 1
 
-# Polled by the probe, not paused here: drain time grows precisely at the rate
-# where the system stops keeping up, so a fixed wait under-reports the rung that
-# matters and spills its backlog into the next one. Ansible's until cannot
-# compare consecutive reads, so the waiting lives in the probe.
+# Fixed, not polled. Draining "until the count stops moving" cannot work
+# here: the simulated fleet emits continuously, so the count never stops. The
+# poll either ran to its cap or stopped on a coincidental lull, and the
+# resulting 7x swing in bracket length made the background correction below
+# swing with it. A fixed bracket makes that correction exact. The cost is that
+# a rung which needs longer than this to drain under-reports, which is visible
+# as sent and events diverging rather than hidden in a varying window.
 - name: "Let the pipeline drain after rate {{ fm_rate }}"
-  ansible.builtin.command:
-    cmd: kafka-offsets {{ sink_topic }} --settle={{ fm_settle_seconds }}
-  register: fm_drain
-  changed_when: false
+  ansible.builtin.pause:
+    seconds: "{{ fm_settle_seconds }}"
 
 - name: "Read the sink offset after rate {{ fm_rate }}"
   ansible.builtin.command:
@@ -59,7 +60,7 @@
   ansible.builtin.command:
     cmd: >-
       sudo -u postgres psql -qtA -d {{ endpoints.measurement.database.name }}
-      -c "select count(*) from events where eventsource = 'syslogd'"
+      -c "select count(*) || ' ' || extract(epoch from now()) from events where eventsource = 'syslogd'"
   delegate_to: "{{ db }}"
   become: true
   register: fm_events_after
@@ -79,8 +80,8 @@
     fm_results: "{{ (fm_results | default([])) + [rung] }}"
     fm_rows: >-
       {{ (fm_rows | default([]))
-         + ['%-9s %-6s %-11s %-8s %-7s %s' | format(
-              fm_rate, rung.sent, rung.sink, rung.events,
+         + ['%-9s %-6s %-11s %-10s %-6s %-8s %-7s %s' | format(
+              fm_rate, rung.sent, rung.sink, rung.events_raw, rung.background, rung.events,
               (rung.sent | int / ([window_s | int, 1] | max)) | round(1),
               (rung.events | int / ([window_s | int, 1] | max)) | round(1)) ] }}
   vars:
@@ -91,6 +92,12 @@
     # Go durations. Stripping non-digits made "2m" yield 2 and reported rates
     # 60x too high. Guarded against zero: a malformed ledger must not divide.
     window_s: "{{ ledger.request.window_seconds | default(0) | float }}"
+    # "<count> <epoch>" from one statement, so the count and the instant it
+    # describes cannot drift apart the way two separate reads would.
+    ev_before: "{{ fm_events_before.stdout.split()[0] }}"
+    ts_before: "{{ fm_events_before.stdout.split()[1] }}"
+    ev_after: "{{ fm_events_after.stdout.split()[0] }}"
+    ts_after: "{{ fm_events_after.stdout.split()[1] }}"
     sink_before: "{{ fm_sink_before.stdout | trim | int }}"
     sink_after: "{{ fm_sink_after.stdout | trim | int }}"
     rung:
@@ -103,4 +110,15 @@
       expected: "{{ ledger.delivered.expected | default(0) }}"
       send_failures: "{{ ledger.delivered.send_failures | default(0) }}"
       sink: "{{ sink_after | int - sink_before | int }}"
-      events: "{{ fm_events_after.stdout | trim | int - fm_events_before.stdout | trim | int }}"
+      # Raw, then what the idle fleet would have produced over the same
+      # bracket, then the difference. All three are kept: a correction large
+      # relative to the rung is itself the finding, and hiding it behind a
+      # single adjusted number is how a background-dominated rung passes for a
+      # measurement. Floored at zero, since noise can make it negative.
+      events_raw: "{{ ev_after | int - ev_before | int }}"
+      bracket_s: "{{ (ts_after | float - ts_before | float) | round(1) }}"
+      background: "{{ ((fm_background_mps | int * (ts_after | float - ts_before | float)) / 1000) | round | int }}"
+      events: >-
+        {{ [ (ev_after | int - ev_before | int)
+             - (((fm_background_mps | int * (ts_after | float - ts_before | float)) / 1000) | round | int),
+             0 ] | max }}

--- a/experiments/pm-snmp/experiment.yml
+++ b/experiments/pm-snmp/experiment.yml
@@ -6,8 +6,10 @@
 #
 # Sweeps fleet size. At each rung the fleet grows, is provisioned, and a full
 # collection interval is measured on the Kafka metrics topic. The column to read
-# is samples per device per cycle: it should hold steady as the fleet grows, and
-# when it falls the deployment is no longer keeping up.
+# is samples per device per cycle, read against the nodes column: if nodes
+# tracks the fleet size then a falling per-device rate is the system slowing
+# down, and if it lags then the run never collected the whole fleet and the
+# rate says nothing at all. Totals alone cannot tell those apart.
 #
 # The measurement point is the topic, not the OpenNMS UI. Under exclusive
 # forwarding the OSGi persister installs EmptyResourceStorageDao, so there are
@@ -32,6 +34,33 @@
       failed_when: not pm_tool.stat.exists
       changed_when: false
 
+    # A sweep that starts with the previous run's fleet still present measures
+    # that fleet at every rung while reporting the size it created.
+    #
+    # The reset alone is enough to clear OpenNMS too: the first rung re-imports
+    # the requisition from whatever nl6 then holds, and provisiond deletes the
+    # nodes absent from it. Running the import against an empty fleet would be
+    # the more direct way to say that, but nl6's onms-provision.sh iterates the
+    # device list without a null guard and fails when it is empty.
+    - name: Assert the sweep grows at every rung
+      ansible.builtin.assert:
+        that:
+          - pm_device_increments | length > 0
+          - pm_device_increments | map('int') | min > 0
+        fail_msg: >-
+          pm_device_increments must be non-empty and every entry positive. A
+          zero increment leaves the cumulative fleet unchanged, so two rungs
+          share a device count, write to the same JSON path and report the same
+          measurement twice under different labels.
+        quiet: true
+
+    - name: Reset the fleet before sweeping
+      ansible.builtin.include_role:
+        name: nl6_fleet
+        tasks_from: reset
+      vars:
+        nl6_fleet_endpoints: "{{ endpoints }}"
+
     - name: Run the sweep
       ansible.builtin.include_tasks: rung.yml
       loop: "{{ pm_device_increments }}"
@@ -43,7 +72,7 @@
 
     - name: Report the sweep
       ansible.builtin.debug:
-        msg: "{{ ['devices  samples  mean/s    per-dev/cyc  kafka msgs'] + pm_rows }}"
+        msg: "{{ ['devices  nodes   samples  mean/s   per-dev/cyc   coverage  kafka msgs'] + pm_rows }}"
 
     # A sweep that collected nothing at any size is a blocked Collectd, not a
     # result. Under exclusive forwarding that is what a missing Kafka Producer

--- a/experiments/pm-snmp/opennms-lab-vars.yml
+++ b/experiments/pm-snmp/opennms-lab-vars.yml
@@ -9,5 +9,8 @@ pm_foreign_source: nl6-pm
 # One full collection interval plus margin, so every node is collected exactly
 # once inside the window. Each rung costs this much wall clock.
 pm_collection_interval: 300
+# One full interval, so every newly provisioned node has been scheduled and
+# collected once before measurement starts. Each rung costs settle + window.
+pm_settle_seconds: 300
 pm_window_seconds: 330
 pm_bucket_seconds: 30

--- a/experiments/pm-snmp/rung.yml
+++ b/experiments/pm-snmp/rung.yml
@@ -28,6 +28,15 @@
     opennms_requisition_location: "{{ endpoints.ingestion.syslog.location }}"
     opennms_requisition_foreign_source: "{{ pm_foreign_source }}"
 
+# Provisiond returns as soon as the nodes exist, but Collectd schedules a new
+# node at some point within the interval rather than immediately. Measuring
+# straight away catches a partial cycle and reports it as a system that has
+# stopped keeping up. Settling for a full interval first means every node has
+# been scheduled and collected at least once before the window opens.
+- name: "Let collection settle after provisioning at rung {{ pm_rung_index }}"
+  ansible.builtin.pause:
+    seconds: "{{ pm_settle_seconds }}"
+
 - name: "Mark the measurement start for rung {{ pm_rung_index }}"
   ansible.builtin.command:
     cmd: kafka-metrics-report --label "pm baseline" --html /tmp/pm-base.html --json /tmp/pm-base.json
@@ -71,24 +80,59 @@
     src: "/tmp/pm-{{ pm_rung_devices }}.json"
   register: pm_result
 
+# Zero identified nodes with non-zero samples is a broken parser, not a data
+# point: the divide-by-zero guard would otherwise render the whole sample total
+# as a plausible-looking per-device rate.
+- name: "Assert the rung identified the nodes it collected at {{ pm_rung_devices }}"
+  ansible.builtin.assert:
+    that:
+      - (pm.totals.nodes_seen | default(0) | int) > 0 or (pm.totals.samples | int) == 0
+    fail_msg: >-
+      {{ pm.totals.samples }} samples arrived but no node could be identified in
+      any of them. That is a decoding problem, not a measurement: check the
+      warnings block in /tmp/pm-{{ pm_rung_devices }}.json for
+      unknown_resource_shape.
+    quiet: true
+  vars:
+    pm: "{{ pm_result.content | b64decode | from_json }}"
+
 - name: "Record the rung at {{ pm_rung_devices }}"
   ansible.builtin.set_fact:
     pm_results: "{{ (pm_results | default([])) + [rung] }}"
     pm_rows: >-
       {{ (pm_rows | default([]))
-         + ['%-8s %-8s %-9s %-11s %s' | format(
-              pm_rung_devices, rung.samples, rung.mean, rung.per_device_cycle, rung.records) ] }}
+         + ['%-8s %-7s %-8s %-8s %-13s %-9s %s' | format(
+              pm_rung_devices, rung.nodes_seen, rung.samples, rung.mean,
+              rung.per_device_cycle, rung.coverage, rung.records) ] }}
   vars:
     pm: "{{ pm_result.content | b64decode | from_json }}"
     cycles: "{{ (pm_window_seconds | int / pm_collection_interval | int) }}"
     rung:
       devices: "{{ pm_rung_devices }}"
+      # The discriminator. If this tracks the fleet size, a falling
+      # per-device-per-cycle is the system slowing down. If it lags, the run
+      # simply never collected the whole fleet and the rate says nothing.
+      # default(0): absent on a lab still running a consumer from before
+      # nodes_seen existed, which would otherwise abort after the window.
+      nodes_seen: "{{ pm.totals.nodes_seen | default(0) }}"
       samples: "{{ pm.totals.samples }}"
       records: "{{ pm.totals.records }}"
-      mean: "{{ pm.rate.mean_per_second | default(0) }}"
+      # mean_per_second is null, not absent, when the accepted span is zero.
+      mean: "{{ pm.rate.mean_per_second | default(0, true) }}"
       # The column that matters. Samples per device per collection cycle should
       # hold steady as the fleet grows; when it falls, collection is no longer
       # completing within the interval and the deployment has given way.
+      # Divided by the fleet this rung asked for, NOT by the nodes observed.
+      # nodes_seen is derived from the same message stream as the numerator, so
+      # normalising by it is self-cancelling: collect half the fleet and both
+      # halve, leaving the headline column flat at exactly the moment it should
+      # fall. The two numbers are independent only while one is the fleet we
+      # built and the other is what the topic reported, which is what makes the
+      # coverage check below mean anything.
       per_device_cycle: >-
         {{ (pm.totals.samples | int / ([pm_rung_devices | int, 1] | max) / ([cycles | float, 0.01] | max))
            | round(1) }}
+      # Observed over asked-for. Reconciled programmatically rather than left
+      # for a human to notice two adjacent columns disagreeing.
+      coverage: >-
+        {{ ((pm.totals.nodes_seen | int) / ([pm_rung_devices | int, 1] | max)) | round(2) }}

--- a/experiments/roles/kafka_offsets/files/kafka_offsets.py
+++ b/experiments/roles/kafka_offsets/files/kafka_offsets.py
@@ -11,32 +11,84 @@
 # already measured.
 import json
 import sys
+import time
 from pathlib import Path
 
 MANIFEST = Path("/etc/lab-endpoints.json")
 
+# Gap between drain polls. Short enough to locate the settle point, long
+# enough not to hammer the broker for a whole sweep.
+POLL_SECONDS = 5
+
+
+def read_total(consumer, topic):
+    """Summed end offsets, or None if the topic does not exist."""
+    from confluent_kafka import TopicPartition
+
+    meta = consumer.list_topics(topic, timeout=10)
+    if topic not in meta.topics or meta.topics[topic].error:
+        return None
+    total = 0
+    for part in meta.topics[topic].partitions:
+        _, high = consumer.get_watermark_offsets(TopicPartition(topic, part), timeout=10, cached=False)
+        total += high
+    return total
+
 
 def main(argv):
-    if len(argv) != 2:
-        print("usage: kafka_offsets.py <topic>", file=sys.stderr)
+    args = [a for a in argv[1:] if not a.startswith("--")]
+    flags = {a for a in argv[1:] if a.startswith("--")}
+    if len(args) != 1:
+        print("usage: kafka_offsets.py <topic> [--settle[=SECONDS]] [--require-topic]", file=sys.stderr)
         return 2
-    topic = argv[1]
+    topic = args[0]
+    settle = next((f for f in flags if f.startswith("--settle")), None)
+    cap = int(settle.split("=", 1)[1]) if settle and "=" in settle else 120
+    require = "--require-topic" in flags
 
-    from confluent_kafka import Consumer, TopicPartition
+    from confluent_kafka import Consumer
 
     bootstrap = json.loads(MANIFEST.read_text())["measurement"]["kafka"]["bootstrap"]
     consumer = Consumer({"bootstrap.servers": bootstrap, "group.id": "kafka-offsets-probe"})
     try:
-        meta = consumer.list_topics(topic, timeout=10)
-        if topic not in meta.topics or meta.topics[topic].error:
-            # An absent topic is zero, not an error: nothing has been produced
-            # to it yet, which is exactly what a before-reading wants to say.
+        total = read_total(consumer, topic)
+        if total is None:
+            # Absent is normally zero: nothing has been produced yet, which is
+            # what a before-reading wants to say. But a caller measuring a topic
+            # it believes exists needs to know the difference, because a wrong
+            # topic name otherwise reads as an ingress that accepted nothing.
+            if require:
+                print(f"topic {topic!r} does not exist on the broker", file=sys.stderr)
+                return 3
             print(0)
             return 0
-        total = 0
-        for part in meta.topics[topic].partitions:
-            _, high = consumer.get_watermark_offsets(TopicPartition(topic, part), timeout=10, cached=False)
-            total += high
+
+        if settle:
+            # Poll until two consecutive reads agree. Drain time grows exactly
+            # at the rate where the system stops keeping up, so a fixed pause
+            # under-reports the rung that matters and spills its backlog into
+            # the next one. Capped, so a stuck pipeline cannot hang a sweep.
+            #
+            # KNOWN LIMIT: this settles only on a topic that goes quiet.
+            # Simulated devices emit background syslog and traps on their own
+            # interval, so on such a topic the offset always advances, the cap
+            # is always reached, and this degrades to a fixed wait that says so.
+            # That is no worse than pausing, and it is honest about it, but
+            # separating backlog drain from steady background traffic needs a
+            # rate threshold rather than an equality test.
+            deadline = time.monotonic() + cap
+            while time.monotonic() < deadline:
+                time.sleep(POLL_SECONDS)
+                current = read_total(consumer, topic)
+                if current == total:
+                    break
+                total = current
+            else:
+                print(
+                    f"still advancing after {cap}s; reporting the last read. On a topic with\n"
+                    f"background traffic this is expected and the value is a fixed-window read.",
+                    file=sys.stderr,
+                )
         print(total)
     finally:
         consumer.close()

--- a/experiments/roles/kafka_offsets/files/kafka_offsets.py
+++ b/experiments/roles/kafka_offsets/files/kafka_offsets.py
@@ -11,14 +11,9 @@
 # already measured.
 import json
 import sys
-import time
 from pathlib import Path
 
 MANIFEST = Path("/etc/lab-endpoints.json")
-
-# Gap between drain polls. Short enough to locate the settle point, long
-# enough not to hammer the broker for a whole sweep.
-POLL_SECONDS = 5
 
 
 def read_total(consumer, topic):
@@ -39,11 +34,9 @@ def main(argv):
     args = [a for a in argv[1:] if not a.startswith("--")]
     flags = {a for a in argv[1:] if a.startswith("--")}
     if len(args) != 1:
-        print("usage: kafka_offsets.py <topic> [--settle[=SECONDS]] [--require-topic]", file=sys.stderr)
+        print("usage: kafka_offsets.py <topic> [--require-topic]", file=sys.stderr)
         return 2
     topic = args[0]
-    settle = next((f for f in flags if f.startswith("--settle")), None)
-    cap = int(settle.split("=", 1)[1]) if settle and "=" in settle else 120
     require = "--require-topic" in flags
 
     from confluent_kafka import Consumer
@@ -63,32 +56,6 @@ def main(argv):
             print(0)
             return 0
 
-        if settle:
-            # Poll until two consecutive reads agree. Drain time grows exactly
-            # at the rate where the system stops keeping up, so a fixed pause
-            # under-reports the rung that matters and spills its backlog into
-            # the next one. Capped, so a stuck pipeline cannot hang a sweep.
-            #
-            # KNOWN LIMIT: this settles only on a topic that goes quiet.
-            # Simulated devices emit background syslog and traps on their own
-            # interval, so on such a topic the offset always advances, the cap
-            # is always reached, and this degrades to a fixed wait that says so.
-            # That is no worse than pausing, and it is honest about it, but
-            # separating backlog drain from steady background traffic needs a
-            # rate threshold rather than an equality test.
-            deadline = time.monotonic() + cap
-            while time.monotonic() < deadline:
-                time.sleep(POLL_SECONDS)
-                current = read_total(consumer, topic)
-                if current == total:
-                    break
-                total = current
-            else:
-                print(
-                    f"still advancing after {cap}s; reporting the last read. On a topic with\n"
-                    f"background traffic this is expected and the value is a fixed-window read.",
-                    file=sys.stderr,
-                )
         print(total)
     finally:
         consumer.close()

--- a/experiments/roles/nl6_fleet/tasks/main.yml
+++ b/experiments/roles/nl6_fleet/tasks/main.yml
@@ -49,13 +49,13 @@
   register: nl6_fleet_check
   changed_when: false
   failed_when: >-
-    (nl6_fleet_check.json.data | default([]) | length) < (nl6_fleet_count | int)
+    (nl6_fleet_check.json.data | default([], true) | length) < (nl6_fleet_count | int)
   tags: ["fleet"]
 
 - name: Report the fleet
   ansible.builtin.debug:
     msg: >-
-      {{ nl6_fleet_check.json.data | length }} device(s) live from
+      {{ nl6_fleet_check.json.data | default([], true) | length }} device(s) live from
       {{ nl6_fleet_start_ip }}, syslog to {{ nl6_fleet_syslog_collector | trim }},
       traps to {{ nl6_fleet_trap_collector | trim }}
   tags: ["fleet"]

--- a/experiments/roles/nl6_fleet/tasks/reset.yml
+++ b/experiments/roles/nl6_fleet/tasks/reset.yml
@@ -1,0 +1,40 @@
+---
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: Apache-2.0
+
+# Removes every simulated device, so a sweep starts from a known fleet size.
+#
+# Without this a run inherits whatever the previous run left behind, and every
+# rung measures the accumulated fleet while reporting the count it created. The
+# nodes column makes that visible; this makes it not happen.
+- name: Remove every simulated device
+  ansible.builtin.uri:
+    url: "{{ nl6_fleet_endpoints.generators.nl6.url }}/api/v1/devices"
+    method: DELETE
+    # 404 is a fine outcome: there was nothing to delete. Anything else is not.
+    status_code: [200, 202, 204, 404]
+  register: nl6_fleet_reset
+  changed_when: nl6_fleet_reset.status != 404
+  # A 2xx is not success on this API; it wraps replies in {"success": …}.
+  failed_when: >-
+    nl6_fleet_reset.status not in [200, 202, 204, 404]
+    or (nl6_fleet_reset.status != 404
+        and not (nl6_fleet_reset.json.success | default(true)))
+  tags: ["fleet"]
+
+# default([], true), not default([]): nl6 returns "data": null for an empty
+# fleet, so the key exists and a plain default never fires.
+- name: Confirm the fleet is empty
+  ansible.builtin.uri:
+    url: "{{ nl6_fleet_endpoints.generators.nl6.url }}/api/v1/devices"
+    method: GET
+    return_content: true
+  register: nl6_fleet_empty
+  # .json is absent entirely if nl6 answers with a proxy error page, which would
+  # error the conditional instead of retrying through a transient failure.
+  until: >-
+    ((nl6_fleet_empty.json | default({}, true)).data | default([], true) | length) == 0
+  retries: 10
+  delay: 3
+  changed_when: false
+  tags: ["fleet"]

--- a/experiments/roles/opennms_requisition/tasks/main.yml
+++ b/experiments/roles/opennms_requisition/tasks/main.yml
@@ -47,6 +47,20 @@
   changed_when: false
   tags: ["requisition"]
 
+# Without this the wait below cannot fail: an empty fleet makes its target 0,
+# and "totalCount >= 0" is true on the first poll for any value, including zero
+# nodes. The rung would then settle a full interval and measure an empty system.
+- name: Assert nl6 holds a fleet to provision
+  ansible.builtin.assert:
+    that:
+      - (opennms_requisition_fleet.json.data | default([], true) | length) > 0
+    fail_msg: >-
+      nl6 reports no devices, so there is nothing to provision and the wait
+      below would pass immediately against zero nodes. Create the fleet before
+      calling this role.
+    quiet: true
+  tags: ["requisition"]
+
 - name: Wait for provisiond to finish importing
   ansible.builtin.uri:
     url: >-
@@ -59,9 +73,12 @@
       Accept: application/json
     return_content: true
   register: opennms_requisition_nodes
+  # Exact, not >=. A stale foreign source holding more nodes than this fleet
+  # would otherwise satisfy the wait immediately and every rung would measure
+  # the previous run's lab.
   until: >-
     (opennms_requisition_nodes.json.totalCount | default(0) | int)
-    >= (opennms_requisition_fleet.json.data | default([]) | length)
+    == (opennms_requisition_fleet.json.data | default([], true) | length)
   retries: "{{ (opennms_requisition_timeout | int // (opennms_requisition_poll_interval | int)) | int }}"
   delay: "{{ opennms_requisition_poll_interval }}"
   changed_when: false

--- a/group_vars/all/vars.yml
+++ b/group_vars/all/vars.yml
@@ -30,3 +30,9 @@ lab_kafka_topics:
   events: events
   alarms: alarms
   nodes: nodes
+
+# IPC topics are namespaced by the OpenNMS instance id; producer topics are not.
+# Named here so the manifest can publish the sink topic an experiment must read,
+# rather than each experiment retyping "OpenNMS.Sink.Trap" and discovering a typo
+# as a run where nothing arrived.
+lab_instance_id: OpenNMS

--- a/templates/lab-endpoints.yml.j2
+++ b/templates/lab-endpoints.yml.j2
@@ -45,11 +45,17 @@ ingestion:
     port: {{ lab_syslog_port }}
     via: minion
     location: "{{ opennms_minion_controller.location | default('') }}"
+    # Where the Minion forwards what it accepts. Published so an experiment
+    # reading the accepted side reads a name rather than retyping one: a wrong
+    # topic reads as zero arrivals, which is indistinguishable from an ingress
+    # that accepted nothing.
+    sink_topic: "{{ lab_instance_id }}.Sink.Syslog"
   traps:
     host: "{{ addr(minion, 'sim') }}"
     port: {{ lab_trap_port }}
     via: minion
     location: "{{ opennms_minion_controller.location | default('') }}"
+    sink_topic: "{{ lab_instance_id }}.Sink.Trap"
 {% endif %}
 {% if bootstrap or db or core %}
 


### PR DESCRIPTION
Refs #161

## What

Three changes that make a PM number mean something, plus the trap sweep.

**`kafka-metrics-report` reports distinct nodes seen.** A falling per-device rate has two readings totals cannot separate: a system that stopped keeping up, versus one that only collected part of the fleet. Counting nodes separates them.

**`pm-snmp` settles a full collection interval after provisioning.** Provisiond returns when nodes exist, but Collectd schedules a new node somewhere within the interval, so measuring straight away catches a partial cycle and reports it as falling behind.

**`fm-snmptrap`** sweeps the trap path as `fm-syslog` sweeps syslog. Until #207 the Minion bound no trap listener at all, so this path had never carried traffic.

Review fixes on top (all of #210's findings applied), plus three defects those fixes then exposed on hardware. Every table below was re-measured after them; none of the earlier numbers survived.

## What the review fixes exposed

**The node count was counting the wrong stream.** `resource_node()` treated Pollerd `response` resources as collection. Those exist for every polled node, so the fleet appeared fully collected. Restricted to collection resources, the fleet size that is actually collected is **2**, at every rung, out of 100 provisioned. The `nodes 27/52/102` previously reported here and in #208 was Pollerd latency, not performance data.

**The sweeps were measuring the fleet's idle chatter as if it were the load.** Simulated devices emit syslog and traps continuously, not only during a scenario: measured at ~10/s for ten devices, that is ~950 events per rung. More than the entire offered load at the low rungs, and constant rather than rate-dependent, so every rung appeared to receive more than was sent to it. The baseline is now measured once per sweep and taken back out per rung, with the raw count and the correction both kept as columns.

**Draining "until the count stops moving" cannot terminate against that background.** The count never stops. The poll either ran to its cap or stopped on a coincidental lull, swinging the bracket 7x and taking the correction with it. The bracket is now fixed, which makes the correction exact. This removed the only caller of `kafka-offsets --settle`, whose own KNOWN LIMIT note had predicted exactly this, so that flag went too.

Also: `sink_topic` was never defined in either FM experiment. It survived only because `rate.yml` had the topic inline. It now comes from the endpoints manifest.

## Results

**`fm-syslog`**, 10 devices, 30s window + 60s fixed drain per rung:

```
rate/dev  sent   sink(msgs)  events_raw bkgnd  events   sent/s  events/s
5         1500   1275        2440       908    1532     50.0    51.1
25        7380   1382        8290       908    7382     246.0   246.1
100       27704  1491        28659      907    27752    923.5   925.1
250       63735  1447        29426      919    28507    2124.5  950.2
```

Sent and persisted reconcile at 102%, 100.0% and 100.2%, then break down cleanly: 2125/s offered yields 950/s persisted. The background column holding at 908/908/907/919 across four rates is the fixed bracket working.

**`fm-snmptrap`**, same shape:

```
rate/dev  sent   sink(msgs)  events_raw bkgnd  events   sent/s  events/s
5         1490   745         944        168    776      49.7    25.9
25        7490   831         3881       169    3712     249.7   123.7
100       29990  838         15037      167    14870    999.7   495.7
250       74990  894         37532      168    37364    2499.7  1245.5
```

**`pm-snmp`**, 300s settle + 330s window per rung:

```
devices  nodes   samples  mean/s   per-dev/cyc   coverage  kafka msgs
25       2       1342     4.33     48.8          0.08      103
50       2       1461     4.57     26.6          0.04      221
100      2       1646     4.96     15.0          0.02      439
```

## Two findings that need their own issues

**SNMP collection does not reach the Minion-location fleet.** 100 devices provision, all detect SNMP, all appear in Pollerd's latency stream, and none of them produce collection data. Only the two default-location nodes do. This is the deployment, not the harness: the `coverage` column is what makes it visible, and it is why `per-dev/cyc` falling from 48.8 to 15.0 says nothing about capacity.

I tried adding a collectd package with `remote="true"` on the theory that every stock package is `remote="false"` and so never schedules a Minion-location node. It changed nothing, so I reverted it rather than leave unproven config in the harness. Worth recording for whoever picks this up: the first attempt inserted the package after the `<collector>` elements, which the schema forbids. OpenNMS rejected the document and Collectd carried on with its previous config, and the sweep still produced a full table of plausible samples. That failure mode is silent.

**Traps persist almost exactly half of what is sent, at every rate.** 52%, 49.6%, 49.6%, 49.8% from 50/s to 2500/s. A ratio that does not move with offered load is a fixed factor, not saturation, so it is not a capacity result and no trap number should be quoted until it is explained.

## Also

`ControlPersist` went from 60s to 600s. The sweeps now have tasks longer than 60s, so a delegated host's control master expired between uses and the next call failed the run as "unreachable" partway through, discarding every rung already measured. That happened twice.

## Two upstream/API details found

- **nl6 returns `"data": null`** rather than an empty list for an empty fleet, so every `| default([])` guarding it never fired. Now `| default([], true)`.
- **`onms-provision.sh` cannot run against an empty fleet**: it iterates the device list without a null guard. Worked around by not calling it empty; the first rung's requisition replaces the old one anyway.

`lint-yaml`, `lint-ansible`, `lint-python` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
