### PR TITLE
fix(experiments): measure the sweep's baseline instead of assuming 1.0

### DIFF
--- a/experiments/fm-snmptrap/experiment.yml
+++ b/experiments/fm-snmptrap/experiment.yml
@@ -4,20 +4,33 @@
 #
 #   make experiment EXPERIMENT=fm-snmptrap DEPLOYMENT=kfk-exclusive
 #
-# Sweeps a list of rates and, for each, reconciles three independently-derived
-# numbers:
+# Sweeps a list of rates. Each rung reports what left the generator and what
+# the Core persisted, read against a measured reference rather than against an
+# assumed 1.0:
 #
 #   sent      nl6's immutable sent-ledger — what left the generator
-#   sink      OpenNMS.Sink.Trap offset delta — what the Minion took
-#   events    rows in the OpenNMS events table — what the Core turned into events
+#   raw       rows added to the events table over the rung's bracket
+#   bkgnd     what the idle fleet would have produced over the same bracket
+#   events    raw minus bkgnd — what this rung's load actually persisted
+#   ratio     events / sent. Composition: it should NOT move with rate.
+#   vs-ref    ratio / reference ratio. Fidelity: a fall here is the system
+#             giving way.
 #
-# A rate where sent stops tracking sink is the ingress giving way. A rate where
-# sink stops tracking events is the Core. Measuring only one of the three cannot
-# tell those apart, and measuring only what was requested cannot see either.
+# Both ratios are published on purpose. A deployment that persists only part of
+# what a generator emits is a real property of the pair, and normalising it away
+# would swap one misleading number for another. Half of every nl6 trap workload
+# is authenticationFailure, which this deployment discards, so the trap ratio
+# sits near 0.5 with nothing wrong (#212).
 #
-# The sink batches, so its delta counts Kafka messages rather than records. It
-# is a floor on what arrived, not an exact count; the events delta is the
-# record-accurate figure.
+# raw and bkgnd are printed, not just used: a correction large relative to the
+# rung is itself the finding. They also separate a rung that lost its generator
+# ledger (sent 0, raw large) from one where the deployment gave way, which the
+# ratio columns alone render identical.
+#
+# OpenNMS.Sink.Trap is still read and still asserted non-zero, but is not
+# tabulated: the sink batches at a rate-dependent size, so its offset delta
+# counts Kafka messages rather than SNMP traps and cannot be compared against
+# them. See #215.
 
 - name: Build the fleet
   hosts: net_sim
@@ -65,6 +78,20 @@
     # constant rather than rate-dependent, so it reads as every rung receiving
     # more than was sent to it. It is not in nl6's ledger, so the two sides
     # cannot reconcile until it is measured here and taken back out per rung.
+    # The reference is ft_rates | first, so the list must be ascending for it to
+    # be the least-loaded measurement. Nothing else enforces the ordering, and a
+    # reordered list would silently calibrate the sweep against a saturated rung.
+    - name: Assert the sweep rates ascend
+      ansible.builtin.assert:
+        that:
+          - (ft_rates | length) > 1
+          - ft_rates | map('int') | list == (ft_rates | map('int') | sort | list)
+        fail_msg: >-
+          ft_rates must be ascending and hold at least two entries: the first is
+          used as the reference, and the reference has to be the least-loaded
+          rung in the sweep. Got {{ ft_rates }}.
+        quiet: true
+
     - name: Measure the idle background event rate
       ansible.builtin.shell:
         cmd: |
@@ -85,9 +112,10 @@
       ansible.builtin.set_fact:
         ft_background_mps: "{{ ft_baseline.stdout | trim | int }}"
 
-    # The reference rung. Its persisted-over-sent ratio is the definition of
-    # "nothing was lost" for this workload against this deployment, and it is
-    # measured rather than assumed to be 1.0.
+    # The reference rung: the lowest sweep rate, run once before the sweep and
+    # once inside it. Its persisted-over-sent ratio is the definition of
+    # "nothing was lost" for this workload against this deployment, measured
+    # rather than assumed to be 1.0.
     #
     # Assuming 1.0 assumes the deployment persists everything the generator
     # emits. That held for syslog by luck and was false for traps: about half
@@ -95,49 +123,64 @@
     # deployment discards, so the sweep reported a permanent 50% deficit that
     # no component caused (#212).
     #
-    # Run at a rate with wide margin against the knee, and for longer than a
-    # sweep rung, so the background correction is a small share of the count
-    # rather than the dominant term.
+    # Same rate and same window as the rung it is corroborated against, on
+    # purpose. An earlier version ran the reference at its own rate and window,
+    # which made it the *more* loaded of the two measurements and left their
+    # background corrections asymmetric (~24% against ~40% of the raw count),
+    # so the tolerance was being spent on noise rather than on signal. Running
+    # identical conditions twice makes corroboration a test-retest, and the
+    # background correction cancels instead of biasing.
+    #
+    # There is deliberately no reference rate or window variable. The previous
+    # ones could not work: make passes the experiment vars file via
+    # --extra-vars, which outranks include_tasks vars, so a window override was
+    # silently ignored and the reference ran at the sweep window regardless.
     - name: Measure the reference rung
       ansible.builtin.include_tasks: rate.yml
       vars:
-        ft_rate: "{{ ft_reference_rate }}"
-        ft_window: "{{ ft_reference_window }}"
+        ft_rate: "{{ ft_rates | first }}"
+        # Distinct sidecar, so the reference and the identical sweep rung
+        # cannot overwrite each other's ledger.
+        ft_rung_label: ref
 
-    # Split from the capture below deliberately: doing both in one set_fact
-    # would make the result depend on the order Ansible evaluates its keys.
-    - name: Capture the reference rung
+    - name: Capture the reference
       ansible.builtin.set_fact:
         ft_reference: "{{ ft_results | last }}"
-        ft_reference_row: "{{ ft_rows | last }}"
-
-    - name: Take the reference out of the sweep rows
-      ansible.builtin.set_fact:
-        ft_results: "{{ ft_results[:-1] }}"
-        ft_rows: "{{ ft_rows[:-1] }}"
-
-    - name: Record the reference ratio
-      ansible.builtin.set_fact:
-        ft_reference_ratio: "{{ (ft_reference.events | int) / ([ft_reference.sent | int, 1] | max) }}"
+        # Where the sweep's own rungs begin, recorded rather than assumed, so
+        # nothing depends on the reference being at a particular index later.
+        ft_sweep_from: "{{ ft_results | length }}"
 
     # A reference of zero cannot define healthy: every rung measured against it
     # would read as perfect. This fails towards reporting success, which is the
     # direction nobody investigates.
+    #
+    # The delivery check is the other half. rate.yml deliberately tolerates the
+    # generator falling short (rc 1), so without this a reference built from a
+    # handful of delivered records would pass on ratio alone and mis-scale the
+    # whole table.
     - name: Assert the reference carries a signal
       ansible.builtin.assert:
         that:
           - (ft_reference.sent | int) > 0
-          - (ft_reference_ratio | float) > 0
+          - (ft_reference.ratio | float) > 0
+          - (ft_reference.expected | int) == 0
+            or (ft_reference.sent | int) >= (ft_reference.expected | int) * (ft_reference_min_delivery | float)
         fail_msg: >-
-          The reference rung at {{ ft_reference_rate }}/device persisted
-          {{ ft_reference.events }} of {{ ft_reference.sent }} sent.
-          Nothing can be measured against a reference of zero. Check the
-          trap ingress before reading anything below it.
+          The reference rung at {{ ft_rates | first }}/device delivered
+          {{ ft_reference.sent }} of {{ ft_reference.expected }} expected and
+          persisted {{ ft_reference.events }}. A reference that is zero, or built
+          from a short delivery, cannot define healthy: every rung measured
+          against it inherits the error.
         success_msg: >-
