### PR TITLE
feat(deployments): remove thresholding from the kfk-exclusive SUT

### DIFF
--- a/deployments/kfk-exclusive/playbook.yml
+++ b/deployments/kfk-exclusive/playbook.yml
@@ -36,6 +36,17 @@
   roles:
     - opennms_kafka_producer
 
+# Thresholding runs inside Collectd's persistence path and issues
+# metadata-scope database calls per evaluation (NMS-19537) — on the smoke lab
+# it burned a full thread while the only persistence target was the Kafka
+# topic no threshold ever reads. Removed as a controlled variable of this
+# deployment: parameter off, definitions deleted, packages deleted.
+- name: Remove thresholding from Core
+  hosts: core
+  become: true
+  roles:
+    - opennms_thresholding_off
+
 # The deployment publishes syslog and trap ingress in lab-endpoints.yml, so it
 # has to bind them. The pinned collection's opennms_minion role configures Kafka
 # IPC and the firewall and nothing else, so without this the ports are open, the

--- a/deployments/roles/opennms_thresholding_off/files/threshd-configuration.xml
+++ b/deployments/roles/opennms_thresholding_off/files/threshd-configuration.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright 2026 Ronny Trommer <ronny@no42.org>
+SPDX-License-Identifier: Apache-2.0
+
+Deliberately inert. The schema requires at least one package
+(cvc-complex-type.2.4.b, verified against Horizon 36.0.2), so a fully empty
+document fails startup in OnmsThreshdDao. This single package's filter can
+never match an interface, so nothing is ever selected for threshold
+evaluation. Pairs with the emptied thresholds.xml and the
+thresholding-enabled=false collectd parameters (see tasks/main.yml).
+-->
+<threshd-configuration xmlns="http://xmlns.opennms.org/xsd/config/thresholding" threads="5">
+   <package name="nothing">
+      <filter>IPADDR == '0.0.0.0'</filter>
+   </package>
+</threshd-configuration>

--- a/deployments/roles/opennms_thresholding_off/files/thresholds.xml
+++ b/deployments/roles/opennms_thresholding_off/files/thresholds.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright 2026 Ronny Trommer <ronny@no42.org>
+SPDX-License-Identifier: Apache-2.0
+
+Deliberately empty: every threshold group deleted. Thresholding runs inside
+Collectd's persistence path and issues metadata-scope database calls per
+evaluation (NMS-19537); on a benchmark SUT whose only output is the Kafka
+metrics topic that is pure overhead, so it is removed as a controlled
+variable of the deployment. Record it in every run manifest.
+-->
+<thresholding-config xmlns="http://xmlns.opennms.org/xsd/config/thresholding"/>

--- a/deployments/roles/opennms_thresholding_off/handlers/main.yml
+++ b/deployments/roles/opennms_thresholding_off/handlers/main.yml
@@ -1,0 +1,13 @@
+---
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: Apache-2.0
+
+- name: Restart opennms core
+  ansible.builtin.service:
+    name: opennms.service
+    state: restarted
+  # Same gate as the collection's own "Restart opennms" handler, so an image
+  # bake or config-only rerun (skip_startup=true) does not get an unwanted
+  # restart from this role alone.
+  when:
+    - skip_startup | default("false") == "false"

--- a/deployments/roles/opennms_thresholding_off/tasks/main.yml
+++ b/deployments/roles/opennms_thresholding_off/tasks/main.yml
@@ -1,0 +1,39 @@
+---
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: Apache-2.0
+
+# Removes thresholding from the SUT entirely (NMS-19537: per-evaluation
+# metadata-scope database calls make it a measurable CPU tax inside
+# Collectd). Three layers, because any one alone leaves work behind:
+# the per-service collectd parameter stops scheduling evaluation, the
+# emptied thresholds.xml deletes every definition, and the emptied
+# threshd-configuration.xml removes every package. All three are controlled
+# variables of this deployment and belong in every run manifest.
+
+- name: Disable thresholding on every collectd service
+  ansible.builtin.replace:
+    path: /opt/opennms/etc/collectd-configuration.xml
+    regexp: '(<parameter\s+key="thresholding-enabled"\s+value=")true("\s*/>)'
+    replace: '\1false\2'
+  notify: Restart opennms core
+  tags: ["thresholding"]
+
+- name: Delete all threshold definitions
+  ansible.builtin.copy:
+    src: thresholds.xml
+    dest: /opt/opennms/etc/thresholds.xml
+    owner: opennms
+    group: opennms
+    mode: "0644"
+  notify: Restart opennms core
+  tags: ["thresholding"]
+
+- name: Delete all thresholding packages
+  ansible.builtin.copy:
+    src: threshd-configuration.xml
+    dest: /opt/opennms/etc/threshd-configuration.xml
+    owner: opennms
+    group: opennms
+    mode: "0644"
+  notify: Restart opennms core
+  tags: ["thresholding"]


### PR DESCRIPTION
Thresholding evaluates every sample inside Collectd's persistence path with per-evaluation metadata-scope DB calls ([NMS-19537](https://opennms.atlassian.net/browse/NMS-19537)). During the smoke sweep it burned a full thread on a SUT whose only persistence target is the Kafka metrics topic, which no threshold ever reads.

New `opennms_thresholding_off` role, wired into the kfk-exclusive deployment playbook: `thresholding-enabled=false` on all 18 collectd service parameters, all 9 threshold groups deleted, all 8 threshd packages replaced by one inert package whose filter never matches (the XSD requires at least one package - a fully empty `threshd-configuration.xml` fails startup in `OnmsThreshdDao`, verified live on Horizon 36.0.2).

Applied to the running lab and verified: config state confirmed, OpenNMS restarts clean, no thresholding thread in the hot list under active collection. This is a controlled variable of the SUT and belongs in every run manifest.

Refs #225.

🤖 Generated with [Claude Code](https://claude.com/claude-code)