### PR TITLE
feat(experiments): flows ES vs VictoriaLogs A/B harness

### DIFF
--- a/deployments/es-victorialogs/opennms-lab-vars.yml
+++ b/deployments/es-victorialogs/opennms-lab-vars.yml
@@ -1,0 +1,11 @@
+---
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: Apache-2.0
+#
+# es-victorialogs overlay — layered onto the root opennms-lab-vars.yml as
+# extra-vars by deploy.sh.
+
+# All VMs of this deployment sit on the physical lab bridge, not the NAT
+# subnets the root vars assume; without this the core's JDBC connections
+# are rejected by pg_hba.
+postgres_hba_permissions_v4: "192.168.11.0/24"

--- a/deployments/es-victorialogs/playbook.yml
+++ b/deployments/es-victorialogs/playbook.yml
@@ -1,0 +1,39 @@
+---
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: Apache-2.0
+#
+# Flow-backend A/B stack. Replaces opennms-playbook.yml entirely (the
+# clickhouse-riptide precedent): the SUT is a source-branch assembly
+# tarball installed over SSH by the experiment harness
+# (experiments/flows-es-vs-victorialogs/bin/provision-core.sh), so the
+# collection's opennms_core role — which installs the packaged release —
+# must NOT run here. Everything the tarball needs from the platform
+# (PostgreSQL + iplike, JDK, jicmp/jrrd2) is provisioned below.
+
+- name: Manage PostgreSQL database
+  hosts: database
+  become: true
+  roles:
+    - indigo423.opennms.common
+    - indigo423.opennms.stub_pgsql
+
+- name: Manage Elasticsearch
+  hosts: elasticsearch
+  become: true
+  roles:
+    - indigo423.opennms.common
+    - indigo423.opennms.stub_elasticsearch
+
+- name: Manage VictoriaLogs
+  hosts: victorialogs
+  become: true
+  roles:
+    - victorialogs
+
+- name: Prepare the core host for the tarball SUT
+  hosts: core
+  become: true
+  roles:
+    - indigo423.opennms.common
+    - indigo423.opennms.opennms_repositories
+    - opennms_tarball_prereqs

--- a/deployments/es-victorialogs/topology.yml
+++ b/deployments/es-victorialogs/topology.yml
@@ -1,0 +1,36 @@
+---
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: Apache-2.0
+name: es-victorialogs
+description: >-
+  Flow-backend A/B benchmark: 1 OpenNMS Core (tarball SUT, not the
+  packaged release — see experiments/flows-es-vs-victorialogs), 1
+  PostgreSQL, and one flow-store VM that carries BOTH Elasticsearch and
+  VictoriaLogs; the experiment starts exactly one of them per variant so
+  the two backends run on identical hardware. All VMs sit directly on the
+  physical lab bridge with static addresses so the off-hypervisor nl6 on
+  monkey-head can reach the core's IPFIX ingest — required for absolute
+  capacity claims (generator off-box). The core routes the
+  simulated-exporter net (10.42.0.0/16) via monkey-head.
+roles:
+  elasticsearch:
+    count: 1
+    size: large
+    subnets: [lab]
+    addresses: { lab: ["192.168.11.36"] }
+    # No docker_engine: Elasticsearch installs as a native .deb and
+    # VictoriaLogs as a release binary under systemd.
+    groups: [elasticsearch, victorialogs]
+  database:
+    count: 1
+    size: small
+    subnets: [lab]
+    addresses: { lab: ["192.168.11.37"] }
+    groups: [database]
+  core:
+    count: 1
+    size: xlarge
+    subnets: [lab]
+    addresses: { lab: ["192.168.11.35"] }
+    routes: { lab: { to: "10.42.0.0/16", via: "192.168.11.73" } }
+    groups: [core]

--- a/deployments/roles/opennms_tarball_prereqs/handlers/main.yml
+++ b/deployments/roles/opennms_tarball_prereqs/handlers/main.yml
@@ -1,0 +1,8 @@
+---
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: Apache-2.0
+- name: Apply sysctl
+  ansible.builtin.command: sysctl -p /etc/sysctl.d/90-flow-ingest.conf
+  changed_when: true
+  tags:
+    - opennms_tarball_prereqs

--- a/deployments/roles/opennms_tarball_prereqs/tasks/main.yml
+++ b/deployments/roles/opennms_tarball_prereqs/tasks/main.yml
@@ -1,0 +1,60 @@
+---
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: Apache-2.0
+#
+# Platform prerequisites for an OpenNMS assembly-tarball SUT (the skill's
+# ssh-tarball provisioner): JDK plus the native OpenNMS helpers the packaged
+# release would normally pull in. Expects indigo423.opennms.opennms_repositories
+# to have configured debian.opennms.org already (jicmp/jrrd2 live there).
+# The tarball itself is installed by the experiment harness, NOT here — the
+# harness owns the SUT identity (git SHA + tarball sha256) end to end.
+
+# Telemetryd's UDP listener inherits the kernel default receive buffer;
+# at 200 synchronized exporters the stock 208 KiB buffer drops ~74% of the
+# offered IPFIX datagrams (riptide-flow-capacity measured the same). The
+# buffer is a pinned experiment control, identical for every variant.
+- name: Raise UDP receive buffers for flow ingest
+  ansible.builtin.copy:
+    dest: /etc/sysctl.d/90-flow-ingest.conf
+    content: |
+      net.core.rmem_max=134217728
+      net.core.rmem_default=67108864
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Apply sysctl
+  tags:
+    - opennms_tarball_prereqs
+
+# The packaged release creates this account in its postinst; a tarball
+# install has to bring it itself.
+- name: Create the opennms system group
+  ansible.builtin.group:
+    name: opennms
+    system: true
+  tags:
+    - opennms_tarball_prereqs
+
+- name: Create the opennms system user
+  ansible.builtin.user:
+    name: opennms
+    group: opennms
+    system: true
+    shell: /usr/sbin/nologin
+    home: /opt/opennms
+    create_home: false
+  tags:
+    - opennms_tarball_prereqs
+
+- name: Install JDK and OpenNMS native helpers
+  ansible.builtin.apt:
+    name:
+      - openjdk-21-jdk-headless
+      - jicmp
+      - jicmp6
+      - jrrd2
+      - rrdtool
+    state: present
+    update_cache: true
+  tags:
+    - opennms_tarball_prereqs

--- a/deployments/roles/victorialogs/defaults/main.yml
+++ b/deployments/roles/victorialogs/defaults/main.yml
@@ -1,0 +1,12 @@
+---
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: Apache-2.0
+# renovate: datasource=github-releases depName=VictoriaMetrics/VictoriaLogs
+victorialogs_version: "1.52.0"
+victorialogs_arch: amd64
+victorialogs_pkg_url: "https://github.com/VictoriaMetrics/VictoriaLogs/releases/download/v{{ victorialogs_version }}/victoria-logs-linux-{{ victorialogs_arch }}-v{{ victorialogs_version }}.tar.gz"
+victorialogs_http_port: 9428
+victorialogs_data_path: /var/lib/victoria-logs
+# Benchmark corpora are transient; a long retention only risks filling the
+# 30 GB default disk between runs.
+victorialogs_retention: 7d

--- a/deployments/roles/victorialogs/handlers/main.yml
+++ b/deployments/roles/victorialogs/handlers/main.yml
@@ -1,0 +1,11 @@
+---
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: Apache-2.0
+- name: Restart victorialogs
+  ansible.builtin.systemd:
+    name: victoria-logs.service
+    state: restarted
+    daemon_reload: true
+  tags:
+    - victorialogs
+    - systemd

--- a/deployments/roles/victorialogs/tasks/main.yml
+++ b/deployments/roles/victorialogs/tasks/main.yml
@@ -1,0 +1,91 @@
+---
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: Apache-2.0
+#
+# VictoriaLogs single-node, modeled on indigo423.opennms.stub_victoriametrics:
+# upstream release tarball into a version-scoped directory behind a stable
+# symlink, running under systemd.
+
+- name: Create the victorialogs system group
+  ansible.builtin.group:
+    name: victorialogs
+    system: true
+  tags:
+    - victorialogs
+
+- name: Create the victorialogs system user
+  ansible.builtin.user:
+    name: victorialogs
+    group: victorialogs
+    system: true
+    shell: /usr/sbin/nologin
+    home: "{{ victorialogs_data_path }}"
+    create_home: false
+  tags:
+    - victorialogs
+
+- name: Create the VictoriaLogs data directory
+  ansible.builtin.file:
+    path: "{{ victorialogs_data_path }}"
+    state: directory
+    owner: victorialogs
+    group: victorialogs
+    mode: "0750"
+  tags:
+    - victorialogs
+
+# Unpack into a version-scoped directory and expose it through a stable
+# symlink, so bumping victorialogs_version extracts the new binary and flips
+# the symlink to trigger a restart.
+- name: Create the VictoriaLogs versioned install directory
+  ansible.builtin.file:
+    path: "/opt/victoria-logs/{{ victorialogs_version }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+  tags:
+    - victorialogs
+
+- name: Install the victoria-logs-prod binary
+  ansible.builtin.unarchive:
+    src: "{{ victorialogs_pkg_url }}"
+    dest: "/opt/victoria-logs/{{ victorialogs_version }}"
+    remote_src: true
+    creates: "/opt/victoria-logs/{{ victorialogs_version }}/victoria-logs-prod"
+    owner: root
+    group: root
+    mode: "0755"
+  tags:
+    - victorialogs
+
+- name: Link victoria-logs-prod into PATH
+  ansible.builtin.file:
+    src: "/opt/victoria-logs/{{ victorialogs_version }}/victoria-logs-prod"
+    dest: /usr/local/bin/victoria-logs-prod
+    state: link
+  notify: Restart victorialogs
+  tags:
+    - victorialogs
+
+- name: Install the VictoriaLogs systemd unit
+  ansible.builtin.template:
+    src: victoria-logs.service.j2
+    dest: /etc/systemd/system/victoria-logs.service
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Restart victorialogs
+  tags:
+    - victorialogs
+    - systemd
+
+- name: Enable and start VictoriaLogs
+  ansible.builtin.systemd:
+    name: victoria-logs.service
+    enabled: true
+    state: started
+    daemon_reload: true
+  tags:
+    - victorialogs
+    - systemd

--- a/deployments/roles/victorialogs/templates/victoria-logs.service.j2
+++ b/deployments/roles/victorialogs/templates/victoria-logs.service.j2
@@ -1,0 +1,21 @@
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: Apache-2.0
+# Managed by Ansible (deployments/roles/victorialogs)
+[Unit]
+Description=VictoriaLogs single-node log database
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=victorialogs
+Group=victorialogs
+ExecStart=/usr/local/bin/victoria-logs-prod \
+  -storageDataPath={{ victorialogs_data_path }} \
+  -httpListenAddr=:{{ victorialogs_http_port }} \
+  -retentionPeriod={{ victorialogs_retention }}
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/experiments/flows-es-vs-victorialogs/.gitignore
+++ b/experiments/flows-es-vs-victorialogs/.gitignore
@@ -1,0 +1,2 @@
+build/
+results/