-          reference {{ (ft_reference_ratio | float) | round(3) }}
+          reference {{ (ft_reference.ratio | float) | round(3) }}
           ({{ ft_reference.events }}/{{ ft_reference.sent }} at
-          {{ ft_reference_rate }}/device)
+          {{ ft_rates | first }}/device)
         quiet: true
+
+    # Published so every rung's vs-ref can be computed against it.
+    - name: Record the reference ratio
+      ansible.builtin.set_fact:
+        ft_reference_ratio: "{{ ft_reference.ratio }}"
 
     - name: Run the sweep
       ansible.builtin.include_tasks: rate.yml
@@ -145,45 +188,61 @@
       loop_control:
         loop_var: ft_rate
 
-    # The whole point of the sweep. Reported as a table so the rate at which
-    # accepted stops tracking sent is visible rather than inferred.
+    # The reference and the sweep's own first rung are the same measurement
+    # taken twice. If they disagree, one is already degraded and the reference
+    # does not define healthy, so every vs-ref figure is against the wrong
+    # baseline. Relative, not absolute: an absolute window means +/-8% against a
+    # syslog reference near 1.0 and +/-16% against a trap reference near 0.5,
+    # which is the column it is supposed to be guarding.
+    #
+    # The zero case is called out separately because the relative test cannot
+    # see it: a near-zero reference makes the interval straddle zero, so a rung
+    # that persisted nothing would corroborate cleanly.
+    - name: Corroborate the reference against its repeat
+      ansible.builtin.assert:
+        that:
+          - (repeat.ratio | float) > 0
+          - ((repeat.ratio | float) / (ft_reference_ratio | float) - 1) | abs < (ft_reference_tolerance | float)
+        fail_msg: >-
+          The reference persisted {{ (ft_reference_ratio | float) | round(3) }} of what
+          was sent; its repeat at the same rate and window persisted
+          {{ (repeat.ratio | float) | round(3) }}. Two identical measurements
+          differing by more than {{ (ft_reference_tolerance | float * 100) | round }}%
+          mean one of them is already degraded, so the baseline is not sound and
+          nothing in the vs-ref column can be read.
+        success_msg: >-
+          reference {{ (ft_reference_ratio | float) | round(3) }} corroborated by its
+          repeat at {{ (repeat.ratio | float) | round(3) }}
+        quiet: true
+      vars:
+        repeat: "{{ ft_results[ft_sweep_from | int] }}"
+      register: ft_corroboration
+      failed_when: false
+
+    # Reported before the asserts below fire, so a failed run still shows its
+    # measurements, but never without saying the baseline is unsound. Printing
+    # a clean-looking table and only then failing is what the previous ordering
+    # did, and it is worse than either.
     - name: Report the sweep
       ansible.builtin.debug:
         msg: >-
