### PR TITLE
fix(terraform): AWS sim routing + homogeneous CRS-X smoke sweep

### DIFF
--- a/experiments/pm-snmp-smoke/experiment.yml
+++ b/experiments/pm-snmp-smoke/experiment.yml
@@ -1,0 +1,14 @@
+---
+# The pm-snmp sweep, parameterized for a smoke-profile lab: a homogeneous
+# CRS-X fleet ramped until collection stops completing, to locate the knee
+# cheaply before paying for measurement-grade instances.
+#
+#   make experiment EXPERIMENT=pm-snmp-smoke DEPLOYMENT=kfk-exclusive
+#
+# Smoke results are reconnaissance, not benchmarks: t-class instances deplete
+# CPU credits under sustained load, so late rungs run on a slower machine than
+# early ones. Two readings survive that: samples per device per cycle at a
+# fleet size the lab still handles (a count, so a valid scaling reference for
+# sizing the real run), and the mechanics of the pipeline itself.
+- name: Run the pm-snmp sweep with the smoke parameters
+  ansible.builtin.import_playbook: ../pm-snmp/experiment.yml

--- a/experiments/pm-snmp-smoke/opennms-lab-vars.yml
+++ b/experiments/pm-snmp-smoke/opennms-lab-vars.yml
@@ -1,0 +1,21 @@
+---
+# Smoke-profile sweep parameters. Only this file is layered for
+# pm-snmp-smoke (make loads the *named* experiment's vars, not pm-snmp's),
+# so every pm_* variable the playbook reads is restated here.
+#
+# Rung 0 is a single device: its per-device-per-cycle column IS the CRS-X
+# density calibration that sizes the 72M-target fleet (N = 72e6 / density).
+# Later rungs ramp until coverage or per-device-cycle falls — the knee.
+#
+# Increments stay <= 250 because each rung starts at 10.42.<index>.1 and a
+# larger batch would spill into the next rung's third octet and collide.
+pm_device_increments: [1, 24, 75, 150, 250, 250]
+pm_foreign_source: nl6-pm
+# One homogeneous profile so per-device-cycle is a per-device fact rather
+# than a mixed-fleet average. cisco_crs_x is nl6's densest profile
+# (144 interfaces); rung 0 doubles as verification of the file name.
+pm_resource_file: cisco_crs_x.json
+pm_collection_interval: 300
+pm_settle_seconds: 300
+pm_window_seconds: 330
+pm_bucket_seconds: 30

--- a/experiments/pm-snmp/opennms-lab-vars.yml
+++ b/experiments/pm-snmp/opennms-lab-vars.yml
@@ -6,6 +6,11 @@
 # octet, so cumulative fleet size here is 25, 50, 100.
 pm_device_increments: [25, 25, 50]
 pm_foreign_source: nl6-pm
+# Empty means nl6's default mixed fleet. Set to one profile (e.g.
+# cisco_crs_x.json, the densest at 144 interfaces) when the sweep's
+# per-device-per-cycle column is meant to be a scaling reference rather than a
+# mixed-fleet average.
+pm_resource_file: ""
 # One full collection interval plus margin, so every node is collected exactly
 # once inside the window. Each rung costs this much wall clock.
 pm_collection_interval: 300

--- a/experiments/pm-snmp/rung.yml
+++ b/experiments/pm-snmp/rung.yml
@@ -18,6 +18,7 @@
     nl6_fleet_sim_network: "{{ endpoints.generators.nl6.sim_network }}"
     nl6_fleet_start_ip: "10.42.{{ pm_rung_index }}.1"
     nl6_fleet_count: "{{ pm_rung_increment }}"
+    nl6_fleet_resource_file: "{{ pm_resource_file }}"
 
 - name: "Provision the fleet for rung {{ pm_rung_index }}"
   ansible.builtin.include_role:

--- a/experiments/roles/nl6_fleet/defaults/main.yml
+++ b/experiments/roles/nl6_fleet/defaults/main.yml
@@ -7,6 +7,11 @@
 # be recorded on the result to mean anything.
 nl6_fleet_start_ip: "10.42.0.1"
 nl6_fleet_count: 10