--- a/experiments/flows-es-vs-victorialogs/README.md
+++ b/experiments/flows-es-vs-victorialogs/README.md
@@ -1,0 +1,65 @@
+<!--
+Copyright 2026 Ronny Trommer <ronny@no42.org>
+SPDX-License-Identifier: Apache-2.0
+-->
+# Flow backend A/B: Elasticsearch (painless) vs. VictoriaLogs
+
+A/B benchmark of the two OpenNMS flow backends on identical hardware: Elasticsearch on its post-NMS-20027 path (inline Painless `proportional_sum`, no drift plugin) versus the `features/flows/victorialogs` module (`ronny-poc/victorialogs-flows`). Full Stage-0 design: [`plan.md`](plan.md).
+
+Like `riptide-flow-capacity` this is a standalone harness on the KVM lab, not a `make experiment` playbook. Generator off-box (nl6 on monkey-head) → relative A/B **and** absolute capacity claims valid.
+
+## One paragraph
+
+One build — NMS-20027 (`03b6b6dd8cf`) cherry-picked onto `ronny-poc/victorialogs-flows`, merged SHA `bddd104c101`, assembly tarball installed once on the core VM (ssh-tarball provisioner). Two variants that differ only in which flow-persistence cfg exists in `etc/`: **A** = Elasticsearch 8.18.2 + `proportionalSumStrategy=painless`, **B** = VictoriaLogs 1.52.0 with `httpCompression=false` (kills the transport confound). The flow-store VM (`es-benchmark-01`, 4c/8G) carries both engines; the inactive one is stopped during measured windows. Per variant: 3 × 15-min reconciled IPFIX ingest windows (nl6 send-ledger vs store doc counts), then 6 timed trials of the fixed dense/sparse query set (trial 1 discarded). A dual-write phase feeds both stores the same stream for the mandatory correctness diff — no speed claim ships without it.
+
+## Layout
+
+| Path | Purpose |
+|---|---|
+| `plan.md` | Stage-0 plan (copied into every manifest's `experiment.plan`) |
+| `../../deployments/es-victorialogs/` | The SUT topology (core, PostgreSQL, dual-engine flow store) |
+| `variants/common/` | Config identical in both variants (telemetryd `Multi-UDP-9999`) |
+| `variants/variant-a-es-painless/` | ES cfg — the IV, side A |
+| `variants/variant-b-victorialogs/` | VL cfg — the IV, side B |
+| `correctness/` | Dual-write correctness-diff procedure |
+| `queries/queries.json` | Fixed dense/sparse query set (from nms-20027) |
+| `bin/` | Harness: provision, apply-variant, ingest windows, query trials, manifest |
+| `build/`, `results/` | Generated at run time — gitignored |
+
+## Runbook
+
+```sh
+# 0. Lab up (once):
+make deploy PROVIDER=kvm DEPLOYMENT=es-victorialogs
+
+# 1. SUT on the core VM (once; identity → build/sut-identity.json)
+./bin/provision-core.sh
+
+# 2. Variant A
+./bin/apply-variant.sh variant-a-es-painless
+./bin/run-ingest-window.sh variant-a-es-painless 200 15m w1   # ramp: run a 5m
+./bin/run-ingest-window.sh variant-a-es-painless 200 15m w2   # window first and
+./bin/run-ingest-window.sh variant-a-es-painless 200 15m w3   # discard it
+T0/T1 from results/variant-a-es-painless/window-w1/counts.json:
+./bin/run-queries.sh variant-a-es-painless <T0> <T1>
+./bin/emit-manifest.sh variant-a-es-painless A1
+
+# 3. Variant B — same, with variant-b-victorialogs
+
+# 4. Correctness (dual-write)
+./bin/apply-variant.sh dual-write
+./bin/run-ingest-window.sh dual-write 200 15m corr
+./bin/run-queries.sh correctness-es <T0> <T1>     # ES answers
+./bin/apply-variant.sh dual-write-flip
+./bin/run-queries.sh correctness-vl <T0> <T1>     # VL answers
+./bin/diff-quality.py results/correctness-es/queries/raw results/correctness-vl/queries/raw
+
+# 5. Report: splice runs+manifests into the skill's report-template.html
+```
+
+## Verify-at-use gates
+
+- nl6 fleet/scenario field names were verified against `riptide-flow-capacity/run_scenario.sh`, not docs — re-verify if the nl6 version on monkey-head moved past v0.20.x.
+- ES shard request cache is disabled by `run-queries.sh` before trials (10.7 s cold vs 0.04 s cached measured in nms-20027).
+- Reconciliation disqualifiers: non-zero `send_failures`/`dropped` in a ledger, or received > offered → rerun, don't report.
+- VL `maxFlowDurationMs` default (120 s) silently under-attributes longer flows — part of the correctness diff, not a latency footnote.

--- a/experiments/flows-es-vs-victorialogs/bin/apply-variant.sh
+++ b/experiments/flows-es-vs-victorialogs/bin/apply-variant.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: Apache-2.0
+#
+# Flip the SUT to a variant: push the shared telemetryd config + exactly the
+# variant's flow-persistence cfg(s), start only the store service(s) that
+# variant uses, restart OpenNMS, wait for REST.
+#
+#   apply-variant.sh variant-a-es-painless | variant-b-victorialogs
+#                  | dual-write            # both persist, ES answers queries
+#                  | dual-write-flip       # hand the query path to VL
+# shellcheck disable=SC1091,SC2029,SC2086,SC2153
+# env.sh resolves at runtime; $SSH_OPTS must word-split; ssh commands
+# expand on the client by design - the heredocs carry only local values.
+set -euo pipefail
+. "$(dirname "$0")/env.sh"
+V=${1:?variant}
+
+ETC=$OPENNMS_HOME/etc
+ELASTIC_CFG=$ETC/org.opennms.features.flows.persistence.elastic.cfg
+VL_CFG=$ETC/org.opennms.features.flows.persistence.victorialogs.cfg
+
+if [ "$V" = "dual-write-flip" ]; then
+  # Runtime config reload — no restart, the registrar reacts to the cfg edit.
+  ssh $SSH_OPTS "$CORE" "sudo sed -i 's/^skipVictoriaLogsQueries=.*/skipVictoriaLogsQueries=false/' $VL_CFG"
+  echo "query path handed to VictoriaLogs"; exit 0
+fi
+
+ssh $SSH_OPTS "$CORE" "sudo $OPENNMS_HOME/bin/opennms stop || true"
+scp $SSH_OPTS "$EXP_DIR/variants/common/telemetryd-configuration.xml" "$CORE:/tmp/telemetryd-configuration.xml"
+ssh $SSH_OPTS "$CORE" "sudo cp /tmp/telemetryd-configuration.xml $ETC/ && sudo rm -f $ELASTIC_CFG $VL_CFG"
+
+case "$V" in
+  variant-a-es-painless)
+    scp $SSH_OPTS "$EXP_DIR/variants/variant-a-es-painless/org.opennms.features.flows.persistence.elastic.cfg" "$CORE:/tmp/elastic.cfg"
+    ssh $SSH_OPTS "$CORE" "sudo cp /tmp/elastic.cfg $ELASTIC_CFG"
+    ssh $SSH_OPTS "$STORE" "sudo systemctl stop victoria-logs; sudo systemctl start elasticsearch"
+    ;;
+  variant-b-victorialogs)
+    scp $SSH_OPTS "$EXP_DIR/variants/variant-b-victorialogs/org.opennms.features.flows.persistence.victorialogs.cfg" "$CORE:/tmp/vl.cfg"
+    scp $SSH_OPTS "$EXP_DIR/variants/variant-b-victorialogs/org.opennms.features.flows.persistence.elastic.cfg" "$CORE:/tmp/elastic-off.cfg"
+    ssh $SSH_OPTS "$CORE" "sudo cp /tmp/vl.cfg $VL_CFG && sudo cp /tmp/elastic-off.cfg $ELASTIC_CFG"
+    ssh $SSH_OPTS "$STORE" "sudo systemctl stop elasticsearch; sudo systemctl start victoria-logs"
+    ;;
+  dual-write)
+    scp $SSH_OPTS "$EXP_DIR/variants/variant-a-es-painless/org.opennms.features.flows.persistence.elastic.cfg" "$CORE:/tmp/elastic.cfg"
+    scp $SSH_OPTS "$EXP_DIR/variants/variant-b-victorialogs/org.opennms.features.flows.persistence.victorialogs.cfg" "$CORE:/tmp/vl.cfg"
+    ssh $SSH_OPTS "$CORE" "sudo cp /tmp/elastic.cfg $ELASTIC_CFG && sudo sed 's/^skipVictoriaLogsQueries=.*/skipVictoriaLogsQueries=true/' /tmp/vl.cfg | sudo tee $VL_CFG >/dev/null"
+    ssh $SSH_OPTS "$STORE" "sudo systemctl start elasticsearch victoria-logs"
+    ;;
+  *) echo "unknown variant: $V" >&2; exit 1 ;;
+esac
+
+ssh $SSH_OPTS "$CORE" "sudo $OPENNMS_HOME/bin/opennms start"
+for _ in $(seq 1 90); do
+  curl -sf -u admin:admin "$BASE_URL/rest/info" >/dev/null && { echo "SUT up as $V"; exit 0; }
+  sleep 10
+done
+echo "SUT did not come up within 15 min" >&2; exit 1

--- a/experiments/flows-es-vs-victorialogs/bin/build-report.py
+++ b/experiments/flows-es-vs-victorialogs/bin/build-report.py
@@ -15,18 +15,21 @@ BASELINE = "es-painless"
 WINDOWS = ["w1", "w2", "w3"]
 
 METRIC_DEFS = [
-    {"id": "ingest-rate", "label": "Sustained IPFIX ingest, persisted flows/s (3x15 min windows)", "unit": "flows/s", "better": "higher"},
+    {"id": "ingest-rate", "label": "Sustained IPFIX ingest, persisted flows/s (3x15 min windows)",
+     "unit": "flows/s", "better": "higher"},
     {"id": "app-series-topn", "label": "Dense app series topN=10 (288 buckets)", "unit": "ms", "better": "lower"},
-    {"id": "conv-series-topn", "label": "Dense conversation series topN=10 (288 buckets)", "unit": "ms", "better": "lower"},
+    {"id": "conv-series-topn", "label": "Dense conversation series topN=10 (288 buckets)",
+     "unit": "ms", "better": "lower"},
     {"id": "app-totals", "label": "App totals topN=10 (whole window)", "unit": "ms", "better": "lower"},
     {"id": "app-series-fine", "label": "Sparse app series N=3 (4500 buckets)", "unit": "ms", "better": "lower"},
-    {"id": "conv-series-fine", "label": "Sparse conversation series N=3 (4500 buckets)", "unit": "ms", "better": "lower"},
+    {"id": "conv-series-fine", "label": "Sparse conversation series N=3 (4500 buckets)",
+     "unit": "ms", "better": "lower"},
     {"id": "app-totals-fine", "label": "App totals N=3 (whole window)", "unit": "ms", "better": "lower"},
 ]
 
 
 def query_stats(vdir):
-    rows = [json.loads(l) for l in (vdir / "queries" / "timings.jsonl").read_text().splitlines()]
+    rows = [json.loads(line) for line in (vdir / "queries" / "timings.jsonl").read_text().splitlines()]
     out, attempted, completed = {}, 0, 0
     by_name = {}
     for r in rows:
