### PR TITLE
chore(gitignore): ignore .agent/ and .agents/ skill directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,8 @@ terraform.rc
 *.auto.tfvars
 
 # === Claude Code / BMAD ===
+.agent/
+.agents/
 .claude/
 _bmad/
 _bmad-output/


### PR DESCRIPTION
AI tool working directories are never committed. These two also leak into the local ansible-lint run, which scans the tree rather than `git ls-files`, and fail `make lint` on skill YAML this repo does not own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)