+# Empty means nl6's default mixed device set. Set to one profile's file name
+# (e.g. cisco_crs_x.json) for a homogeneous fleet, which is what a scaling
+# benchmark needs: with mixed types the samples-per-device rate averages over
+# unlike devices and cannot be read as a per-device reference.
+nl6_fleet_resource_file: ""
 # Collectors are taken from the manifest by default, so an experiment names
 # where telemetry goes only if it wants something other than this deployment's
 # published ingress.

--- a/experiments/roles/nl6_fleet/tasks/main.yml
+++ b/experiments/roles/nl6_fleet/tasks/main.yml
@@ -22,15 +22,16 @@
     method: POST
     body_format: json
     status_code: [200, 201, 202]
-    body:
-      start_ip: "{{ nl6_fleet_start_ip }}"
-      device_count: "{{ nl6_fleet_count | int }}"
-      netmask: "{{ nl6_fleet_sim_network.split('/')[1] }}"
-      syslog:
-        collector: "{{ nl6_fleet_syslog_collector | trim }}"
-      traps:
-        collector: "{{ nl6_fleet_trap_collector | trim }}"
-        mode: trap
+    # resource_file is merged in only when set: sending it empty would ask nl6
+    # for a profile named "" instead of its default mixed device set.
+    body: >-
+      {{ {'start_ip': nl6_fleet_start_ip,
+          'device_count': nl6_fleet_count | int,
+          'netmask': nl6_fleet_sim_network.split('/')[1],
+          'syslog': {'collector': nl6_fleet_syslog_collector | trim},
+          'traps': {'collector': nl6_fleet_trap_collector | trim, 'mode': 'trap'}}
+         | combine({'resource_file': nl6_fleet_resource_file}
+                   if nl6_fleet_resource_file else {}) }}
   register: nl6_fleet_result
   changed_when: true
   # A 2xx is not success: nl6 wraps replies in {"success": …} and rejects a

--- a/experiments/roles/opennms_requisition/tasks/main.yml
+++ b/experiments/roles/opennms_requisition/tasks/main.yml
@@ -20,6 +20,22 @@
     mode: "0755"
   tags: ["requisition"]
 
+# Before the import, so the first scan already runs under it. Re-posting the
+# same definition on every rung is idempotent: OpenNMS replaces it in place.
+- name: Define the foreign source (ICMP+SNMP detectors, collect all up interfaces)
+  ansible.builtin.uri:
+    url: "{{ opennms_requisition_base }}/rest/foreignSources"
+    method: POST
+    user: "{{ opennms_requisition_user }}"
+    password: "{{ opennms_requisition_password }}"
+    force_basic_auth: true
+    headers:
+      Content-Type: application/xml
+    body: "{{ lookup('template', 'foreign-source.xml.j2') }}"
+    status_code: [200, 201, 202, 204]
+  changed_when: true
+  tags: ["requisition"]
+
 # Every endpoint comes from the manifest. Nodes are pinned to the Minion's
 # location because the simulated network is reachable from the Minion and
 # nowhere else: a node polled from the Core would simply never answer.
@@ -79,6 +95,50 @@
   until: >-
     (opennms_requisition_nodes.json.totalCount | default(0) | int)
     == (opennms_requisition_fleet.json.data | default([], true) | length)
