### PR TITLE
fix(experiments): give the scan wait its own budget

### DIFF
--- a/experiments/roles/opennms_requisition/defaults/main.yml
+++ b/experiments/roles/opennms_requisition/defaults/main.yml
@@ -15,3 +15,9 @@ opennms_requisition_password: admin
 # the nodes exist measures nothing and reports it as a slow system.
 opennms_requisition_timeout: 300
 opennms_requisition_poll_interval: 10
+# Node scans lag the import: each one walks the agent's full ifTable through
+# the Minion, and a rung that adds hundreds of nodes queues them behind one
+# RPC path. Separate budget because it scales with rung size where the
+# import wait does not; 250 CRS-X scans through a single Minion were observed
+# to need well over the 300s import budget on the smoke lab.
+opennms_requisition_scan_timeout: 1800

--- a/experiments/roles/opennms_requisition/tasks/main.yml
+++ b/experiments/roles/opennms_requisition/tasks/main.yml
@@ -139,7 +139,7 @@
     return_content: true
   register: opennms_requisition_snmpifs
   until: (opennms_requisition_snmpifs.json.totalCount | default(0) | int) > 0
-  retries: "{{ (opennms_requisition_timeout | int // (opennms_requisition_poll_interval | int)) | int }}"
+  retries: "{{ (opennms_requisition_scan_timeout | int // (opennms_requisition_poll_interval | int)) | int }}"
   delay: "{{ opennms_requisition_poll_interval }}"
   changed_when: false
   tags: ["requisition"]


### PR DESCRIPTION
Follow-up to #226. The post-import wait for persisted SNMP interfaces reused the 300s import budget, but scan time scales with rung size where import time does not: each new node walks its full ifTable through the Minion, so a rung adding 150 CRS-X devices queues them behind one RPC path and the guard fired on a healthy lab.

A separate `opennms_requisition_scan_timeout` (default 1800s) keeps the guard meaningful: a lagging scan becomes a wait, a failed scan stays a loud error instead of a rung measuring an empty system.

Observed on the smoke lab (#225): 250-device rungs need well over 300s of scan time through a single Minion - itself the first capacity finding of the 72M campaign.

Refs #225.

🤖 Generated with [Claude Code](https://claude.com/claude-code)