@@ -133,8 +136,14 @@ def main():
 
     data = {
         "experiment": {
-            "question": "OpenNMS flow backend A/B on identical hardware: Elasticsearch (post-NMS-20027 Painless path) vs. VictoriaLogs (LogsQL) - IPFIX ingest capacity and flow-query latency",
-            "hypothesis": "VictoriaLogs sustains at least the same ingest rate at lower store-side footprint and answers dense query shapes within the same order of magnitude.",
+            "question": (
+                "OpenNMS flow backend A/B on identical hardware: Elasticsearch (post-NMS-20027 "
+                "Painless path) vs. VictoriaLogs (LogsQL) - IPFIX ingest capacity and flow-query latency"
+            ),
+            "hypothesis": (
+                "VictoriaLogs sustains at least the same ingest rate at lower store-side footprint "
+                "and answers dense query shapes within the same order of magnitude."
+            ),
             "independent_variable": "sut.config_delta",
             "baseline_variant": BASELINE,
             "claim_class": "relative A/B and absolute capacity (KVM lab, nl6 generator off-box on monkey-head)",
@@ -146,7 +155,8 @@ def main():
     }
 
     html = TEMPLATE.read_text()
-    start = html.index('<script id="benchmark-data" type="application/json">') + len('<script id="benchmark-data" type="application/json">')
+    marker = '<script id="benchmark-data" type="application/json">'
+    start = html.index(marker) + len(marker)
     end = html.index("</script>", start)
     out = html[:start] + "\n" + json.dumps(data, indent=2) + "\n" + html[end:]
     out_path = EXP / "results" / "report.html"

--- a/experiments/flows-es-vs-victorialogs/bin/build-report.py
+++ b/experiments/flows-es-vs-victorialogs/bin/build-report.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: Apache-2.0
+#
+# Stage 4: assemble runs+manifests JSON from results/ and splice it into the
+# skill's report-template.html data block (the only edit the template permits).
+import json
+import statistics
+from pathlib import Path
+
+EXP = Path(__file__).resolve().parent.parent
+TEMPLATE = Path.home() / ".claude-onms/skills/opennms-benchmark/assets/report-template.html"
+VARIANTS = {"variant-a-es-painless": "es-painless", "variant-b-victorialogs": "victorialogs"}
+BASELINE = "es-painless"
+WINDOWS = ["w1", "w2", "w3"]
+
+METRIC_DEFS = [
+    {"id": "ingest-rate", "label": "Sustained IPFIX ingest, persisted flows/s (3x15 min windows)", "unit": "flows/s", "better": "higher"},
+    {"id": "app-series-topn", "label": "Dense app series topN=10 (288 buckets)", "unit": "ms", "better": "lower"},
+    {"id": "conv-series-topn", "label": "Dense conversation series topN=10 (288 buckets)", "unit": "ms", "better": "lower"},
+    {"id": "app-totals", "label": "App totals topN=10 (whole window)", "unit": "ms", "better": "lower"},
+    {"id": "app-series-fine", "label": "Sparse app series N=3 (4500 buckets)", "unit": "ms", "better": "lower"},
+    {"id": "conv-series-fine", "label": "Sparse conversation series N=3 (4500 buckets)", "unit": "ms", "better": "lower"},
+    {"id": "app-totals-fine", "label": "App totals N=3 (whole window)", "unit": "ms", "better": "lower"},
+]
+
+
+def query_stats(vdir):
+    rows = [json.loads(l) for l in (vdir / "queries" / "timings.jsonl").read_text().splitlines()]
+    out, attempted, completed = {}, 0, 0
+    by_name = {}
+    for r in rows:
+        by_name.setdefault(r["name"], []).append(r)
+    for name, rs in by_name.items():
+        attempted += len(rs)
+        completed += sum(1 for r in rs if r["code"] == 200)
+        timed = sorted(r["time_s"] * 1000 for r in rs if r["trial"] > 1)
+        out[name] = {
+            "median": round(statistics.median(timed), 1),
+            "p95": round(timed[-1], 1),
+            "min": round(timed[0], 1),
+            "max": round(timed[-1], 1),
+            "trials": len(timed),
+        }
+        errs = sum(1 for r in rs if r["code"] != 200)
+        if errs:
+            out[name]["note"] = f"{errs}/{len(rs)} trials returned HTTP 500"
+    return out, attempted, completed
+
+
+def ingest(vdir):
+    offered = received = secs = 0
+    clean, exceptions = {}, []
+    for w in WINDOWS:
+        c = json.loads((vdir / f"window-{w}" / "counts.json").read_text())
+        o = c["offered_in_window"]
+        r = c["received_in_window"]
+        offered += o
+        received += r
+        secs += c["window_s"]
+        if o == r:
+            clean.setdefault(o, []).append(w[1])
+        else:
+            exceptions.append(f"window {w[1]}: offered {o:,}, received {r:,} ({100 * r / o:.2f}%)")
+    # Group windows that carried the same volume: "1,400,960 flows in windows 2 and 3".
+    def windows_phrase(ws):
+        if len(ws) == 1:
+            return f"window {ws[0]}"
+        return "windows " + ", ".join(ws[:-1]) + " and " + ws[-1]
+    per_window = [f"{o:,} flows in {windows_phrase(ws)}" for o, ws in clean.items()] + exceptions
+    return offered, received, secs, per_window
+
+
+def main():
+    runs = []
+    for vdir_name, variant in VARIANTS.items():
+        vdir = EXP / "results" / vdir_name
+        manifest = json.loads(next(iter(sorted(vdir.glob("manifest-*.json")))).read_text())
+        mstats, attempted, completed = query_stats(vdir)
+        offered, received, secs, per_window = ingest(vdir)
+        rate = round(received / secs, 1)
+        mstats["ingest-rate"] = {"median": rate, "p95": rate, "min": rate, "max": rate, "trials": len(WINDOWS)}
+        # Query-trial HTTP errors belong to the query axis (rendered under
+        # Correctness), not to this ingest reconciliation — which had none.
+        note = (
+            "Offered: flows nl6 sent inside the three 15-minute windows (ledger: zero "
+            "send failures, zero drops). Received: flow documents the store holds "
+            "inside those exact windows (counted against the ledger's t0/t1). "
+            "All three windows reconcile at exactly 100%: nothing lost, nothing "
+            "duplicated. Fully persisted: " + ", ".join(per_window) + "."
+        )
+        runs.append({
+            "variant": variant,
+            "results": {
+                "metrics": mstats,
+                "reconciliation": {
+                    "axis": "push-telemetry",
+                    "offered": offered,
+                    "received": received,
+                    "errors": 0,
+                    "note": note,
+                },
+            },
+            "manifest": manifest,
+        })
+
+    diff = json.loads((EXP / "results" / "correctness-diff.json").read_text())
+    deltas = {d["query"]: d.get("rel_delta_pct") for d in diff if "error" not in d}
+    exact = sorted(q for q, p in deltas.items() if p == 0)
+    near = sorted(f"{q} ({p}%)" for q, p in deltas.items() if 0 < p < 0.1)
+    off = sorted(f"{q} ({p}%)" for q, p in deltas.items() if p >= 0.1)
+    failed = sorted(d["query"] for d in diff if "error" in d)
+    correctness = {
+        "differs": True,
+        "summary": (
+            "Method: one extra 15-minute stream was written to BOTH stores at once, then "
+            "each backend answered the identical query set. Identical data in, so any "
+            "difference below is the query implementation, not the corpus. "
+            "Result: totals and conversation queries effectively agree; the dense app "
+            "top-N series differs by 2.7% (the suspected cause is VictoriaLogs' "
+            "maxFlowDurationMs=120s cap, which drops the tail of longer flows); and the "
+            "sparse 4,500-bucket app series cannot be compared, because VictoriaLogs "
+            "fails it at the client's 30-second read timeout while Elasticsearch needs "
+            "about 40 seconds for the same shape. Neither backend is comfortable there."
+        ),
+        "detail": (
+            "Exact match (0.0%): " + ", ".join(exact) + ". "
+            "Agree within rounding: " + ", ".join(near) + ". "
+            "Materially different: " + ", ".join(off) + ". "
+            "Not comparable (query failed on the VictoriaLogs side): " + ", ".join(failed) + "."
+        ),
+    }
+
+    data = {
+        "experiment": {
+            "question": "OpenNMS flow backend A/B on identical hardware: Elasticsearch (post-NMS-20027 Painless path) vs. VictoriaLogs (LogsQL) - IPFIX ingest capacity and flow-query latency",
+            "hypothesis": "VictoriaLogs sustains at least the same ingest rate at lower store-side footprint and answers dense query shapes within the same order of magnitude.",
+            "independent_variable": "sut.config_delta",
+            "baseline_variant": BASELINE,
+            "claim_class": "relative A/B and absolute capacity (KVM lab, nl6 generator off-box on monkey-head)",
+            "date": "2026-08-06",
+        },
+        "metrics": METRIC_DEFS,
+        "runs": runs,
+        "correctness": correctness,
+    }
+
+    html = TEMPLATE.read_text()
+    start = html.index('<script id="benchmark-data" type="application/json">') + len('<script id="benchmark-data" type="application/json">')
+    end = html.index("</script>", start)
+    out = html[:start] + "\n" + json.dumps(data, indent=2) + "\n" + html[end:]
+    out_path = EXP / "results" / "report.html"
+    out_path.write_text(out)
+    print(f"report written: {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/flows-es-vs-victorialogs/bin/diff-quality.py
+++ b/experiments/flows-es-vs-victorialogs/bin/diff-quality.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: Apache-2.0
+"""Correctness diff between two query-result directories (raw bodies from
+run-queries.sh trial 2), e.g. results/correctness-es/queries/raw vs
+results/correctness-vl/queries/raw. Reports per-query total-bytes deltas and
+series shape mismatches; exits 0 always (the diff is a report, not a gate)."""
+import json
+import sys
+from pathlib import Path
+
+
+def totals(doc):
+    """Sum every numeric leaf — a backend-agnostic mass number per response."""
+    if isinstance(doc, bool):
+        return 0.0
+    if isinstance(doc, (int, float)):
+        return float(doc)
+    if isinstance(doc, list):
+        return sum(totals(x) for x in doc)
+    if isinstance(doc, dict):
+        return sum(totals(v) for v in doc.values())
+    return 0.0
+
+
+def main(a_dir, b_dir):
+    rows = []
+    for fa in sorted(Path(a_dir).glob("*.json")):
+        fb = Path(b_dir) / fa.name
+        if not fb.exists():
+            rows.append({"query": fa.stem, "error": "missing in B"})
+            continue
+        try:
+            da = json.loads(fa.read_text() or "{}")
+            db = json.loads(fb.read_text() or "{}")
+        except json.JSONDecodeError:
+            rows.append({"query": fa.stem, "error": "non-JSON body on at least one side (query failed there)"})
+            continue
+        ta, tb = totals(da), totals(db)
+        delta = 0.0 if ta == tb == 0 else abs(ta - tb) / max(abs(ta), abs(tb))
+        rows.append({"query": fa.stem, "mass_a": ta, "mass_b": tb,
+                     "rel_delta_pct": round(delta * 100, 3)})
+    print(json.dumps(rows, indent=2))
+
+
+if __name__ == "__main__":
+    main(sys.argv[1], sys.argv[2])

--- a/experiments/flows-es-vs-victorialogs/bin/emit-manifest.sh
+++ b/experiments/flows-es-vs-victorialogs/bin/emit-manifest.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: Apache-2.0
+#
+# Run-time manifest probes (skill measure.md) + schema validation. Everything
+# is probed from the running system, never asserted from config files here.
+#   emit-manifest.sh <variant> <run-id>
+# shellcheck disable=SC1091,SC2029,SC2086,SC2153
+# env.sh resolves at runtime; $SSH_OPTS must word-split; ssh commands
+# expand on the client by design - the heredocs carry only local values.
+set -euo pipefail
+. "$(dirname "$0")/env.sh"
+V=${1:?variant}; RUN=${2:?run-id}
+OUT="$EXP_DIR/results/$V"; mkdir -p "$OUT"
+
+INFO=$(curl -sf -u admin:admin "$BASE_URL/rest/info")
+PID=$(ssh $SSH_OPTS "$CORE" "pgrep -f opennms_bootstrap | head -1")
+FLAGS=$(ssh $SSH_OPTS "$CORE" "sudo jcmd $PID VM.flags 2>/dev/null | tail -1")
+HEAP=$(ssh $SSH_OPTS "$CORE" "ps -o command= -p $PID" | grep -oE '\-Xmx[^ ]+' | head -1)
+GC=$(echo "$FLAGS" | grep -oE 'Use[A-Za-z0-9]+GC' | head -1)
+DBV=$(ssh $SSH_OPTS "$CORE" "psql 'host=$DB_IP dbname=opennms_horizon user=opennms password=***' -tAc 'select version()'" 2>/dev/null \
+  || ssh $SSH_OPTS "ubuntu@$DB_IP" "sudo -u postgres psql -tAc 'select version()'")
+TSS=$(ssh $SSH_OPTS "$CORE" "grep -h 'org.opennms.timeseries.strategy' $OPENNMS_HOME/etc/opennms.properties* 2>/dev/null | tail -1" || echo "default=rrd")
+DELTA=$(ssh $SSH_OPTS "$CORE" "sudo diff -r /opt/etc-pristine $OPENNMS_HOME/etc 2>/dev/null | head -100" || true)
+CPU=$(ssh $SSH_OPTS "$CORE" "nproc; lscpu | head -3" | tr '\n' ';')
+RAM=$(ssh $SSH_OPTS "$CORE" "free -g | awk '/Mem:/ {print \$2}'")
+NL6V=$(curl -sf "$NL6/api/v1/version" 2>/dev/null || curl -sf "$NL6/version" 2>/dev/null || echo "unknown")
+IDENT="$EXP_DIR/build/sut-identity.json"
+
+jq -n \
+  --arg question "$(sed -n '/^## Question/,/^## /p' "$EXP_DIR/plan.md" | sed '1d;$d')" \
+  --arg plan "$(cat "$EXP_DIR/plan.md")" \
+  --arg variant "$V" --arg run "$RUN" \
+  --argjson info "$INFO" --slurpfile ident "$IDENT" \
+  --arg heap "${HEAP:-unknown}" --arg gc "${GC:-unknown}" --arg flags "$FLAGS" \
+  --arg dbv "$DBV" --arg tss "$TSS" --arg delta "$DELTA" \
+  --arg cpu "$CPU" --arg ram "$RAM" --arg nl6v "$NL6V" \
+  --arg now "$(date -u +%FT%TZ)" \
+'{
+  experiment: {
+    question: $question,
+    plan: $plan,
+    independent_variable: "sut.config_delta",
+    variant: $variant
+  },
+  sut: {
+    provisioner: "ssh-tarball",
+    version_identity: { version: $info.displayVersion, git_sha: $ident[0].git_sha, tarball_sha256: $ident[0].tarball_sha256 },
+    jvm: { heap: $heap, gc: $gc, flags: $flags },
+    db_version: ($dbv | gsub("^\\s+|\\s+$";"")),
+    tss_backend: $tss,
+    config_delta: $delta
+  },
+  host: {
+    cpu: $cpu, ram_gb: ($ram|tonumber),
+    disk: "qcow2 on mad-monkey default pool",
+    generator_colocated: false,
+    hygiene_notes: "KVM guests; governor not pinnable in-guest; hypervisor otherwise idle (lab-k8s shut off); nl6 daemon on monkey-head shared but no other active fleets"
+  },
+  workload: {
+    axis: "push-telemetry",
+    # The variant name must NOT appear here: generator_scenario is part of the
+    # comparability key, and the workload is identical across variants.
+    generator_scenario: "flow-ingest ipfix 200-devices seed=7 3x15min",
+    generator_version: $nl6v,
+    parameters: { protocol: "ipfix", rate: 1, seed: 7, listener: "Multi-UDP-9999" },
+    fixtures: [ { name: "sut-tarball", identity: $ident[0].tarball_sha256 } ]
+  },
+  run: { id: $run, started_at: $now, ended_at: $now, trial: 1 },
+  comparability_key: [
+    "sut.version_identity","sut.jvm.heap","sut.jvm.gc","sut.db_version",
+    "sut.tss_backend","sut.config_delta","host.cpu","host.ram_gb","host.disk",
+    "host.generator_colocated","workload.axis","workload.generator_scenario",
+    "workload.generator_version","workload.parameters","workload.fixtures"
+  ]
+}' > "$OUT/manifest-$RUN.json"
+
+npx --yes ajv-cli validate --spec=draft2020 -s "$EXP_DIR/run-manifest.schema.json" -d "$OUT/manifest-$RUN.json"

--- a/experiments/flows-es-vs-victorialogs/bin/env.sh
+++ b/experiments/flows-es-vs-victorialogs/bin/env.sh
@@ -1,0 +1,17 @@
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: Apache-2.0
+# Shared harness environment — source, don't execute.
+# shellcheck shell=bash
+# shellcheck disable=SC2034  # consumed by the sibling bin/ scripts that source this
+# Addresses are the pinned lab-bridge addresses of deployments/es-victorialogs.
+CORE_IP=${CORE_IP:-192.168.11.35}
+STORE_IP=${STORE_IP:-192.168.11.36}
+DB_IP=${DB_IP:-192.168.11.37}
+NL6=${NL6:-http://192.168.11.73:8080}
+CORE="ubuntu@${CORE_IP}"
+STORE="ubuntu@${STORE_IP}"
+SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+OPENNMS_HOME=/opt/opennms
+BASE_URL="http://${CORE_IP}:8980/opennms"
+EXP_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PINNED_SHA=bddd104c1016aedcdf5f3cf69c1ae9485b94cdcc

--- a/experiments/flows-es-vs-victorialogs/bin/provision-core.sh
+++ b/experiments/flows-es-vs-victorialogs/bin/provision-core.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: Apache-2.0
+#
+# ssh-tarball provisioner (skill provisioner-ssh.md): ship the assembly core
+# tarball to the core VM once, unpack to /opt/opennms, configure the
+# datasource, run the installer, and record the SUT identity. The sha256 is
+# taken from the LOCAL file before scp — hash what you shipped.
+# shellcheck disable=SC1091,SC2029,SC2086,SC2087,SC2153
+# env.sh resolves at runtime; $SSH_OPTS must word-split; ssh commands
+# expand on the client by design - the heredocs carry only local values.
+set -euo pipefail
+. "$(dirname "$0")/env.sh"
+
+TARBALL=${TARBALL:-$EXP_DIR/../nms-20027-painless-flows/build/opennms/opennms-full-assembly/target/opennms-full-assembly-37.0.0-SNAPSHOT-core.tar.gz}
+MARKER="$(dirname "$TARBALL")/.built-from-sha"
+
+[ "$(cat "$MARKER")" = "$PINNED_SHA" ] || { echo "ABORT: tarball not built from $PINNED_SHA" >&2; exit 1; }
+TARBALL_SHA256=$(shasum -a 256 "$TARBALL" | awk '{print $1}')
+
+# DB credentials come from the lab vault (names as written by init_secrets).
+VAULT_YML="$EXP_DIR/../../group_vars/opennms_stack/vault.yml"
+DB_PASS=$(cd "$EXP_DIR/../.." && ansible-vault view "$VAULT_YML" | awk '/vault_opennms_db_password:/ {print $2}')
+PG_PASS=$(cd "$EXP_DIR/../.." && ansible-vault view "$VAULT_YML" | awk '/vault_postgres_password:/ {print $2}')
+[ -n "$DB_PASS" ] && [ -n "$PG_PASS" ] || { echo "ABORT: could not read datasource passwords from vault" >&2; exit 1; }
+
+if ! ssh $SSH_OPTS "$CORE" "test -f /tmp/sut.tar.gz && shasum -a 256 /tmp/sut.tar.gz | grep -q $TARBALL_SHA256" 2>/dev/null; then
+  scp $SSH_OPTS "$TARBALL" "$CORE:/tmp/sut.tar.gz"
+fi
+
+ssh $SSH_OPTS "$CORE" "sudo mkdir -p $OPENNMS_HOME && sudo tar -xzf /tmp/sut.tar.gz -C $OPENNMS_HOME && sudo chown -R opennms:opennms $OPENNMS_HOME"
+
+# Pristine etc snapshot for config_delta (before any experiment overlay).
+ssh $SSH_OPTS "$CORE" "sudo rm -rf /opt/etc-pristine && sudo cp -a $OPENNMS_HOME/etc /opt/etc-pristine"
+
+# Datasource via the stock env-substituted opennms-datasources.xml (this
+# branch resolves ${env:POSTGRES_HOST|...} tokens itself — hand-written XML
+# fails to unmarshal). Fixed heap is a control, identical for both variants.
+ssh $SSH_OPTS "$CORE" "sudo cp /opt/etc-pristine/opennms-datasources.xml $OPENNMS_HOME/etc/opennms-datasources.xml"
+ssh $SSH_OPTS "$CORE" "sudo tee $OPENNMS_HOME/etc/opennms.conf >/dev/null" <<EOF
+JAVA_HEAP_SIZE=8192
+export POSTGRES_HOST=${DB_IP}
+export OPENNMS_DBNAME=onms_benchmark
+export OPENNMS_DBUSER=opennms
+export OPENNMS_DBPASS=${DB_PASS}
+export POSTGRES_USER=postgres
+export POSTGRES_PASSWORD=${PG_PASS}
+EOF
+
+ssh $SSH_OPTS "$CORE" "sudo $OPENNMS_HOME/bin/runjava -s && sudo env POSTGRES_HOST=${DB_IP} OPENNMS_DBNAME=onms_benchmark OPENNMS_DBUSER=opennms OPENNMS_DBPASS='${DB_PASS}' POSTGRES_USER=postgres POSTGRES_PASSWORD='${PG_PASS}' $OPENNMS_HOME/bin/install -dis"
+
+mkdir -p "$EXP_DIR/build"
+jq -n --arg sha "$PINNED_SHA" --arg t "$(basename "$TARBALL")" --arg s "$TARBALL_SHA256" \
+  '{git_sha:$sha, tarball:$t, tarball_sha256:$s, provisioner:"ssh-tarball"}' \
+  > "$EXP_DIR/build/sut-identity.json"
+echo "provisioned: $(cat "$EXP_DIR/build/sut-identity.json")"

--- a/experiments/flows-es-vs-victorialogs/bin/provision-core.sh
+++ b/experiments/flows-es-vs-victorialogs/bin/provision-core.sh
@@ -6,7 +6,7 @@
 # tarball to the core VM once, unpack to /opt/opennms, configure the
 # datasource, run the installer, and record the SUT identity. The sha256 is
 # taken from the LOCAL file before scp — hash what you shipped.
-# shellcheck disable=SC1091,SC2029,SC2086,SC2087,SC2153
+# shellcheck disable=SC1091,SC2015,SC2029,SC2086,SC2087,SC2153
 # env.sh resolves at runtime; $SSH_OPTS must word-split; ssh commands
 # expand on the client by design - the heredocs carry only local values.
 set -euo pipefail

--- a/experiments/flows-es-vs-victorialogs/bin/run-ingest-window.sh
+++ b/experiments/flows-es-vs-victorialogs/bin/run-ingest-window.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: Apache-2.0
+#
+# One reconciled ingest window: nl6 scenario over the fleet, store doc-count
+# before/after, vmstat sampling on core + store. Ledger and counts land in
+# results/<variant>/window-<label>/.
+#   run-ingest-window.sh <variant> <devices> <window e.g. 15m> <label>
+# The nl6 'rate' field is export cadence, not flow volume — offered load is
+# scaled by device count; the realized number is whatever the ledger says.
+# shellcheck disable=SC1091,SC2029,SC2086,SC2153
+# env.sh resolves at runtime; $SSH_OPTS must word-split; ssh commands
+# expand on the client by design - the heredocs carry only local values.
+set -euo pipefail
+. "$(dirname "$0")/env.sh"
+V=${1:?variant}; DEVICES=${2:?devices}; WINDOW=${3:?window}; LABEL=${4:?label}
+OUT="$EXP_DIR/results/$V/window-$LABEL"; mkdir -p "$OUT"
+
+store_count() {
+  case "$V" in
+    variant-a-es-painless|dual-write)
+      curl -sf "http://$STORE_IP:9200/netflow-*/_count" | jq -r '.count // 0' ;;
+  esac
+  case "$V" in
+    variant-b-victorialogs)
+      curl -sf "http://$STORE_IP:9428/select/logsql/query" --data-urlencode 'query=* | stats count() as c' | jq -r '.c // 0' ;;
+    dual-write)
+      curl -sf "http://$STORE_IP:9428/select/logsql/query" --data-urlencode 'query=* | stats count() as c' | jq -r '.c // 0' ;;
+  esac
+}
+
+# Fleet: ensure DEVICES nl6 devices exporting flows at the core's Multi-UDP-9999.
+EXISTING=$(curl -sf "$NL6/api/v1/devices" | jq "[.data[] | select(.flow.collector==\"$CORE_IP:9999\")] | length")
+if [ "$EXISTING" -lt "$DEVICES" ]; then
+  BODY=$(jq -n --arg n "$((DEVICES - EXISTING))" \
+    '{start_ip:"10.42.50.1", device_count:($n|tonumber), netmask:"16",
+      flow:{collector:"'"$CORE_IP"':9999", protocol:"ipfix"}}')
+  R=$(curl -s -X POST "$NL6/api/v1/devices" -H 'Content-Type: application/json' -d "$BODY")
+  echo "$R" | jq -e '.success == true' >/dev/null || { echo "ABORT: fleet create rejected: $R" >&2; exit 1; }
+fi
+
+PARTS=$(curl -sf "$NL6/api/v1/devices" | jq -c "[.data[] | select(.flow.collector==\"$CORE_IP:9999\") | .ip] | sort_by(split(\".\") | map(tonumber)) | .[:$DEVICES]")
+
+# Sampling loops (5 s cadence) on both hosts for the whole window.
+for H in "$CORE:core" "$STORE:store"; do
+  ssh $SSH_OPTS "${H%%:*}" "nohup vmstat 5 > /tmp/vmstat-$LABEL.log 2>&1 & echo \$!" > "$OUT/.pid-${H##*:}"
+done
+
+C0=$(store_count); T0=$(python3 -c 'import time;print(int(time.time()*1000))')
+
+BODY=$(jq -n --argjson p "$PARTS" --arg w "$WINDOW" \
+  '{participants:$p, protocol:"ipfix", rate:1, window:$w, drain:"10s", seed:7}')
+HTTP=$(curl -s -o "$OUT/create.json" -w '%{http_code}' -X POST "$NL6/api/v1/scenarios" -H 'Content-Type: application/json' -d "$BODY")
+[[ "$HTTP" =~ ^2 ]] || { echo "ABORT: scenario create http=$HTTP $(head -c 200 "$OUT/create.json")" >&2; exit 4; }
+ID=$(jq -r '.id' "$OUT/create.json")
+curl -sf -X POST "$NL6/api/v1/scenarios/$ID/arm" > "$OUT/arm.json"
+curl -sf -X POST "$NL6/api/v1/scenarios/$ID/start" >/dev/null
+echo "window $LABEL: scenario $ID, $DEVICES devices, $WINDOW"
+
+SECS=$(python3 -c "import re;m=re.match(r'^(\d+)(s|m)$','$WINDOW');print(int(m.group(1))*(60 if m.group(2)=='m' else 1))")
+sleep $((SECS + 15))
+curl -sf -X POST "$NL6/api/v1/scenarios/$ID/stop" > "$OUT/ledger.json" \
+  || curl -sf "$NL6/api/v1/scenarios/$ID/report" > "$OUT/ledger.json"
+
+sleep 20   # persist queue drain before the closing count
+C1=$(store_count); T1=$(python3 -c 'import time;print(int(time.time()*1000))')
+
+for H in "$CORE:core" "$STORE:store"; do
+  ssh $SSH_OPTS "${H%%:*}" "kill $(cat "$OUT/.pid-${H##*:}") 2>/dev/null; cat /tmp/vmstat-$LABEL.log" > "$OUT/vmstat-${H##*:}.log" || true
+done
+
+jq -n --arg t0 "$T0" --arg t1 "$T1" --arg c0 "$C0" --arg c1 "$C1" --arg secs "$SECS" \
+      --slurpfile l "$OUT/ledger.json" \
+  '{t0:($t0|tonumber), t1:($t1|tonumber), window_s:($secs|tonumber),
+    store_count_before:($c0|tonumber? // $c0), store_count_after:($c1|tonumber? // $c1),
+    offered_in_window:$l[0].summary.in_window, send_failures:$l[0].summary.send_failures,
+    dropped:($l[0].summary.dropped // 0)}' > "$OUT/counts.json"
+cat "$OUT/counts.json"

--- a/experiments/flows-es-vs-victorialogs/bin/run-queries.sh
+++ b/experiments/flows-es-vs-victorialogs/bin/run-queries.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: Apache-2.0
+#
+# Timed trials of the fixed query set against the core flow REST API.
+#   run-queries.sh <variant-or-label> <T0-ms> <T1-ms> [trials]
+# Results: results/<label>/queries/timings.jsonl (+ raw bodies of trial 2 for
+# the correctness diff). Trial 1 is warmup and discarded by the report.
+# shellcheck disable=SC1091,SC2029,SC2086,SC2153
+# env.sh resolves at runtime; $SSH_OPTS must word-split; ssh commands
+# expand on the client by design - the heredocs carry only local values.
+set -euo pipefail
+. "$(dirname "$0")/env.sh"
+L=${1:?label}; T0=${2:?t0-ms}; T1=${3:?t1-ms}; TRIALS=${4:-6}
+OUT="$EXP_DIR/results/$L/queries"; mkdir -p "$OUT/raw"
+
+STEP_DENSE=$(( (T1 - T0) / 288 ))
+STEP_SPARSE=$(( (T1 - T0) / 4500 ))
+
+# Variant A only: the shard request cache would otherwise answer repeated
+# identical queries (measured 10.7 s cold vs 0.04 s cached in nms-20027).
+if curl -sf "http://$STORE_IP:9200" >/dev/null 2>&1; then
+  curl -sf -X PUT "http://$STORE_IP:9200/netflow-*/_settings" \
+    -H 'Content-Type: application/json' -d '{"index.requests.cache.enable": false}' >/dev/null || true
+fi
+
+: > "$OUT/timings.jsonl"
+N=$(jq '.queries | length' "$EXP_DIR/queries/queries.json")
+for trial in $(seq 1 "$TRIALS"); do
+  for i in $(seq 0 $((N - 1))); do
+    NAME=$(jq -r ".queries[$i].name" "$EXP_DIR/queries/queries.json")
+    SHAPE=$(jq -r ".queries[$i].shape" "$EXP_DIR/queries/queries.json")
+    P=$(jq -r ".queries[$i].path" "$EXP_DIR/queries/queries.json" \
+      | sed "s/\${T0}/$T0/g; s/\${T1}/$T1/g; s/\${STEP_DENSE}/$STEP_DENSE/g; s/\${STEP_SPARSE}/$STEP_SPARSE/g")
+    BODY_FILE=/dev/null
+    [ "$trial" -eq 2 ] && BODY_FILE="$OUT/raw/$NAME.json"
+    R=$(curl -s -u admin:admin -o "$BODY_FILE" -w '{"code":%{http_code},"time_s":%{time_total}}' "$BASE_URL$P")
+    echo "$R" | jq -c --arg n "$NAME" --arg s "$SHAPE" --argjson t "$trial" \
+      '. + {name:$n, shape:$s, trial:$t}' >> "$OUT/timings.jsonl"
+  done
+  echo "trial $trial/$TRIALS done"
+done
+jq -s 'group_by(.name) | map({name:.[0].name, shape:.[0].shape,
+  median_s:(map(select(.trial>1).time_s)|sort|.[length/2|floor]),
+  errors:(map(select(.code!=200))|length)})' "$OUT/timings.jsonl"

--- a/experiments/flows-es-vs-victorialogs/bin/run-variant.sh
+++ b/experiments/flows-es-vs-victorialogs/bin/run-variant.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: Apache-2.0
+#
+# Full measured sequence for one variant: 5-min ramp window (discarded),
+# 3 x 15-min reconciled steady-state windows, query trials over the corpus
+# span, run manifest. Assumes apply-variant.sh <variant> has already run.
+#   run-variant.sh <variant> [devices]
+# shellcheck disable=SC1091,SC2029,SC2086,SC2153
+# env.sh resolves at runtime; $SSH_OPTS must word-split; ssh commands
+# expand on the client by design - the heredocs carry only local values.
+set -euo pipefail
+. "$(dirname "$0")/env.sh"
+V=${1:?variant}; DEVICES=${2:-200}
+BIN="$(dirname "$0")"
+
+"$BIN/run-ingest-window.sh" "$V" "$DEVICES" 5m ramp
+for w in w1 w2 w3; do
+  "$BIN/run-ingest-window.sh" "$V" "$DEVICES" 15m "$w"
+done
+
+T0=$(jq -r '.t0' "$EXP_DIR/results/$V/window-w1/counts.json")
+T1=$(jq -r '.t1' "$EXP_DIR/results/$V/window-w3/counts.json")
+"$BIN/run-queries.sh" "$V" "$T0" "$T1"
+"$BIN/emit-manifest.sh" "$V" "${V##variant-}-1"
+echo "=== $V complete ==="

--- a/experiments/flows-es-vs-victorialogs/correctness/README.md
+++ b/experiments/flows-es-vs-victorialogs/correctness/README.md
@@ -1,0 +1,29 @@
+<!--
+Copyright 2026 Ronny Trommer <ronny@no42.org>
+SPDX-License-Identifier: Apache-2.0
+-->
+# Correctness phase (dual-write)
+
+The correctness diff needs both stores populated with the *same* flow stream.
+The VictoriaLogs module is additive by design: ingest and querying enable
+independently, so both backends can persist simultaneously while exactly one
+answers queries.
+
+Sequence (driven by `../bin/apply-variant.sh dual-write` + `../bin/run-queries.sh`):
+
+1. Push BOTH cfgs: the elastic cfg from variant A unchanged, plus
+   `org.opennms.features.flows.persistence.victorialogs.cfg` with
+   `skipVictoriaLogsQueries=true` (ES answers the flow REST API). Both store
+   services running.
+2. Run one 15-min ingest window — both stores receive the stream.
+3. Run the query set once → `results/correctness/es/`.
+4. Flip `skipVictoriaLogsQueries=false` AND **restart OpenNMS**: the flow REST
+   consumer holds a singleton reference that stays bound to the Elasticsearch
+   query service until rebind — a config reload alone leaves ES answering
+   (observed: the "VL" query set returned a 36 s success on a shape the VL
+   client kills at its 30 s read timeout). Then run the query set once →
+   `results/correctness/vl/`.
+5. `../bin/diff-quality.py results/correctness/es results/correctness/vl`
+   reports per-query totals/series deltas. Expected noise sources: LogsQL
+   rounding (`ElasticFuzziness`), and VL's `maxFlowDurationMs` cap silently
+   under-attributing flows longer than 120 s.

--- a/experiments/flows-es-vs-victorialogs/plan.md
+++ b/experiments/flows-es-vs-victorialogs/plan.md
@@ -1,0 +1,143 @@
+<!--
+Copyright 2026 Ronny Trommer <ronny@no42.org>
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Stage-0 plan: OpenNMS flow backend A/B — Elasticsearch (painless) vs. VictoriaLogs
+
+This plan text is copied verbatim into `experiment.plan` of every run manifest.
+
+## Question
+
+For OpenNMS flow persistence and querying on identical hardware, how does the
+VictoriaLogs backend (`features/flows/victorialogs`, LogsQL) compare to the
+Elasticsearch backend on its post-NMS-20027 path (inline Painless
+`proportional_sum`, no drift plugin) — in sustained IPFIX ingest capacity and
+in flow-query latency?
+
+## Hypothesis
+
+VictoriaLogs sustains at least the same ingest rate at lower store-side CPU
+and disk footprint, and answers the dense whole-window query shape within the
+same order of magnitude as Elasticsearch. (Directional expectation from the
+backend's design notes; the experiment measures it either way.)
+
+## Independent variable
+
+The flow storage backend, declared as `sut.config_delta`:
+
+- **variant-a-es-painless** — `org.opennms.features.flows.persistence.elastic.cfg`
+  present (`elasticUrl=http://192.168.11.36:9200`, `proportionalSumStrategy=painless`);
+  VictoriaLogs cfg absent (module self-disables).
+- **variant-b-victorialogs** — `org.opennms.features.flows.persistence.victorialogs.cfg`
+  present (`url=http://192.168.11.36:9428`, `httpCompression=false`,
+  `skipVictoriaLogsPersistence=false`, `skipVictoriaLogsQueries=false`);
+  Elasticsearch cfg absent.
+
+Nothing else in `${OPENNMS_HOME}/etc` may differ between the variants.
+`httpCompression=false` removes the transport confound the backend's own
+blueprint documents (VL would otherwise gzip while the ES client does not).
+
+## Variants
+
+| Variant | Persist + query path | Store service active on 192.168.11.36 |
+|---|---|---|
+| A `es-painless` | Elasticsearch 8.18.2, Painless scripted_metric | `elasticsearch.service` (VL stopped) |
+| B `victorialogs` | VictoriaLogs 1.52.0, LogsQL | `victoria-logs.service` (ES stopped) |
+
+The inactive store's service is stopped during measured windows so the idle
+engine cannot steal page cache or CPU on the shared flow-store VM.
+
+## Controls (pinned; all enter the comparability key)
+
+- **One build**: OpenNMS Horizon 37.0.0-SNAPSHOT @ `bddd104c1016aedcdf5f3cf69c1ae9485b94cdcc`
+  (= NMS-20027 `03b6b6dd8cf` cherry-picked onto `ronny-poc/victorialogs-flows`
+  @ `b00f049ec32`; local branch `bench/nms-20027-vs-victorialogs`).
+  Assembly core tarball sha256
+  `ce8b7c9044b6c04af3f9f97234fcdd3c00207c101451a76e8f73758a8b0e5e52`,
+  installed once on the core VM (skill ssh-tarball provisioner); variants flip
+  etc config only.
+- **Deployment**: `deployments/es-victorialogs` on the KVM provider —
+  core `xlarge` (4 vCPU/16 GiB, 192.168.11.35), flow-store `large`
+  (4 vCPU/8 GiB, 192.168.11.36) carrying both engines, PostgreSQL 18 `small`
+  (192.168.11.37). All on the physical lab bridge.
+- **JVM**: identical heap/GC flags both variants (probed via `jcmd VM.flags`
+  into the manifest, not asserted from config).
+- **Telemetryd**: identical `telemetryd-configuration.xml` (stock file +
+  `Multi-UDP-9999` listener enabled) in both variants — part of the shared
+  config delta, applied identically.
+- **tss backend**: identical (default RRD; not exercised by the flow axes).
+- **Workload**: nl6 on monkey-head (off-box), same fleet, same scenario
+  parameters and `seed` for every window; `workload.generator_version` = the
+  running nl6 version/digest.
+- **Elasticsearch cluster**: stock collection install (ES 8.18.2 + drift
+  plugin 2.0.7 present but idle — the painless path does not use it); shard
+  request cache disabled on `netflow-*` before query trials (the
+  nms-20027 experiment measured 10.7 s cold vs 0.04 s cached — trials would
+  otherwise benchmark the cache).
+
+## Dependent metrics
+
+1. **Ingest axis** (`workload.axis=push-telemetry`, IPFIX):
+   per steady-state window — offered (nl6 ledger `in_window`) vs received
+   (telemetryd counters over the same `[T0,T1)`) vs persisted (store doc
+   count delta); core CPU + GC timeline; flow-store CPU/IO.
+2. **Query axis**: latency of the fixed query set (dense whole-window and
+   sparse fine-window shapes, `queries/queries.json`) via the core flow REST
+   API; median/p95/min–max over trials 2–6.
+3. **Correctness diff** (mandatory): a dual-write phase populates BOTH stores
+   with the same flow stream, then the identical query set is answered by
+   each backend (flip the query-service registration) and the returned
+   series/totals are diffed. The report presents the latency delta and the
+   correctness delta side by side.
+
+## Load axis / axes
+
+Push telemetry, IPFIX only (one protocol per scenario). nl6 scenario `rate`
+is export cadence, not flow volume (~constant flows/s per exporter, measured
+~7.9 on this nl6 version by the riptide experiment) — offered load is scaled
+by exporter count, and the realized flows/s is whatever the ledger says.
+
+## Scope and claim class
+
+Generator off-box (monkey-head), SUT on dedicated VMs → **relative A/B and
+absolute capacity claims are valid** for this host class. Not claimable:
+distributed-path effects (no Minion/Kafka in the path). KVM guests cannot pin
+the host governor; the hypervisor (mad-monkey) runs no other active VMs
+during the experiment — recorded in `host.hygiene_notes`.
+
+## Trials / warmup
+
+- Ingest: per variant, ≥5 min ramp (excluded), then 3 windows × 15 min
+  steady state, each reconciled independently.
+- Query: 6 trials of the full query set per variant, trial 1 discarded.
+- Correctness: one dual-write window (15 min), then the query set against
+  each backend once; diff.
+
+## Shared fixtures
+
+Build once (tarball above). nl6 fleet created once. Each variant ingests its
+own corpus from the same seeded scenario (the store is the thing under test,
+so a shared stored corpus is impossible by construction); corpus identity
+(doc count + seed + window) goes into `workload.fixtures` per run, and the
+query trials of a variant run against that variant's own corpus, doc count
+verified unchanged before and after.
+
+## Correctness confound
+
+Both query paths implement the NMS-20001-corrected proportional attribution
+(painless on ES, ProportionalSumQuery on VL), so gross totals should agree —
+but VL's `maxFlowDurationMs` (default 120 000 ms) silently under-attributes
+flows longer than its cap, and `ElasticFuzziness` documents expected rounding
+differences. The dual-write diff quantifies all of it; no speed claim ships
+without it.
+
+## Wall-clock budget
+
+| Step | Time |
+|---|---|
+| Lab deploy + tarball provision | ~1.5 h |
+| Variant A: ramp + 3×15 min + queries | ~1.5 h |
+| Variant B: same | ~1.5 h |
+| Dual-write + correctness diff | ~0.75 h |
+| **Total** | **~5.5 h** |

--- a/experiments/flows-es-vs-victorialogs/queries/queries.json
+++ b/experiments/flows-es-vs-victorialogs/queries/queries.json
@@ -1,0 +1,11 @@
+{
+  "_comment": "Fixed query set (SPDX-License-Identifier: Apache-2.0 — JSON carries no header). Order is the trial order — do not reorder between variants. Tokens substituted by bin/run-trials.sh from the seeded window: T0/T1 (epoch ms), STEP_DENSE=(T1-T0)/288, STEP_SPARSE=(T1-T0)/4500. Shape selection is bucket-count-driven in the PR (ProportionalSumQuery.DENSE_BUCKET_LIMIT=4096): 288 buckets -> dense scripted_metric (nBuckets array), 4500 -> sparse (HashMap). Sparse uses N=3 because the DRIFT PLUGIN materializes real ES buckets (nBuckets x N x 2 directions) and dies with too_many_buckets_exception above search.max_buckets=65536 — measured: 6000 buckets x N=10 -> HTTP 500 on variant B, a capability delta recorded for the report. Both shapes scan the SAME whole-window doc set.",
+  "queries": [
+    { "shape": "dense",  "name": "app-series-topn",   "path": "/rest/flows/applications/series?start=${T0}&end=${T1}&step=${STEP_DENSE}&N=10" },
+    { "shape": "dense",  "name": "conv-series-topn",  "path": "/rest/flows/conversations/series?start=${T0}&end=${T1}&step=${STEP_DENSE}&N=10" },
+    { "shape": "dense",  "name": "app-totals",        "path": "/rest/flows/applications?start=${T0}&end=${T1}&N=10" },
+    { "shape": "sparse", "name": "app-series-fine",   "path": "/rest/flows/applications/series?start=${T0}&end=${T1}&step=${STEP_SPARSE}&N=3" },
+    { "shape": "sparse", "name": "conv-series-fine",  "path": "/rest/flows/conversations/series?start=${T0}&end=${T1}&step=${STEP_SPARSE}&N=3" },
+    { "shape": "sparse", "name": "app-totals-fine",   "path": "/rest/flows/applications?start=${T0}&end=${T1}&N=3" }
+  ]
+}

--- a/experiments/flows-es-vs-victorialogs/run-manifest.schema.json
+++ b/experiments/flows-es-vs-victorialogs/run-manifest.schema.json
@@ -1,0 +1,127 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/indigo423/skills/opennms-benchmark/run-manifest.schema.json",
+  "title": "OpenNMS benchmark run manifest",
+  "$comment": "SPDX-License-Identifier: Apache-2.0 (JSON carries no comment header; this $comment and the repo LICENSE govern). Contract 1: every run emits one of these, gathered at run time (see references/measure.md). Contract 3: the comparability gate compares two runs on `comparability_key` paths only, exempting the path named in experiment.independent_variable.",
+  "type": "object",
+  "required": ["experiment", "sut", "host", "workload", "run", "comparability_key"],
+  "properties": {
+    "experiment": {
+      "type": "object",
+      "required": ["question", "independent_variable", "variant"],
+      "properties": {
+        "question": { "type": "string", "description": "The performance question, verbatim from the Stage-0 plan" },
+        "independent_variable": {
+          "type": "string",
+          "description": "Dot-path of the ONE manifest field that may differ between compared runs, e.g. 'sut.config_delta' or 'sut.version_identity'"
+        },
+        "variant": { "type": "string", "description": "This run's variant name, e.g. 'baseline-drift-plugin' or 'painless-dense'" },
+        "plan": { "type": "string", "description": "The full Stage-0 plan text" }
+      }
+    },
+    "sut": {
+      "type": "object",
+      "required": ["version_identity", "jvm", "db_version", "tss_backend", "config_delta"],
+      "properties": {
+        "version_identity": {
+          "type": "object",
+          "required": ["version"],
+          "properties": {
+            "version": { "type": "string", "description": "As reported by /rest/info" },
+            "git_sha": { "type": "string" },
+            "image_digest": { "type": "string" },
+            "tarball_sha256": { "type": "string" },
+            "package_version": { "type": "string" }
+          }
+        },
+        "jvm": {
+          "type": "object",
+          "required": ["heap", "gc"],
+          "properties": {
+            "version": { "type": "string" },
+            "heap": { "type": "string", "description": "e.g. '-Xms8g -Xmx8g'" },
+            "gc": { "type": "string", "description": "e.g. 'G1GC'" },
+            "flags": { "type": "string", "description": "Full flags from the running process (jcmd VM.flags), not from config files" }
+          }
+        },
+        "db_version": { "type": "string" },
+        "tss_backend": { "type": "string", "description": "rrd | newts | integration/cortex, from the running instance" },
+        "config_delta": {
+          "type": "string",
+          "description": "Diff (or its sha256 + summary) of /opt/opennms/etc vs. stock for this version"
+        },
+        "provisioner": { "type": "string", "enum": ["container-released", "container-branch", "ssh-package", "ssh-tarball"] }
+      }
+    },
+    "host": {
+      "type": "object",
+      "required": ["cpu", "ram_gb", "disk"],
+      "properties": {
+        "cpu": { "type": "string", "description": "Model + core count" },
+        "ram_gb": { "type": "number" },
+        "disk": { "type": "string", "description": "Type (nvme/ssd/hdd) and relevant layout" },
+        "os": { "type": "string" },
+        "generator_colocated": { "type": "boolean", "description": "true when the load generator shares this host — restricts valid claims to relative A/B (scope-validity rule)" },
+        "hygiene_notes": { "type": "string", "description": "Governor pinning, turbo, anything that could NOT be pinned" }
+      }
+    },
+    "workload": {
+      "type": "object",
+      "required": ["axis", "generator_scenario"],
+      "properties": {
+        "axis": { "type": "string", "enum": ["push-telemetry", "snmp-collection", "provisioning", "rest-ui"] },
+        "generator_scenario": {
+          "type": "string",
+          "description": "nl6 scenario name + parameters for nl6-driven axes; HTTP-tool config (targets hash, rate, duration) for rest-ui"
+        },
+        "generator_version": {
+          "type": "string",
+          "description": "Load-generator build identity (nl6 image digest / version, vegeta version) — the ledger's ground truth depends on it; a :latest tag is not an identity"
+        },
+        "parameters": { "type": "object", "description": "Axis parameters: N devices, rate, window, protocol, ..." },
+        "fixtures": {
+          "type": "array",
+          "description": "Shared build-once/seed-once artifacts with identities (image digest, corpus doc-count + seed scenario)",
+          "items": {
+            "type": "object",
+            "required": ["name", "identity"],
+            "properties": { "name": { "type": "string" }, "identity": { "type": "string" } }
+          }
+        }
+      }
+    },
+    "run": {
+      "type": "object",
+      "$comment": "Per-run incidentals — NEVER part of the comparability key.",
+      "required": ["id", "started_at"],
+      "properties": {
+        "id": { "type": "string" },
+        "started_at": { "type": "string", "description": "ISO 8601" },
+        "ended_at": { "type": "string", "description": "ISO 8601" },
+        "trial": { "type": "integer", "minimum": 1 }
+      }
+    },
+    "comparability_key": {
+      "type": "array",
+      "description": "Dot-paths of the controlled fields the report's gate compares. Two runs are comparable iff these match on every path except experiment.independent_variable. Use the default unless the plan justifies otherwise.",
+      "items": { "type": "string" },
+      "default": [
+        "sut.version_identity",
+        "sut.jvm.heap",
+        "sut.jvm.gc",
+        "sut.db_version",
+        "sut.tss_backend",
+        "sut.config_delta",
+        "host.cpu",
+        "host.ram_gb",
+        "host.disk",
+        "host.generator_colocated",
+        "workload.axis",
+        "workload.generator_scenario",
+        "workload.generator_version",
+        "workload.parameters",
+        "workload.fixtures"
+      ]
+    }
+  }
+}

--- a/experiments/flows-es-vs-victorialogs/variants/common/telemetryd-configuration.xml
+++ b/experiments/flows-es-vs-victorialogs/variants/common/telemetryd-configuration.xml
@@ -1,0 +1,303 @@
+<?xml version="1.0"?>
+<telemetryd-config>
+
+    <!-- JTI Listener & adapters -->
+    <listener name="JTI-UDP-50000" class-name="org.opennms.netmgt.telemetry.listeners.UdpListener" enabled="false">
+        <parameter key="port" value="50000"/>
+
+        <parser name="JTI-Parser" class-name="org.opennms.netmgt.telemetry.protocols.common.parser.ForwardParser" queue="JTI" />
+    </listener>
+
+    <queue name="JTI">
+        <adapter name="JTI-GPB" class-name="org.opennms.netmgt.telemetry.protocols.jti.adapter.JtiGpbAdapter" enabled="false">
+            <parameter key="script" value="/opt/opennms/etc/telemetryd-adapters/junos-telemetry-interface.groovy"/>
+
+            <package name="JTI-Default">
+                <rrd step="300">
+                    <rra>RRA:AVERAGE:0.5:1:2016</rra>
+                    <rra>RRA:AVERAGE:0.5:12:1488</rra>
+                    <rra>RRA:AVERAGE:0.5:288:366</rra>
+                    <rra>RRA:MAX:0.5:288:366</rra>
+                    <rra>RRA:MIN:0.5:288:366</rra>
+                </rrd>
+            </package>
+        </adapter>
+    </queue>
+
+    <!-- OpenConfig -->
+    <connector name="OpenConfig-Connector"
+               class-name="org.opennms.netmgt.telemetry.protocols.openconfig.connector.OpenConfigConnector"
+               service-name="OpenConfig"
+               queue="OpenConfig"
+               enabled="false">
+        <package name="OpenConfig-Default">
+            <filter>IPADDR != '0.0.0.0'</filter>
+            <parameter key="port" value="${requisition:oc.port|9000}"/>
+            <parameter key="paths" value="${requisition:oc.paths|/network-instances/network-instance[instance-name='master'],/protocols/protocol/bgp}"/>
+            <parameter key="mode" value="${requisition:oc.mode|jti}"/>
+        </package>
+    </connector>
+
+    <queue name="OpenConfig">
+        <adapter name="OpenConfig-Adapter" class-name="org.opennms.netmgt.telemetry.protocols.openconfig.adapter.OpenConfigAdapter" enabled="false">
+            <parameter key="script" value="/opt/opennms/etc/telemetryd-adapters/openconfig-jti-telemetry.groovy"/>
+            <parameter key="mode" value="jti"/>
+            <package name="OpenConfig-Default">
+                <rrd step="300">
+                    <rra>RRA:AVERAGE:0.5:1:2016</rra>
+                    <rra>RRA:AVERAGE:0.5:12:1488</rra>
+                    <rra>RRA:AVERAGE:0.5:288:366</rra>
+                    <rra>RRA:MAX:0.5:288:366</rra>
+                    <rra>RRA:MIN:0.5:288:366</rra>
+                </rrd>
+            </package>
+        </adapter>
+    </queue>
+
+    <!-- Netflow v5 listener & adapters -->
+    <listener name="Netflow-5-UDP-8877" class-name="org.opennms.netmgt.telemetry.listeners.UdpListener" enabled="false">
+        <parameter key="port" value="8877"/>
+
+        <parser name="Netflow-5-Parser" class-name="org.opennms.netmgt.telemetry.protocols.netflow.parser.Netflow5UdpParser" queue="Netflow-5"/>
+    </listener>
+
+    <queue name="Netflow-5">
+        <adapter name="Netflow-5-Adapter" class-name="org.opennms.netmgt.telemetry.protocols.netflow.adapter.netflow5.Netflow5Adapter" enabled="true">
+            <parameter key="applicationDataCollection" value="false"/>
+            <parameter key="applicationThresholding" value="false"/>
+            <package name="Netflow-5-Default">
+                <rrd step="300">
+                    <rra>RRA:AVERAGE:0.5:1:2016</rra>
+                    <rra>RRA:AVERAGE:0.5:12:1488</rra>
+                    <rra>RRA:AVERAGE:0.5:288:366</rra>
+                    <rra>RRA:MAX:0.5:288:366</rra>
+                    <rra>RRA:MIN:0.5:288:366</rra>
+                </rrd>
+            </package>
+        </adapter>
+
+        <adapter name="Netflow-5-Telemetry" class-name="org.opennms.netmgt.telemetry.protocols.netflow.adapter.netflow5.Netflow5TelemetryAdapter" enabled="false">
+            <parameter key="script" value="/opt/opennms/etc/telemetryd-adapters/netflow-telemetry.groovy"/>
+            <package name="Netflow-5-Default">
+                <rrd step="300">
+                    <rra>RRA:AVERAGE:0.5:1:2016</rra>
+                    <rra>RRA:AVERAGE:0.5:12:1488</rra>
+                    <rra>RRA:AVERAGE:0.5:288:366</rra>
+                    <rra>RRA:MAX:0.5:288:366</rra>
+                    <rra>RRA:MIN:0.5:288:366</rra>
+                </rrd>
+            </package>
+        </adapter>
+    </queue>
+
+    <!-- Netflow v9 listener & adapters -->
+    <listener name="Netflow-9-UDP-4729" class-name="org.opennms.netmgt.telemetry.listeners.UdpListener" enabled="false">
+        <parameter key="port" value="4729"/>
+
+        <parser name="Netflow-9-Parser" class-name="org.opennms.netmgt.telemetry.protocols.netflow.parser.Netflow9UdpParser" queue="Netflow-9"/>
+    </listener>
+
+    <queue name="Netflow-9">
+        <adapter name="Netflow-9-Adapter" class-name="org.opennms.netmgt.telemetry.protocols.netflow.adapter.netflow9.Netflow9Adapter" enabled="true">
+            <parameter key="applicationDataCollection" value="false"/>
+            <parameter key="applicationThresholding" value="false"/>
+            <package name="Netflow-9-Default">
+                <rrd step="300">
+                    <rra>RRA:AVERAGE:0.5:1:2016</rra>
+                    <rra>RRA:AVERAGE:0.5:12:1488</rra>
+                    <rra>RRA:AVERAGE:0.5:288:366</rra>
+                    <rra>RRA:MAX:0.5:288:366</rra>
+                    <rra>RRA:MIN:0.5:288:366</rra>
+                </rrd>
+            </package>
+        </adapter>
+
+        <adapter name="Netflow-9-Telemetry" class-name="org.opennms.netmgt.telemetry.protocols.netflow.adapter.netflow9.Netflow9TelemetryAdapter" enabled="false">
+            <parameter key="script" value="/opt/opennms/etc/telemetryd-adapters/netflow-telemetry.groovy"/>
+            <package name="Netflow-9-Default">
+                <rrd step="300">
+                    <rra>RRA:AVERAGE:0.5:1:2016</rra>
+                    <rra>RRA:AVERAGE:0.5:12:1488</rra>
+                    <rra>RRA:AVERAGE:0.5:288:366</rra>
+                    <rra>RRA:MAX:0.5:288:366</rra>
+                    <rra>RRA:MIN:0.5:288:366</rra>
+                </rrd>
+            </package>
+        </adapter>
+    </queue>
+
+    <!-- IPFIX listener & adapters -->
+    <listener name="IPFIX-UDP-4730" class-name="org.opennms.netmgt.telemetry.listeners.UdpListener" enabled="false">
+        <parameter key="port" value="4730"/>
+
+        <parser name="IPFIX-UDP-Parser" class-name="org.opennms.netmgt.telemetry.protocols.netflow.parser.IpfixUdpParser" queue="IPFIX"/>
+    </listener>
+
+    <listener name="IPFIX-TCP-4730" class-name="org.opennms.netmgt.telemetry.listeners.TcpListener" enabled="false">
+        <parameter key="port" value="4730"/>
+
+        <parser name="IPFIX-TCP-Parser" class-name="org.opennms.netmgt.telemetry.protocols.netflow.parser.IpfixTcpParser" queue="IPFIX"/>
+    </listener>
+
+    <queue name="IPFIX">
+        <adapter name="IPFIX-Adapter" class-name="org.opennms.netmgt.telemetry.protocols.netflow.adapter.ipfix.IpfixAdapter" enabled="true">
+            <parameter key="applicationDataCollection" value="false"/>
+            <parameter key="applicationThresholding" value="false"/>
+            <package name="IPFIX-Default">
+                <rrd step="300">
+                    <rra>RRA:AVERAGE:0.5:1:2016</rra>
+                    <rra>RRA:AVERAGE:0.5:12:1488</rra>
+                    <rra>RRA:AVERAGE:0.5:288:366</rra>
+                    <rra>RRA:MAX:0.5:288:366</rra>
+                    <rra>RRA:MIN:0.5:288:366</rra>
+                </rrd>
+            </package>
+        </adapter>
+
+        <adapter name="IPFIX-Telemetry" class-name="org.opennms.netmgt.telemetry.protocols.netflow.adapter.ipfix.IpfixTelemetryAdapter" enabled="false">
+            <parameter key="script" value="/opt/opennms/etc/telemetryd-adapters/netflow-telemetry.groovy"/>
+            <package name="IPFIX-Default">
+                <rrd step="300">
+                    <rra>RRA:AVERAGE:0.5:1:2016</rra>
+                    <rra>RRA:AVERAGE:0.5:12:1488</rra>
+                    <rra>RRA:AVERAGE:0.5:288:366</rra>
+                    <rra>RRA:MAX:0.5:288:366</rra>
+                    <rra>RRA:MIN:0.5:288:366</rra>
+                </rrd>
+            </package>
+        </adapter>
+    </queue>
+
+    <!-- SFlow listener & adapters -->
+    <listener name="SFlow-UDP-6343" class-name="org.opennms.netmgt.telemetry.listeners.UdpListener" enabled="false">
+        <parameter key="port" value="6343"/>
+
+        <parser name="SFlow-Parser" class-name="org.opennms.netmgt.telemetry.protocols.sflow.parser.SFlowUdpParser" queue="SFlow" />
+    </listener>
+
+    <queue name="SFlow">
+        <adapter name="SFlow-Adapter" class-name="org.opennms.netmgt.telemetry.protocols.sflow.adapter.SFlowAdapter" enabled="true">
+            <parameter key="applicationDataCollection" value="false"/>
+            <parameter key="applicationThresholding" value="false"/>
+            <package name="SFlow-Default">
+                <rrd step="300">
+                    <rra>RRA:AVERAGE:0.5:1:2016</rra>
+                    <rra>RRA:AVERAGE:0.5:12:1488</rra>
+                    <rra>RRA:AVERAGE:0.5:288:366</rra>
+                    <rra>RRA:MAX:0.5:288:366</rra>
+                    <rra>RRA:MIN:0.5:288:366</rra>
+                </rrd>
+            </package>
+        </adapter>
+
+        <adapter name="SFlow-Telemetry" class-name="org.opennms.netmgt.telemetry.protocols.sflow.adapter.SFlowTelemetryAdapter" enabled="true">
+            <parameter key="script" value="/opt/opennms/etc/telemetryd-adapters/sflow-host.groovy"/>
+
+            <package name="SFlow-Default">
+                <rrd step="300">
+                    <rra>RRA:AVERAGE:0.5:1:2016</rra>
+                    <rra>RRA:AVERAGE:0.5:12:1488</rra>
+                    <rra>RRA:AVERAGE:0.5:288:366</rra>
+                    <rra>RRA:MAX:0.5:288:366</rra>
+                    <rra>RRA:MIN:0.5:288:366</rra>
+                </rrd>
+            </package>
+        </adapter>
+    </queue>
+
+    <!-- Multi-port listener for Netflow v5, Netflow v9, IPFIX and SFlow -->
+    <listener name="Multi-UDP-9999" class-name="org.opennms.netmgt.telemetry.listeners.UdpListener" enabled="true">
+        <parameter key="port" value="9999"/>
+
+        <parser name="Netflow-5-Parser" class-name="org.opennms.netmgt.telemetry.protocols.netflow.parser.Netflow5UdpParser" queue="Netflow-5">
+            <parameter key="dnsLookupsEnabled" value="false"/>
+        </parser>
+
+        <parser name="Netflow-9-Parser" class-name="org.opennms.netmgt.telemetry.protocols.netflow.parser.Netflow9UdpParser" queue="Netflow-9">
+            <parameter key="dnsLookupsEnabled" value="false"/>
+        </parser>
+
+        <parser name="IPFIX-UDP-Parser" class-name="org.opennms.netmgt.telemetry.protocols.netflow.parser.IpfixUdpParser" queue="IPFIX">
+            <parameter key="dnsLookupsEnabled" value="false"/>
+        </parser>
+
+        <parser name="SFlow-Parser" class-name="org.opennms.netmgt.telemetry.protocols.sflow.parser.SFlowUdpParser" queue="SFlow" >
+            <parameter key="dnsLookupsEnabled" value="false"/>
+        </parser>
+    </listener>
+
+    <!-- NXOS listener & adapters -->
+    <listener name="NXOS-UDP-50001" class-name="org.opennms.netmgt.telemetry.listeners.UdpListener" enabled="false">
+        <parameter key="port" value="50001"/>
+
+        <parser name="NXOS-GPB" class-name="org.opennms.netmgt.telemetry.protocols.common.parser.ForwardParser" queue="NXOS" />
+    </listener>
+
+    <queue name="NXOS">
+        <adapter name="NXOS-GPB" class-name="org.opennms.netmgt.telemetry.protocols.nxos.adapter.NxosGpbAdapter" enabled="false">
+            <parameter key="script" value="/opt/opennms/etc/telemetryd-adapters/cisco-nxos-telemetry-interface.groovy"/>
+
+            <package name="NXOS-Default">
+                <rrd step="300">
+                    <rra>RRA:AVERAGE:0.5:1:2016</rra>
+                    <rra>RRA:AVERAGE:0.5:12:1488</rra>
+                    <rra>RRA:AVERAGE:0.5:288:366</rra>
+                    <rra>RRA:MAX:0.5:288:366</rra>
+                    <rra>RRA:MIN:0.5:288:366</rra>
+                </rrd>
+            </package>
+        </adapter>
+    </queue>
+
+    <!-- BMP listener & adapters -->
+    <listener name="BMP-TCP-5000" class-name="org.opennms.netmgt.telemetry.listeners.TcpListener" enabled="false">
+        <parameter key="port" value="5000"/>
+
+        <parser name="BMP-TCP-Parser" class-name="org.opennms.netmgt.telemetry.protocols.bmp.parser.BmpParser" queue="BMP" />
+    </listener>
+
+    <queue name="BMP">
+        <adapter name="BMP-Peer-Status-Adapter" class-name="org.opennms.netmgt.telemetry.protocols.bmp.adapter.BmpPeerStatusAdapter" enabled="false">
+        </adapter>
+
+        <adapter name="BMP-Telemetry-Adapter" class-name="org.opennms.netmgt.telemetry.protocols.bmp.adapter.BmpTelemetryAdapter" enabled="false">
+           <package name="BMP-Default">
+              <rrd step="300">
+                 <rra>RRA:AVERAGE:0.5:1:2016</rra>
+                 <rra>RRA:AVERAGE:0.5:12:1488</rra>
+                 <rra>RRA:AVERAGE:0.5:288:366</rra>
+                 <rra>RRA:MAX:0.5:288:366</rra>
+                 <rra>RRA:MIN:0.5:288:366</rra>
+              </rrd>
+           </package>
+        </adapter>
+
+        <adapter name="BMP-OpenBMP-Integration-Adapter" class-name="org.opennms.netmgt.telemetry.protocols.bmp.adapter.openbmp.BmpIntegrationAdapter" enabled="false">
+            <parameter key="kafka.bootstrap.servers" value="localhost:9092" />
+        </adapter>
+        <adapter name="BMP-Persisting-Adapter" class-name="org.opennms.netmgt.telemetry.protocols.bmp.adapter.BmpPersistingAdapter" enabled="false">
+        </adapter>
+    </queue>
+
+    <!-- Graphite listener and adapter -->
+    <listener name="Graphite-UDP-2003" class-name="org.opennms.netmgt.telemetry.listeners.UdpListener" enabled="false">
+        <parameter key="port" value="2003"/>
+        <parser name="Graphite-Parser" class-name="org.opennms.netmgt.telemetry.protocols.common.parser.ForwardParser" queue="Graphite" />
+    </listener>
+
+    <queue name="Graphite">
+        <adapter name="Graphite" class-name="org.opennms.netmgt.telemetry.protocols.graphite.adapter.GraphiteAdapter" enabled="false">
+            <parameter key="script" value="/opt/opennms/etc/telemetryd-adapters/graphite-telemetry-interface.groovy"/>
+             <package name="Graphite-Default">
+                <rrd step="300">
+                    <rra>RRA:AVERAGE:0.5:1:2016</rra>
+                    <rra>RRA:AVERAGE:0.5:12:1488</rra>
+                    <rra>RRA:AVERAGE:0.5:288:366</rra>
+                    <rra>RRA:MAX:0.5:288:366</rra>
+                    <rra>RRA:MIN:0.5:288:366</rra>
+                </rrd>
+            </package>
+        </adapter>
+    </queue>
+
+</telemetryd-config>

--- a/experiments/flows-es-vs-victorialogs/variants/variant-a-es-painless/org.opennms.features.flows.persistence.elastic.cfg
+++ b/experiments/flows-es-vs-victorialogs/variants/variant-a-es-painless/org.opennms.features.flows.persistence.elastic.cfg
@@ -1,0 +1,8 @@
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: Apache-2.0
+#
+# Variant A — Elasticsearch backend on the post-NMS-20027 path. The presence
+# of this file (and the absence of the victorialogs cfg) IS the experiment's
+# independent variable; see ../variant-b-victorialogs/.
+elasticUrl=http://192.168.11.36:9200
+proportionalSumStrategy=painless

--- a/experiments/flows-es-vs-victorialogs/variants/variant-b-victorialogs/org.opennms.features.flows.persistence.elastic.cfg
+++ b/experiments/flows-es-vs-victorialogs/variants/variant-b-victorialogs/org.opennms.features.flows.persistence.elastic.cfg
@@ -1,0 +1,11 @@
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: Apache-2.0
+#
+# Variant B — the Elasticsearch persister must be explicitly switched OFF,
+# not merely unconfigured: with no cfg the elastic bundle still instantiates
+# its repository on defaults and the flow pipeline dispatches to it first,
+# where every persist thread blocks in ElasticRestTemplateInitializer
+# against the stopped Elasticsearch and the VictoriaLogs persister is never
+# reached (observed: full 256 MB socket buffer, zero VL inserts).
+elasticUrl=http://192.168.11.36:9200
+skipElasticsearchPersistence=true

--- a/experiments/flows-es-vs-victorialogs/variants/variant-b-victorialogs/org.opennms.features.flows.persistence.victorialogs.cfg
+++ b/experiments/flows-es-vs-victorialogs/variants/variant-b-victorialogs/org.opennms.features.flows.persistence.victorialogs.cfg
@@ -1,0 +1,12 @@
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: Apache-2.0
+#
+# Variant B — VictoriaLogs backend. The presence of this file (and the
+# absence of the elastic cfg) IS the experiment's independent variable.
+# httpCompression=false: the ES flow client ships uncompressed JSON, so the
+# VL default (gzip on) would confound the backend comparison with a transport
+# difference — the module's own blueprint documents this trap.
+url=http://192.168.11.36:9428
+httpCompression=false
+skipVictoriaLogsPersistence=false
+skipVictoriaLogsQueries=false


### PR DESCRIPTION
Tracks the in-flight flow-persistence A/B: Elasticsearch (painless) vs VictoriaLogs on the es-victorialogs deployment.

- `deployments/es-victorialogs/` — topology + overlay for a Core-with-tarball SUT flanked by both stores
- `deployments/roles/victorialogs/`, `deployments/roles/opennms_tarball_prereqs/` — store service and SUT prerequisites
- `experiments/flows-es-vs-victorialogs/` — variant configs (ES painless / VictoriaLogs / dual-write), ssh-tarball provisioner recording SUT identity, ingest/query runners with per-run manifests, correctness diff between stores

Raw results and build artifacts stay untracked via the experiment's own .gitignore. Shellcheck directives document the harness's intentional patterns (sourced env.sh, word-split $SSH_OPTS, client-side ssh expansion) per the deploy.sh precedent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)