+  retries: "{{ (opennms_requisition_timeout | int // (opennms_requisition_poll_interval | int)) | int }}"
+  delay: "{{ opennms_requisition_poll_interval }}"
+  changed_when: false
+  tags: ["requisition"]
+
+# The import wait above proves the nodes exist; it says nothing about the
+# async node scans that follow. A scan that runs while the sim network is
+# unreachable persists zero SNMP interfaces and, at the default 1d
+# scan-interval, stays that way for 24 hours — the sweep then measures an
+# empty system and reports it as a slow one. Polling the newest node — the
+# one whose scan is still in flight — until it holds SNMP interfaces converts
+# that silent zero into either a healed wait or a loud failure naming the
+# actual problem.
+- name: Find the newest node in the foreign source
+  ansible.builtin.uri:
+    url: >-
+      {{ opennms_requisition_base }}/rest/nodes?foreignSource={{
+        opennms_requisition_foreign_source }}&limit=1&orderBy=id&order=desc
+    method: GET
+    user: "{{ opennms_requisition_user }}"
+    password: "{{ opennms_requisition_password }}"
+    force_basic_auth: true
+    headers:
+      Accept: application/json
+    return_content: true
+  register: opennms_requisition_newest
+  changed_when: false
+  tags: ["requisition"]
+
+- name: Wait for the node scan to persist SNMP interfaces
+  ansible.builtin.uri:
+    url: >-
+      {{ opennms_requisition_base }}/rest/nodes/{{
+        (opennms_requisition_newest.json.node | first).id
+      }}/snmpinterfaces?limit=1
+    method: GET
+    user: "{{ opennms_requisition_user }}"
+    password: "{{ opennms_requisition_password }}"
+    force_basic_auth: true
+    headers:
+      Accept: application/json
+    return_content: true
+  register: opennms_requisition_snmpifs
+  until: (opennms_requisition_snmpifs.json.totalCount | default(0) | int) > 0
   retries: "{{ (opennms_requisition_timeout | int // (opennms_requisition_poll_interval | int)) | int }}"
   delay: "{{ opennms_requisition_poll_interval }}"
   changed_when: false