-          {{ ['reference: %s persisted of %s sent at %s/device = ratio %s'
-                | format(ft_reference.events, ft_reference.sent, ft_reference_rate,
-                         (ft_reference_ratio | float) | round(3)),
+          {{ ([] if not ft_corroboration.failed else
+                ['*** BASELINE NOT CORROBORATED: the vs-ref column below is measured',
+                 '*** against a reference its own repeat disagrees with. See the error.',
+                 ''])
+             + ['reference: %s persisted of %s sent at %s/device = ratio %.3f'
+                  | format(ft_reference.events, ft_reference.sent,
+                           ft_rates | first, ft_reference.ratio | float),
+                'ratio is composition and should not move with rate.',
+                'vs-ref is fidelity: a fall here is the system giving way.',
                 '',
-                'rate/dev  sent   events   sent/s  events/s  ratio  vs-ref']
+                'rate/dev  sent   raw    bkgnd  events  sent/s   events/s  ratio  vs-ref']
              + (ft_rows | default([])) }}
 
-    # The reference and the lowest sweep rung are two independent low-rate
-    # measurements of the same thing. If they disagree, one of them is already
-    # degraded and the reference cannot be trusted to define healthy. Averaging
-    # them would bury exactly the case this guard exists for.
-    - name: Corroborate the reference against the lowest rung
-      ansible.builtin.assert:
-        that:
-          - (lowest_ratio | float) > (ft_reference_ratio | float) - (ft_reference_tolerance | float)
-          - (lowest_ratio | float) < (ft_reference_ratio | float) + (ft_reference_tolerance | float)
-        fail_msg: >-
-          The reference at {{ ft_reference_rate }}/device persisted
-          {{ (ft_reference_ratio | float) | round(3) }} of what was sent, while the
-          lowest sweep rung at {{ ft_rates | first }}/device persisted
-          {{ (lowest_ratio | float) | round(3) }}. Two low rates that disagree by more
-          than {{ ft_reference_tolerance }} mean one of them is already degraded, so
-          the reference does not define healthy and every vs-ref figure below it
-          is measured against the wrong baseline.
-        success_msg: >-
-          reference {{ (ft_reference_ratio | float) | round(3) }} corroborated by the
-          lowest rung at {{ (lowest_ratio | float) | round(3) }}
-        quiet: true
-      vars:
-        low: "{{ ft_results | first }}"
-        lowest_ratio: "{{ (low.events | int) / ([low.sent | int, 1] | max) }}"
-
     # A sweep where nothing arrived at any rate is a broken deployment, not a
-    # result. Say so rather than publishing a table of zeros.
+    # result. Asserted before the corroboration verdict because it names the
+    # cause: an all-zero sweep would otherwise fail as "two rates disagree",
+    # which is true and useless.
     - name: Assert the deployment accepted something at some rate
       ansible.builtin.assert:
         that:
@@ -197,4 +256,10 @@
           — a deployment can publish that endpoint, open its firewall and run
           the Core-side consumer while nothing listens, and every symptom is a
           clean zero.
+        quiet: true
+
+    - name: Fail if the baseline was not corroborated
+      ansible.builtin.assert:
+        that: [not ft_corroboration.failed]
+        fail_msg: "{{ ft_corroboration.msg | default('baseline not corroborated') }}"
         quiet: true

--- a/experiments/fm-snmptrap/experiment.yml
+++ b/experiments/fm-snmptrap/experiment.yml
@@ -85,6 +85,60 @@
       ansible.builtin.set_fact:
         ft_background_mps: "{{ ft_baseline.stdout | trim | int }}"
 
+    # The reference rung. Its persisted-over-sent ratio is the definition of
+    # "nothing was lost" for this workload against this deployment, and it is
+    # measured rather than assumed to be 1.0.
+    #
+    # Assuming 1.0 assumes the deployment persists everything the generator
+    # emits. That held for syslog by luck and was false for traps: about half
+    # of every nl6 trap workload is authenticationFailure, which this
+    # deployment discards, so the sweep reported a permanent 50% deficit that
+    # no component caused (#212).
+    #
+    # Run at a rate with wide margin against the knee, and for longer than a
+    # sweep rung, so the background correction is a small share of the count
+    # rather than the dominant term.
+    - name: Measure the reference rung
+      ansible.builtin.include_tasks: rate.yml
+      vars:
+        ft_rate: "{{ ft_reference_rate }}"
+        ft_window: "{{ ft_reference_window }}"
+
+    # Split from the capture below deliberately: doing both in one set_fact
+    # would make the result depend on the order Ansible evaluates its keys.
+    - name: Capture the reference rung
+      ansible.builtin.set_fact:
+        ft_reference: "{{ ft_results | last }}"
+        ft_reference_row: "{{ ft_rows | last }}"
+
+    - name: Take the reference out of the sweep rows
+      ansible.builtin.set_fact:
+        ft_results: "{{ ft_results[:-1] }}"
+        ft_rows: "{{ ft_rows[:-1] }}"
+
+    - name: Record the reference ratio
+      ansible.builtin.set_fact:
+        ft_reference_ratio: "{{ (ft_reference.events | int) / ([ft_reference.sent | int, 1] | max) }}"
+
+    # A reference of zero cannot define healthy: every rung measured against it
+    # would read as perfect. This fails towards reporting success, which is the
+    # direction nobody investigates.
+    - name: Assert the reference carries a signal
+      ansible.builtin.assert:
+        that:
+          - (ft_reference.sent | int) > 0
+          - (ft_reference_ratio | float) > 0
+        fail_msg: >-
+          The reference rung at {{ ft_reference_rate }}/device persisted
+          {{ ft_reference.events }} of {{ ft_reference.sent }} sent.
+          Nothing can be measured against a reference of zero. Check the
+          trap ingress before reading anything below it.
+        success_msg: >-
+          reference {{ (ft_reference_ratio | float) | round(3) }}
+          ({{ ft_reference.events }}/{{ ft_reference.sent }} at
+          {{ ft_reference_rate }}/device)
+        quiet: true
+
     - name: Run the sweep
       ansible.builtin.include_tasks: rate.yml
       loop: "{{ ft_rates }}"
@@ -95,7 +149,38 @@
     # accepted stops tracking sent is visible rather than inferred.
     - name: Report the sweep
       ansible.builtin.debug:
-        msg: "{{ ['rate/dev  sent   sink(msgs)  events_raw bkgnd  events   sent/s  events/s'] + (ft_rows | default([])) }}"
+        msg: >-
+          {{ ['reference: %s persisted of %s sent at %s/device = ratio %s'
+                | format(ft_reference.events, ft_reference.sent, ft_reference_rate,
+                         (ft_reference_ratio | float) | round(3)),
+                '',
+                'rate/dev  sent   events   sent/s  events/s  ratio  vs-ref']
+             + (ft_rows | default([])) }}
+
+    # The reference and the lowest sweep rung are two independent low-rate
+    # measurements of the same thing. If they disagree, one of them is already
+    # degraded and the reference cannot be trusted to define healthy. Averaging
+    # them would bury exactly the case this guard exists for.
+    - name: Corroborate the reference against the lowest rung
+      ansible.builtin.assert:
+        that:
+          - (lowest_ratio | float) > (ft_reference_ratio | float) - (ft_reference_tolerance | float)
+          - (lowest_ratio | float) < (ft_reference_ratio | float) + (ft_reference_tolerance | float)
+        fail_msg: >-
+          The reference at {{ ft_reference_rate }}/device persisted
+          {{ (ft_reference_ratio | float) | round(3) }} of what was sent, while the
+          lowest sweep rung at {{ ft_rates | first }}/device persisted
+          {{ (lowest_ratio | float) | round(3) }}. Two low rates that disagree by more
+          than {{ ft_reference_tolerance }} mean one of them is already degraded, so
+          the reference does not define healthy and every vs-ref figure below it
+          is measured against the wrong baseline.
+        success_msg: >-
+          reference {{ (ft_reference_ratio | float) | round(3) }} corroborated by the
+          lowest rung at {{ (lowest_ratio | float) | round(3) }}
+        quiet: true
+      vars:
+        low: "{{ ft_results | first }}"
+        lowest_ratio: "{{ (low.events | int) / ([low.sent | int, 1] | max) }}"
 
     # A sweep where nothing arrived at any rate is a broken deployment, not a
     # result. Say so rather than publishing a table of zeros.

--- a/experiments/fm-snmptrap/opennms-lab-vars.yml
+++ b/experiments/fm-snmptrap/opennms-lab-vars.yml
@@ -16,13 +16,18 @@ ft_settle_seconds: 60
 # not to add a rung to the sweep.
 ft_baseline_seconds: 30
 
-# The reference rung. Its persisted-over-sent ratio defines what "nothing was
-# lost" means for this workload against this deployment, instead of assuming
-# 1.0. Run longer than a sweep rung so the background correction is a small
-# share of the count rather than the dominant term, and at a rate with wide
-# margin against the knee (syslog saturates near 950/s; this offers ~100/s).
-ft_reference_rate: 10
-ft_reference_window: "60s"
-# How far the lowest sweep rung may sit from the reference before the sweep
-# stops. Two independent low rates that disagree mean one is already degraded.
-ft_reference_tolerance: 0.08
+# The reference is the lowest sweep rate, run once before the sweep and once
+# inside it. There is deliberately no reference rate or window variable: make
+# passes this file via --extra-vars, which outranks include_tasks vars, so an
+# override of a name defined here is silently ignored. An earlier version set
+# a 60s reference window that never took effect.
+#
+# Relative, not absolute. An absolute window means +/-8% against a syslog
+# reference near 1.0 and +/-16% against a trap reference near 0.5, which is the
+# column it exists to guard. 0.10 covers the test-retest spread seen on
+# hardware with room for background drift.
+ft_reference_tolerance: 0.10
+# The generator is allowed to fall short of its requested rate (rate.yml
+# tolerates rc 1), but a reference built from a short delivery mis-scales every
+# rung measured against it.
+ft_reference_min_delivery: 0.9

--- a/experiments/fm-snmptrap/opennms-lab-vars.yml
+++ b/experiments/fm-snmptrap/opennms-lab-vars.yml
@@ -15,3 +15,14 @@ ft_settle_seconds: 60
 # Long enough that the count is not dominated by rounding, short enough
 # not to add a rung to the sweep.
 ft_baseline_seconds: 30
+
+# The reference rung. Its persisted-over-sent ratio defines what "nothing was
+# lost" means for this workload against this deployment, instead of assuming
+# 1.0. Run longer than a sweep rung so the background correction is a small
+# share of the count rather than the dominant term, and at a rate with wide
+# margin against the knee (syslog saturates near 950/s; this offers ~100/s).
+ft_reference_rate: 10
+ft_reference_window: "60s"
+# How far the lowest sweep rung may sit from the reference before the sweep
+# stops. Two independent low rates that disagree mean one is already degraded.
+ft_reference_tolerance: 0.08

--- a/experiments/fm-snmptrap/rate.yml
+++ b/experiments/fm-snmptrap/rate.yml
@@ -27,8 +27,8 @@
     cmd: >-
       nl6-loadtest --protocol snmp-trap --rate {{ ft_rate }} --window {{ ft_window }}
       --start-ip {{ ft_start_ip }} --count {{ ft_device_count }}
-      --label "fm-snmptrap {{ ft_rate }}/s" --html /tmp/ft-{{ ft_rate }}.html
-      --json /tmp/ft-{{ ft_rate }}.json
+      --label "fm-snmptrap {{ ft_rate }}/s" --html /tmp/ft-{{ ft_rung_label | default(ft_rate) }}.html
+      --json /tmp/ft-{{ ft_rung_label | default(ft_rate) }}.json
   register: ft_load
   changed_when: true
   # Exit 1 means the generator itself fell short. That is a finding about the
@@ -71,7 +71,7 @@
 # the opposite of tolerating rc 1 above.
 - name: "Read the sent-ledger for rate {{ ft_rate }}"
   ansible.builtin.slurp:
-    src: "/tmp/ft-{{ ft_rate }}.json"
+    src: "/tmp/ft-{{ ft_rung_label | default(ft_rate) }}.json"
   register: ft_ledger
   failed_when: false
 
@@ -80,13 +80,15 @@
     ft_results: "{{ (ft_results | default([])) + [rung] }}"
     ft_rows: >-
       {{ (ft_rows | default([]))
-         + ['%-9s %-6s %-8s %-7s %-9s %-6s %s' | format(
-              ft_rate, rung.sent, rung.events,
+         + ['%-9s %-6s %-6s %-6s %-7s %-8s %-9s %-6.3f %s' | format(
+              ft_rung_label | default(ft_rate), rung.sent, rung.events_raw, rung.background, rung.events,
               (rung.sent | int / ([window_s | int, 1] | max)) | round(1),
               (rung.events | int / ([window_s | int, 1] | max)) | round(1),
-              ratio | round(3),
+              rung.ratio | float,
               '-' if ft_reference_ratio is not defined
-                  else (ratio / ([ft_reference_ratio | float, 0.000001] | max)) | round(3)) ] }}
+                  else '%.3f%s' | format(rung.ratio | float / (ft_reference_ratio | float),
+                                         '  <- over 1.0 means the background correction is off'
+                                         if rung.ratio | float > (ft_reference_ratio | float) * 1.05 else '')) ] }}
   vars:
     ledger: >-
       {{ (ft_ledger.content | default("") | b64decode | from_json)
@@ -101,10 +103,6 @@
     ts_before: "{{ ft_events_before.stdout.split()[1] }}"
     ev_after: "{{ ft_events_after.stdout.split()[0] }}"
     ts_after: "{{ ft_events_after.stdout.split()[1] }}"
-    # Absolute persisted share. Read against the reference, not against 1.0: a
-    # workload the deployment partly discards has a reference below 1.0 and is
-    # not lossy (#212).
-    ratio: "{{ (rung.events | int) / ([rung.sent | int, 1] | max) }}"
     sink_before: "{{ ft_sink_before.stdout | trim | int }}"
     sink_after: "{{ ft_sink_after.stdout | trim | int }}"
     rung:
@@ -125,6 +123,14 @@
       events_raw: "{{ ev_after | int - ev_before | int }}"
       bracket_s: "{{ (ts_after | float - ts_before | float) | round(1) }}"
       background: "{{ ((ft_background_mps | int * (ts_after | float - ts_before | float)) / 1000) | round | int }}"
+      # Absolute persisted share, carried on the rung rather than recomputed by
+      # each consumer. The reference ratio and the corroboration both read it
+      # from here, so a change to the arithmetic cannot leave them disagreeing
+      # with the printed table.
+      ratio: >-
+        {{ ([ (ev_after | int - ev_before | int)
+              - (((ft_background_mps | int * (ts_after | float - ts_before | float)) / 1000) | round | int),
+              0 ] | max) / ([ledger.delivered.sent | default(0) | int, 1] | max) }}
       events: >-
         {{ [ (ev_after | int - ev_before | int)
              - (((ft_background_mps | int * (ts_after | float - ts_before | float)) / 1000) | round | int),

--- a/experiments/fm-snmptrap/rate.yml
+++ b/experiments/fm-snmptrap/rate.yml
@@ -80,10 +80,13 @@
     ft_results: "{{ (ft_results | default([])) + [rung] }}"
     ft_rows: >-
       {{ (ft_rows | default([]))
-         + ['%-9s %-6s %-11s %-10s %-6s %-8s %-7s %s' | format(
-              ft_rate, rung.sent, rung.sink, rung.events_raw, rung.background, rung.events,
+         + ['%-9s %-6s %-8s %-7s %-9s %-6s %s' | format(
+              ft_rate, rung.sent, rung.events,
               (rung.sent | int / ([window_s | int, 1] | max)) | round(1),
-              (rung.events | int / ([window_s | int, 1] | max)) | round(1)) ] }}
+              (rung.events | int / ([window_s | int, 1] | max)) | round(1),
+              ratio | round(3),
+              '-' if ft_reference_ratio is not defined
+                  else (ratio / ([ft_reference_ratio | float, 0.000001] | max)) | round(3)) ] }}
   vars:
     ledger: >-
       {{ (ft_ledger.content | default("") | b64decode | from_json)
@@ -98,6 +101,10 @@
     ts_before: "{{ ft_events_before.stdout.split()[1] }}"
     ev_after: "{{ ft_events_after.stdout.split()[0] }}"
     ts_after: "{{ ft_events_after.stdout.split()[1] }}"
+    # Absolute persisted share. Read against the reference, not against 1.0: a
+    # workload the deployment partly discards has a reference below 1.0 and is
+    # not lossy (#212).
+    ratio: "{{ (rung.events | int) / ([rung.sent | int, 1] | max) }}"
     sink_before: "{{ ft_sink_before.stdout | trim | int }}"
     sink_after: "{{ ft_sink_after.stdout | trim | int }}"
     rung:

--- a/experiments/fm-syslog/experiment.yml
+++ b/experiments/fm-syslog/experiment.yml
@@ -4,20 +4,34 @@
 #
 #   make experiment EXPERIMENT=fm-syslog DEPLOYMENT=kfk-exclusive
 #
-# Sweeps a list of rates and, for each, reconciles three independently-derived
-# numbers:
+# Sweeps a list of rates. Each rung reports what left the generator and what
+# the Core persisted, read against a measured reference rather than against an
+# assumed 1.0:
 #
 #   sent      nl6's immutable sent-ledger — what left the generator
-#   sink      OpenNMS.Sink.Syslog offset delta — what the Minion took
-#   events    rows in the OpenNMS events table — what the Core turned into events
+#   raw       rows added to the events table over the rung's bracket
+#   bkgnd     what the idle fleet would have produced over the same bracket
+#   events    raw minus bkgnd — what this rung's load actually persisted
+#   ratio     events / sent. Composition: it should NOT move with rate.
+#   vs-ref    ratio / reference ratio. Fidelity: a fall here is the system
+#             giving way.
 #
-# A rate where sent stops tracking sink is the ingress giving way. A rate where
-# sink stops tracking events is the Core. Measuring only one of the three cannot
-# tell those apart, and measuring only what was requested cannot see either.
+# Both ratios are published on purpose. A deployment that persists only part of
+# what a generator emits is a real property of the pair, and normalising it away
+# would swap one misleading number for another. This path's reference measures
+# near 1.0, so its workload happens to be fully persistable — but that is a
+# measured fact per run, not an assumption. The trap path's sits near 0.5 with
+# nothing wrong (#212).
 #
-# The sink batches, so its delta counts Kafka messages rather than records. It
-# is a floor on what arrived, not an exact count; the events delta is the
-# record-accurate figure.
+# raw and bkgnd are printed, not just used: a correction large relative to the
+# rung is itself the finding. They also separate a rung that lost its generator
+# ledger (sent 0, raw large) from one where the deployment gave way, which the
+# ratio columns alone render identical.
+#
+# OpenNMS.Sink.Syslog is still read and still asserted non-zero, but is not
+# tabulated: the sink batches at a rate-dependent size, so its offset delta
+# counts Kafka messages rather than syslog messages and cannot be compared against
+# them. See #215.
 
 - name: Build the fleet
   hosts: net_sim
@@ -65,6 +79,20 @@
     # constant rather than rate-dependent, so it reads as every rung receiving
     # more than was sent to it. It is not in nl6's ledger, so the two sides
     # cannot reconcile until it is measured here and taken back out per rung.
+    # The reference is fm_rates | first, so the list must be ascending for it to
+    # be the least-loaded measurement. Nothing else enforces the ordering, and a
+    # reordered list would silently calibrate the sweep against a saturated rung.
+    - name: Assert the sweep rates ascend
+      ansible.builtin.assert:
+        that:
+          - (fm_rates | length) > 1
+          - fm_rates | map('int') | list == (fm_rates | map('int') | sort | list)
+        fail_msg: >-
+          fm_rates must be ascending and hold at least two entries: the first is
+          used as the reference, and the reference has to be the least-loaded
+          rung in the sweep. Got {{ fm_rates }}.
+        quiet: true
+
     - name: Measure the idle background event rate
       ansible.builtin.shell:
         cmd: |
@@ -85,9 +113,10 @@
       ansible.builtin.set_fact:
         fm_background_mps: "{{ fm_baseline.stdout | trim | int }}"
 
-    # The reference rung. Its persisted-over-sent ratio is the definition of
-    # "nothing was lost" for this workload against this deployment, and it is
-    # measured rather than assumed to be 1.0.
+    # The reference rung: the lowest sweep rate, run once before the sweep and
+    # once inside it. Its persisted-over-sent ratio is the definition of
+    # "nothing was lost" for this workload against this deployment, measured
+    # rather than assumed to be 1.0.
     #
     # Assuming 1.0 assumes the deployment persists everything the generator
     # emits. That held for syslog by luck and was false for traps: about half
@@ -95,49 +124,64 @@
     # deployment discards, so the sweep reported a permanent 50% deficit that
     # no component caused (#212).
     #
-    # Run at a rate with wide margin against the knee, and for longer than a
-    # sweep rung, so the background correction is a small share of the count
-    # rather than the dominant term.
+    # Same rate and same window as the rung it is corroborated against, on
+    # purpose. An earlier version ran the reference at its own rate and window,
+    # which made it the *more* loaded of the two measurements and left their
+    # background corrections asymmetric (~24% against ~40% of the raw count),
+    # so the tolerance was being spent on noise rather than on signal. Running
+    # identical conditions twice makes corroboration a test-retest, and the
+    # background correction cancels instead of biasing.
+    #
+    # There is deliberately no reference rate or window variable. The previous
+    # ones could not work: make passes the experiment vars file via
+    # --extra-vars, which outranks include_tasks vars, so a window override was
+    # silently ignored and the reference ran at the sweep window regardless.
     - name: Measure the reference rung
       ansible.builtin.include_tasks: rate.yml
       vars:
-        fm_rate: "{{ fm_reference_rate }}"
-        fm_window: "{{ fm_reference_window }}"
+        fm_rate: "{{ fm_rates | first }}"
+        # Distinct sidecar, so the reference and the identical sweep rung
+        # cannot overwrite each other's ledger.
+        fm_rung_label: ref
 
-    # Split from the capture below deliberately: doing both in one set_fact
-    # would make the result depend on the order Ansible evaluates its keys.
-    - name: Capture the reference rung
+    - name: Capture the reference
       ansible.builtin.set_fact:
         fm_reference: "{{ fm_results | last }}"
-        fm_reference_row: "{{ fm_rows | last }}"
-
-    - name: Take the reference out of the sweep rows
-      ansible.builtin.set_fact:
-        fm_results: "{{ fm_results[:-1] }}"
-        fm_rows: "{{ fm_rows[:-1] }}"
-
-    - name: Record the reference ratio
-      ansible.builtin.set_fact:
-        fm_reference_ratio: "{{ (fm_reference.events | int) / ([fm_reference.sent | int, 1] | max) }}"
+        # Where the sweep's own rungs begin, recorded rather than assumed, so
+        # nothing depends on the reference being at a particular index later.
+        fm_sweep_from: "{{ fm_results | length }}"
 
     # A reference of zero cannot define healthy: every rung measured against it
     # would read as perfect. This fails towards reporting success, which is the
     # direction nobody investigates.
+    #
+    # The delivery check is the other half. rate.yml deliberately tolerates the
+    # generator falling short (rc 1), so without this a reference built from a
+    # handful of delivered records would pass on ratio alone and mis-scale the
+    # whole table.
     - name: Assert the reference carries a signal
       ansible.builtin.assert:
         that:
           - (fm_reference.sent | int) > 0
-          - (fm_reference_ratio | float) > 0
+          - (fm_reference.ratio | float) > 0
+          - (fm_reference.expected | int) == 0
+            or (fm_reference.sent | int) >= (fm_reference.expected | int) * (fm_reference_min_delivery | float)
         fail_msg: >-
-          The reference rung at {{ fm_reference_rate }}/device persisted
-          {{ fm_reference.events }} of {{ fm_reference.sent }} sent.
-          Nothing can be measured against a reference of zero. Check the
-          syslog ingress before reading anything below it.
+          The reference rung at {{ fm_rates | first }}/device delivered
+          {{ fm_reference.sent }} of {{ fm_reference.expected }} expected and
+          persisted {{ fm_reference.events }}. A reference that is zero, or built
+          from a short delivery, cannot define healthy: every rung measured
+          against it inherits the error.
         success_msg: >-
-          reference {{ (fm_reference_ratio | float) | round(3) }}
+          reference {{ (fm_reference.ratio | float) | round(3) }}
           ({{ fm_reference.events }}/{{ fm_reference.sent }} at
-          {{ fm_reference_rate }}/device)
+          {{ fm_rates | first }}/device)
         quiet: true
+
+    # Published so every rung's vs-ref can be computed against it.
+    - name: Record the reference ratio
+      ansible.builtin.set_fact:
+        fm_reference_ratio: "{{ fm_reference.ratio }}"
 
     - name: Run the sweep
       ansible.builtin.include_tasks: rate.yml
@@ -145,45 +189,61 @@
       loop_control:
         loop_var: fm_rate
 
-    # The whole point of the sweep. Reported as a table so the rate at which
-    # accepted stops tracking sent is visible rather than inferred.
+    # The reference and the sweep's own first rung are the same measurement
+    # taken twice. If they disagree, one is already degraded and the reference
+    # does not define healthy, so every vs-ref figure is against the wrong
+    # baseline. Relative, not absolute: an absolute window means +/-8% against a
+    # syslog reference near 1.0 and +/-16% against a trap reference near 0.5,
+    # which is the column it is supposed to be guarding.
+    #
+    # The zero case is called out separately because the relative test cannot
+    # see it: a near-zero reference makes the interval straddle zero, so a rung
+    # that persisted nothing would corroborate cleanly.
+    - name: Corroborate the reference against its repeat
+      ansible.builtin.assert:
+        that:
+          - (repeat.ratio | float) > 0
+          - ((repeat.ratio | float) / (fm_reference_ratio | float) - 1) | abs < (fm_reference_tolerance | float)
+        fail_msg: >-
+          The reference persisted {{ (fm_reference_ratio | float) | round(3) }} of what
+          was sent; its repeat at the same rate and window persisted
+          {{ (repeat.ratio | float) | round(3) }}. Two identical measurements
+          differing by more than {{ (fm_reference_tolerance | float * 100) | round }}%
+          mean one of them is already degraded, so the baseline is not sound and
+          nothing in the vs-ref column can be read.
+        success_msg: >-
+          reference {{ (fm_reference_ratio | float) | round(3) }} corroborated by its
+          repeat at {{ (repeat.ratio | float) | round(3) }}
+        quiet: true
+      vars:
+        repeat: "{{ fm_results[fm_sweep_from | int] }}"
+      register: fm_corroboration
+      failed_when: false
+
+    # Reported before the asserts below fire, so a failed run still shows its
+    # measurements, but never without saying the baseline is unsound. Printing
+    # a clean-looking table and only then failing is what the previous ordering
+    # did, and it is worse than either.
     - name: Report the sweep
       ansible.builtin.debug:
         msg: >-
-          {{ ['reference: %s persisted of %s sent at %s/device = ratio %s'
-                | format(fm_reference.events, fm_reference.sent, fm_reference_rate,
-                         (fm_reference_ratio | float) | round(3)),
+          {{ ([] if not fm_corroboration.failed else
+                ['*** BASELINE NOT CORROBORATED: the vs-ref column below is measured',
+                 '*** against a reference its own repeat disagrees with. See the error.',
+                 ''])
+             + ['reference: %s persisted of %s sent at %s/device = ratio %.3f'
+                  | format(fm_reference.events, fm_reference.sent,
+                           fm_rates | first, fm_reference.ratio | float),
+                'ratio is composition and should not move with rate.',
+                'vs-ref is fidelity: a fall here is the system giving way.',
                 '',
-                'rate/dev  sent   events   sent/s  events/s  ratio  vs-ref']
+                'rate/dev  sent   raw    bkgnd  events  sent/s   events/s  ratio  vs-ref']
              + (fm_rows | default([])) }}
 
-    # The reference and the lowest sweep rung are two independent low-rate
-    # measurements of the same thing. If they disagree, one of them is already
-    # degraded and the reference cannot be trusted to define healthy. Averaging
-    # them would bury exactly the case this guard exists for.
-    - name: Corroborate the reference against the lowest rung
-      ansible.builtin.assert:
-        that:
-          - (lowest_ratio | float) > (fm_reference_ratio | float) - (fm_reference_tolerance | float)
-          - (lowest_ratio | float) < (fm_reference_ratio | float) + (fm_reference_tolerance | float)
-        fail_msg: >-
-          The reference at {{ fm_reference_rate }}/device persisted
-          {{ (fm_reference_ratio | float) | round(3) }} of what was sent, while the
-          lowest sweep rung at {{ fm_rates | first }}/device persisted
-          {{ (lowest_ratio | float) | round(3) }}. Two low rates that disagree by more
-          than {{ fm_reference_tolerance }} mean one of them is already degraded, so
-          the reference does not define healthy and every vs-ref figure below it
-          is measured against the wrong baseline.
-        success_msg: >-
-          reference {{ (fm_reference_ratio | float) | round(3) }} corroborated by the
-          lowest rung at {{ (lowest_ratio | float) | round(3) }}
-        quiet: true
-      vars:
-        low: "{{ fm_results | first }}"
-        lowest_ratio: "{{ (low.events | int) / ([low.sent | int, 1] | max) }}"
-
     # A sweep where nothing arrived at any rate is a broken deployment, not a
-    # result. Say so rather than publishing a table of zeros.
+    # result. Asserted before the corroboration verdict because it names the
+    # cause: an all-zero sweep would otherwise fail as "two rates disagree",
+    # which is true and useless.
     - name: Assert the deployment accepted something at some rate
       ansible.builtin.assert:
         that:
@@ -197,4 +257,10 @@
           — a deployment can publish that endpoint, open its firewall and run
           the Core-side consumer while nothing listens, and every symptom is a
           clean zero.
+        quiet: true
+
+    - name: Fail if the baseline was not corroborated
+      ansible.builtin.assert:
+        that: [not fm_corroboration.failed]
+        fail_msg: "{{ fm_corroboration.msg | default('baseline not corroborated') }}"
         quiet: true

--- a/experiments/fm-syslog/experiment.yml
+++ b/experiments/fm-syslog/experiment.yml
@@ -85,6 +85,60 @@
       ansible.builtin.set_fact:
         fm_background_mps: "{{ fm_baseline.stdout | trim | int }}"
 
+    # The reference rung. Its persisted-over-sent ratio is the definition of
+    # "nothing was lost" for this workload against this deployment, and it is
+    # measured rather than assumed to be 1.0.
+    #
+    # Assuming 1.0 assumes the deployment persists everything the generator
+    # emits. That held for syslog by luck and was false for traps: about half
+    # of every nl6 trap workload is authenticationFailure, which this
+    # deployment discards, so the sweep reported a permanent 50% deficit that
+    # no component caused (#212).
+    #
+    # Run at a rate with wide margin against the knee, and for longer than a
+    # sweep rung, so the background correction is a small share of the count
+    # rather than the dominant term.
+    - name: Measure the reference rung
+      ansible.builtin.include_tasks: rate.yml
+      vars:
+        fm_rate: "{{ fm_reference_rate }}"
+        fm_window: "{{ fm_reference_window }}"
+
+    # Split from the capture below deliberately: doing both in one set_fact
+    # would make the result depend on the order Ansible evaluates its keys.
+    - name: Capture the reference rung
+      ansible.builtin.set_fact:
+        fm_reference: "{{ fm_results | last }}"
+        fm_reference_row: "{{ fm_rows | last }}"
+
+    - name: Take the reference out of the sweep rows
+      ansible.builtin.set_fact:
+        fm_results: "{{ fm_results[:-1] }}"
+        fm_rows: "{{ fm_rows[:-1] }}"
+
+    - name: Record the reference ratio
+      ansible.builtin.set_fact:
+        fm_reference_ratio: "{{ (fm_reference.events | int) / ([fm_reference.sent | int, 1] | max) }}"
+
+    # A reference of zero cannot define healthy: every rung measured against it
+    # would read as perfect. This fails towards reporting success, which is the
+    # direction nobody investigates.
+    - name: Assert the reference carries a signal
+      ansible.builtin.assert:
+        that:
+          - (fm_reference.sent | int) > 0
+          - (fm_reference_ratio | float) > 0
+        fail_msg: >-
+          The reference rung at {{ fm_reference_rate }}/device persisted
+          {{ fm_reference.events }} of {{ fm_reference.sent }} sent.
+          Nothing can be measured against a reference of zero. Check the
+          syslog ingress before reading anything below it.
+        success_msg: >-
+          reference {{ (fm_reference_ratio | float) | round(3) }}
+          ({{ fm_reference.events }}/{{ fm_reference.sent }} at
+          {{ fm_reference_rate }}/device)
+        quiet: true
+
     - name: Run the sweep
       ansible.builtin.include_tasks: rate.yml
       loop: "{{ fm_rates }}"
@@ -95,7 +149,38 @@
     # accepted stops tracking sent is visible rather than inferred.
     - name: Report the sweep
       ansible.builtin.debug:
-        msg: "{{ ['rate/dev  sent   sink(msgs)  events_raw bkgnd  events   sent/s  events/s'] + (fm_rows | default([])) }}"
+        msg: >-
+          {{ ['reference: %s persisted of %s sent at %s/device = ratio %s'
+                | format(fm_reference.events, fm_reference.sent, fm_reference_rate,
+                         (fm_reference_ratio | float) | round(3)),
+                '',
+                'rate/dev  sent   events   sent/s  events/s  ratio  vs-ref']
+             + (fm_rows | default([])) }}
+
+    # The reference and the lowest sweep rung are two independent low-rate
+    # measurements of the same thing. If they disagree, one of them is already
+    # degraded and the reference cannot be trusted to define healthy. Averaging
+    # them would bury exactly the case this guard exists for.
+    - name: Corroborate the reference against the lowest rung
+      ansible.builtin.assert:
+        that:
+          - (lowest_ratio | float) > (fm_reference_ratio | float) - (fm_reference_tolerance | float)
+          - (lowest_ratio | float) < (fm_reference_ratio | float) + (fm_reference_tolerance | float)
+        fail_msg: >-
+          The reference at {{ fm_reference_rate }}/device persisted
+          {{ (fm_reference_ratio | float) | round(3) }} of what was sent, while the
+          lowest sweep rung at {{ fm_rates | first }}/device persisted
+          {{ (lowest_ratio | float) | round(3) }}. Two low rates that disagree by more
+          than {{ fm_reference_tolerance }} mean one of them is already degraded, so
+          the reference does not define healthy and every vs-ref figure below it
+          is measured against the wrong baseline.
+        success_msg: >-
+          reference {{ (fm_reference_ratio | float) | round(3) }} corroborated by the
+          lowest rung at {{ (lowest_ratio | float) | round(3) }}
+        quiet: true
+      vars:
+        low: "{{ fm_results | first }}"
+        lowest_ratio: "{{ (low.events | int) / ([low.sent | int, 1] | max) }}"
 
     # A sweep where nothing arrived at any rate is a broken deployment, not a
     # result. Say so rather than publishing a table of zeros.

--- a/experiments/fm-syslog/opennms-lab-vars.yml
+++ b/experiments/fm-syslog/opennms-lab-vars.yml
@@ -12,3 +12,14 @@ fm_settle_seconds: 60
 # Long enough that the count is not dominated by rounding, short enough
 # not to add a rung to the sweep.
 fm_baseline_seconds: 30
+
+# The reference rung. Its persisted-over-sent ratio defines what "nothing was
+# lost" means for this workload against this deployment, instead of assuming
+# 1.0. Run longer than a sweep rung so the background correction is a small
+# share of the count rather than the dominant term, and at a rate with wide
+# margin against the knee (syslog saturates near 950/s; this offers ~100/s).
+fm_reference_rate: 10
+fm_reference_window: "60s"
+# How far the lowest sweep rung may sit from the reference before the sweep
+# stops. Two independent low rates that disagree mean one is already degraded.
+fm_reference_tolerance: 0.08

--- a/experiments/fm-syslog/opennms-lab-vars.yml
+++ b/experiments/fm-syslog/opennms-lab-vars.yml
@@ -13,13 +13,18 @@ fm_settle_seconds: 60
 # not to add a rung to the sweep.
 fm_baseline_seconds: 30
 
-# The reference rung. Its persisted-over-sent ratio defines what "nothing was
-# lost" means for this workload against this deployment, instead of assuming
-# 1.0. Run longer than a sweep rung so the background correction is a small
-# share of the count rather than the dominant term, and at a rate with wide
-# margin against the knee (syslog saturates near 950/s; this offers ~100/s).
-fm_reference_rate: 10
-fm_reference_window: "60s"
-# How far the lowest sweep rung may sit from the reference before the sweep
-# stops. Two independent low rates that disagree mean one is already degraded.
-fm_reference_tolerance: 0.08
+# The reference is the lowest sweep rate, run once before the sweep and once
+# inside it. There is deliberately no reference rate or window variable: make
+# passes this file via --extra-vars, which outranks include_tasks vars, so an
+# override of a name defined here is silently ignored. An earlier version set
+# a 60s reference window that never took effect.
+#
+# Relative, not absolute. An absolute window means +/-8% against a syslog
+# reference near 1.0 and +/-16% against a trap reference near 0.5, which is the
+# column it exists to guard. 0.10 covers the test-retest spread seen on
+# hardware with room for background drift.
+fm_reference_tolerance: 0.10
+# The generator is allowed to fall short of its requested rate (rate.yml
+# tolerates rc 1), but a reference built from a short delivery mis-scales every
+# rung measured against it.
+fm_reference_min_delivery: 0.9

--- a/experiments/fm-syslog/rate.yml
+++ b/experiments/fm-syslog/rate.yml
@@ -27,8 +27,8 @@
     cmd: >-
       nl6-loadtest --protocol syslog --rate {{ fm_rate }} --window {{ fm_window }}
       --start-ip {{ fm_start_ip }} --count {{ fm_device_count }}
-      --label "fm-syslog {{ fm_rate }}/s" --html /tmp/fm-{{ fm_rate }}.html
-      --json /tmp/fm-{{ fm_rate }}.json
+      --label "fm-syslog {{ fm_rate }}/s" --html /tmp/fm-{{ fm_rung_label | default(fm_rate) }}.html
+      --json /tmp/fm-{{ fm_rung_label | default(fm_rate) }}.json
   register: fm_load
   changed_when: true
   # Exit 1 means the generator itself fell short. That is a finding about the
@@ -71,7 +71,7 @@
 # the opposite of tolerating rc 1 above.
 - name: "Read the sent-ledger for rate {{ fm_rate }}"
   ansible.builtin.slurp:
-    src: "/tmp/fm-{{ fm_rate }}.json"
+    src: "/tmp/fm-{{ fm_rung_label | default(fm_rate) }}.json"
   register: fm_ledger
   failed_when: false
 
@@ -80,13 +80,15 @@
     fm_results: "{{ (fm_results | default([])) + [rung] }}"
     fm_rows: >-
       {{ (fm_rows | default([]))
-         + ['%-9s %-6s %-8s %-7s %-9s %-6s %s' | format(
-              fm_rate, rung.sent, rung.events,
+         + ['%-9s %-6s %-6s %-6s %-7s %-8s %-9s %-6.3f %s' | format(
+              fm_rung_label | default(fm_rate), rung.sent, rung.events_raw, rung.background, rung.events,
               (rung.sent | int / ([window_s | int, 1] | max)) | round(1),
               (rung.events | int / ([window_s | int, 1] | max)) | round(1),
-              ratio | round(3),
+              rung.ratio | float,
               '-' if fm_reference_ratio is not defined
-                  else (ratio / ([fm_reference_ratio | float, 0.000001] | max)) | round(3)) ] }}
+                  else '%.3f%s' | format(rung.ratio | float / (fm_reference_ratio | float),
+                                         '  <- over 1.0 means the background correction is off'
+                                         if rung.ratio | float > (fm_reference_ratio | float) * 1.05 else '')) ] }}
   vars:
     ledger: >-
       {{ (fm_ledger.content | default("") | b64decode | from_json)
@@ -101,10 +103,6 @@
     ts_before: "{{ fm_events_before.stdout.split()[1] }}"
     ev_after: "{{ fm_events_after.stdout.split()[0] }}"
     ts_after: "{{ fm_events_after.stdout.split()[1] }}"
-    # Absolute persisted share. Read against the reference, not against 1.0: a
-    # workload the deployment partly discards has a reference below 1.0 and is
-    # not lossy (#212).
-    ratio: "{{ (rung.events | int) / ([rung.sent | int, 1] | max) }}"
     sink_before: "{{ fm_sink_before.stdout | trim | int }}"
     sink_after: "{{ fm_sink_after.stdout | trim | int }}"
     rung:
@@ -125,6 +123,14 @@
       events_raw: "{{ ev_after | int - ev_before | int }}"
       bracket_s: "{{ (ts_after | float - ts_before | float) | round(1) }}"
       background: "{{ ((fm_background_mps | int * (ts_after | float - ts_before | float)) / 1000) | round | int }}"
+      # Absolute persisted share, carried on the rung rather than recomputed by
+      # each consumer. The reference ratio and the corroboration both read it
+      # from here, so a change to the arithmetic cannot leave them disagreeing
+      # with the printed table.
+      ratio: >-
+        {{ ([ (ev_after | int - ev_before | int)
+              - (((fm_background_mps | int * (ts_after | float - ts_before | float)) / 1000) | round | int),
+              0 ] | max) / ([ledger.delivered.sent | default(0) | int, 1] | max) }}
       events: >-
         {{ [ (ev_after | int - ev_before | int)
              - (((fm_background_mps | int * (ts_after | float - ts_before | float)) / 1000) | round | int),

--- a/experiments/fm-syslog/rate.yml
+++ b/experiments/fm-syslog/rate.yml
@@ -80,10 +80,13 @@
     fm_results: "{{ (fm_results | default([])) + [rung] }}"
     fm_rows: >-
       {{ (fm_rows | default([]))
-         + ['%-9s %-6s %-11s %-10s %-6s %-8s %-7s %s' | format(
-              fm_rate, rung.sent, rung.sink, rung.events_raw, rung.background, rung.events,
+         + ['%-9s %-6s %-8s %-7s %-9s %-6s %s' | format(
+              fm_rate, rung.sent, rung.events,
               (rung.sent | int / ([window_s | int, 1] | max)) | round(1),
-              (rung.events | int / ([window_s | int, 1] | max)) | round(1)) ] }}
+              (rung.events | int / ([window_s | int, 1] | max)) | round(1),
+              ratio | round(3),
+              '-' if fm_reference_ratio is not defined
+                  else (ratio / ([fm_reference_ratio | float, 0.000001] | max)) | round(3)) ] }}
   vars:
     ledger: >-
       {{ (fm_ledger.content | default("") | b64decode | from_json)
@@ -98,6 +101,10 @@
     ts_before: "{{ fm_events_before.stdout.split()[1] }}"
     ev_after: "{{ fm_events_after.stdout.split()[0] }}"
     ts_after: "{{ fm_events_after.stdout.split()[1] }}"
+    # Absolute persisted share. Read against the reference, not against 1.0: a
+    # workload the deployment partly discards has a reference below 1.0 and is
+    # not lossy (#212).
+    ratio: "{{ (rung.events | int) / ([rung.sent | int, 1] | max) }}"
     sink_before: "{{ fm_sink_before.stdout | trim | int }}"
     sink_after: "{{ fm_sink_after.stdout | trim | int }}"
     rung:


### PR DESCRIPTION
Refs #212

## Why

The FM sweeps compared what the generator sent against what OpenNMS persisted and treated any shortfall as loss. That assumes the deployment persists everything the generator emits. It held for syslog by luck, and was false for traps.

About half of every nl6 trap workload is `authenticationFailure`, which this deployment does not persist. So the trap sweep reported a permanent, rate-independent 50% deficit that no component caused, and nothing in the output could say otherwise.

Established on hardware in #212, not inferred:

- A wire capture showed **500 packets for a ledger of 499**, so nothing was lost in transit.
- A hand-sent A/B from the same source gave **1200/1200** for coldStart against **1/300** for authenticationFailure.
- Decoding the `snmpTrapOID` varbind: **50 of 99** captured packets were `.1.3.6.1.6.3.1.1.5.5`.

The generator cannot be told to send only persistable traps. nl6's device API exposes `collector`, `mode`, `community`, `interval` and the inform settings, and no trap-type selection.

## What changed

**The sweep measures its own reference instead of assuming 1.0.** One rung at a rate with wide margin against the knee defines what "nothing was lost" means for this workload against this deployment. Every later rung is read against it. This carries no knowledge of trap OIDs or of which definitions discard what: change either side and the reference follows.

**Both ratios are published.** The absolute share is not an intermediate value to be divided away. A deployment that keeps half of what a generator sends is a real property of the pair, and hiding it behind a normalised column would swap one misleading number for another.

**The reference is corroborated, not trusted.** It is checked against the lowest sweep rung and the sweep stops on disagreement rather than averaging. A saturated reference would define a deficit as normal, which fails towards reporting success.

**`sink(msgs)` is gone from the table.** It counts messages while the Minion batches at a rate-dependent size, so it sat between 745 and 894 while offered load moved 50x. Near-constancy read as stability rather than as the absence of a signal. The underlying count is still recorded.

## Results

Same lab, same fleet, same load as the numbers in #210. Only the interpretation changed.

**`fm-snmptrap`**

```
reference: 716 persisted of 1490 sent at 5/device = ratio 0.481

rate/dev  sent   raw    bkgnd  events  sent/s   events/s  ratio  vs-ref
ref       1490   899    183    716     49.7     23.9      0.481  -
5         1490   913    182    731     49.7     24.4      0.491  1.021
25        7490   3866   184    3682    249.7    122.7     0.492  1.023
100       29990  15056  185    14871   999.7    495.7     0.496  1.032
250       74990  37538  183    37355   2499.7   1245.2    0.498  1.037
```

`ratio` is composition and never moves. `vs-ref` is fidelity, and it holds across a 50x range. **The trap path never saturated**, persisting 1245/s at the top rung.

**`fm-syslog`**

```
reference: 1454 persisted of 1500 sent at 5/device = ratio 0.969

rate/dev  sent   raw    bkgnd  events  sent/s   events/s  ratio  vs-ref
ref       1500   2431   977    1454    50.0     48.5      0.969  -
5         1500   2439   986    1453    50.0     48.4      0.969  0.999
25        7400   8334   975    7359    246.7    245.3     0.994  1.026
100       27853  28782  977    27805   928.4    926.8     0.998  1.030
250       63728  30829  982    29847   2124.3   994.9     0.468  0.483
```

Test-retest divergence is 0.1% on syslog and 2.1% on traps, against 5.9% under the earlier asymmetric design. The knee at the top rung is real.

`raw` and `bkgnd` earn their place immediately: the reference carries a 40% background correction (977 of 2431), which is why its ratio reads 0.969 rather than 1.0 and why `ratio` climbs to 0.998 by rung 100 where the same correction is 3%. That is low-rate measurement noise rather than composition drift, and it was invisible before.


## Review round

Adversarially reviewed by three independent layers. The reference itself turned out to be the weakest part of the change that introduced it.

**It ran at 100/s while the rung corroborating it ran at 50/s**, so any degradation starting between the two landed on the reference, was defined as 1.00, and could not be detected — the rung compared against was the *cleaner* measurement. The guard was inverted.

**Its window override never took effect.** `make` passes the experiment vars file via `--extra-vars`, which outranks `include_tasks` vars, so `reference_window: 60s` was silently ignored. The shipped output proved it: 2980 sent at 10/device across 10 devices is 30 seconds of load. That is the exact defect this PR exists to prevent, occurring inside the fix for it. No review layer caught it; it was found by checking the output's arithmetic against the config that supposedly produced it.

So the reference is now the lowest sweep rate run twice — once before the sweep, once inside it. Identical conditions make corroboration a test-retest, let the background correction cancel rather than bias, and leave no reference rate or window variable to be silently ignored.

Also fixed: tolerance is relative (an absolute window meant ±8% for syslog and ±16% for traps); a near-zero reference could be corroborated by a rung that persisted nothing (verified fixed); a reference built from a short delivery is rejected; `raw`/`bkgnd` restored, without which a rung that lost its generator ledger is indistinguishable from the knee; the table prints before the asserts with a banner when the baseline is unsound; `ratio` moved onto the rung after being recomputed in three places; the rates list is asserted ascending.

## Retraction

The trap throughput figures in #210 and #212 are **withdrawn**. They are the persisted share of a half-unpersistable workload, which is neither a capacity result nor a loss result.

`lint-yaml` and `lint-ansible` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