--- a/experiments/roles/opennms_requisition/templates/foreign-source.xml.j2
+++ b/experiments/roles/opennms_requisition/templates/foreign-source.xml.j2
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+{#
+Copyright 2026 Ronny Trommer <ronny@no42.org>
+SPDX-License-Identifier: Apache-2.0
+
+Foreign-source definition for the benchmark fleet. Two detectors only, so a
+scan costs two probes instead of the stock definition's full suite: at
+thousands of homogeneous simulated devices the default detectors dominate
+import time while telling us nothing we don't already know about nl6.
+
+The policy enables collection on every operationally-up SNMP interface.
+Without it only primary interfaces are collected, and a 144-port CRS-X
+counts as one interface instead of 144 - the density this benchmark scales by.
+#}
+<foreign-source xmlns="http://xmlns.opennms.org/xsd/config/foreign-source"
+                name="{{ opennms_requisition_foreign_source }}">
+  <scan-interval>1d</scan-interval>
+  <detectors>
+    <detector name="ICMP" class="org.opennms.netmgt.provision.detector.icmp.IcmpDetector"/>
+    <detector name="SNMP" class="org.opennms.netmgt.provision.detector.snmp.SnmpDetector"/>
+  </detectors>
+  <policies>
+    <policy name="CollectInterfaces" class="org.opennms.netmgt.provision.persist.policies.MatchingSnmpInterfacePolicy">
+      <parameter key="matchBehavior" value="ALL_PARAMETERS"/>
+      <parameter key="ifAdminStatus" value="1"/>
+      <parameter key="ifOperStatus" value="1"/>
+      <parameter key="action" value="ENABLE_COLLECTION"/>
+    </policy>
+  </policies>
+</foreign-source>

--- a/group_vars/net_sim/vars.yml
+++ b/group_vars/net_sim/vars.yml
@@ -9,4 +9,4 @@
 # group_vars sits beside ansible-inventory.yml, so Ansible loads it for every
 # play that uses the inventory, bootstrap included. It also stays below
 # extra_vars in precedence, which leaves roles free to merge against it.
-nl6_image: "ghcr.io/labmonkeys-space/nl6:v0.21.0"
+nl6_image: "ghcr.io/labmonkeys-space/nl6:v0.22.1"

--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -133,10 +133,16 @@ locals {
       disk_gb = local.smoke ? min(lookup(var.disk_sizes_gb, n.prole, 30), var.smoke_max_disk_gb) : lookup(var.disk_sizes_gb, n.prole, 30)
       public  = try(n.cfg.public_ip, false)
       subnets = n.cfg.subnets
-      # netsim must accept traffic for the whole simulated range without an
-      # address per device: `ip route add local <cidr> dev lo` does that. This
-      # is the first consumer of modules/cloud-init's local_routes.
-      local_routes = n.prole == "netsim" ? [var.net_sim_cidr] : []
+      # nl6 owns the simulated range's host routing: it runs privileged with
+      # host networking and routes the range into its namespace via a veth
+      # pair. Do NOT add `ip route add local <cidr> dev lo` for netsim — the
+      # kernel consults the local table before the main table, so that route
+      # swallows every SNMP packet on the loopback and nl6's devices never
+      # see it. The signature: snmpget times out even on netsim itself while
+      # the nl6 API reports the fleet running, and the pm sweep's nodes_seen
+      # sticks at 2 while the fleet grows. Verified empirically on the first
+      # AWS deploy (2026-08-07); deleting the route made SNMP answer at once.
+      local_routes = []
       interfaces = [
         for si, subnet in n.cfg.subnets : {
           subnet  = subnet

--- a/terraform/modules/cloud-init/templates/user-data.yaml.tftpl
+++ b/terraform/modules/cloud-init/templates/user-data.yaml.tftpl
@@ -58,12 +58,15 @@ write_files:
       [Service]
       Type=oneshot
       RemainAfterExit=yes
-      Restart=on-failure
-      RestartSec=5
-      StartLimitIntervalSec=60
-      StartLimitBurst=10
+      # On EC2 a secondary ENI can get its DHCP lease after
+      # network-online.target, so the next hop is unreachable on the first
+      # try. Retry in-process until it lands: Restart= bookkeeping burned
+      # through StartLimitBurst before the NIC was up (and StartLimit* in
+      # [Service] is ignored anyway), leaving the box with no route and the
+      # unit reporting success.
+      TimeoutStartSec=300
 %{ for route in static_routes ~}
-      ExecStart=/sbin/ip route replace ${route.to} via ${route.via}
+      ExecStart=/bin/sh -ec 'until /sbin/ip route replace ${route.to} via ${route.via}; do sleep 2; done'
 %{ endfor ~}
 
       [Install]


### PR DESCRIPTION
Fixes the three defects that made the first real AWS apply (#174) collect nothing, and adds the homogeneous-fleet smoke sweep for the 72M-metrics-per-interval benchmark (#225).

**Defect 1 - Minion static route raced the ENI.** The oneshot's Restart= bookkeeping burned StartLimitBurst before the secondary NIC had its DHCP lease (StartLimit* sat in [Service], where it is ignored). The unit now retries in-process, bounded by TimeoutStartSec=300.

**Defect 2 - netsim's local-route-on-lo hijacked SNMP.** nl6 v0.21+ routes the sim range into its namespace via a veth pair; the kernel consults the local table first, so `ip route add local 10.42.0.0/16 dev lo` swallowed every packet before nl6 saw it. Signature: snmpget times out on netsim itself, sweep nodes_seen stuck at 2 while the fleet grows. local_routes is now empty for netsim.

**Defect 3 - scans during the broken window persisted zero SNMP interfaces** and stay wrong for the 1d scan-interval. opennms_requisition now waits for the newest node's SNMP interface table to be non-empty after import, turning silent junk into a healed wait or a loud failure.

**Sweep tooling:** nl6_fleet gains resource_file (homogeneous fleets), the requisition defines a lean foreign source (ICMP+SNMP detectors + collect-all-up-interfaces policy), and experiments/pm-snmp-smoke ramps 1 to 750 cisco_crs_x devices - rung 0 doubles as the density calibration for sizing the 72M fleet. Also bumps nl6 to v0.22.1.

Verified on the live smoke lab: SNMP answers end-to-end (Core to Kafka RPC to Minion to device), terraform validate/fmt and ansible-lint pass.

Refs #174. Refs #225.

🤖 Generated with [Claude Code](https://claude.com/claude-code)